### PR TITLE
ENH: Add version switcher dropdown menu

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,10 @@ html_theme_options = {
     ],
     "github_url": "https://github.com/pandas-dev/pydata-sphinx-theme",
     "twitter_url": "https://twitter.com/pandas_dev",
+    "version_switcher": {"base_url": "https://pydata-sphinx-theme.readthedocs.io/",
+                         "json": "versions.json",
+                         "regex": r"/\/(latest|(v\d+\.\d+.\d+))\//",
+                         "location": "navbar"},
     "use_edit_page_button": True,
     "show_toc_level": 1,
 }

--- a/pydata_sphinx_theme/docs-navbar.html
+++ b/pydata_sphinx_theme/docs-navbar.html
@@ -47,6 +47,11 @@
             </a>
           </li>
         {% endif %}
+        {% if theme_version_switcher.location == 'navbar' %}
+        <li class="version_switcher nav-item dropdown">
+          {%- include "version-switcher.html" %}
+        </li>
+        {% endif %}
       </ul>
     </div>
 </div>

--- a/pydata_sphinx_theme/theme.conf
+++ b/pydata_sphinx_theme/theme.conf
@@ -10,6 +10,7 @@ use_edit_page_button = False
 external_links =
 github_url =
 twitter_url =
+version_switcher =
 google_analytics_id =
 show_prev_next = True
 search_bar_text = Search the docs ...

--- a/pydata_sphinx_theme/version-switcher.html
+++ b/pydata_sphinx_theme/version-switcher.html
@@ -1,0 +1,66 @@
+<script type="text/javascript">
+    (function () {
+
+        var all_versions = {
+            'latest': 'v0.4.1',
+            'v0.3': 'v0.3.2',
+            'v0.2': 'v0.2.1',
+        };
+
+        function change_version(url, new_version) {
+            var version_regex = /\/(latest|(v\d+\.\d+.\d+))\//;
+            return url.replace(version_regex, '/' + new_version + '/');
+        }
+
+        function on_switch() {
+            var selected = $(this).children('option:selected').attr('value');
+
+            // original url
+            // https://pydata-sphinx-theme.readthedocs.io/en/latest/
+            var url = window.location.href;
+            // changed url
+            // https://pydata-sphinx-theme.readthedocs.io/en/v0.3.2/
+            var new_url = change_version(url, selected);
+
+            if (new_url != url) {
+                // check beforehand if url exists, otherwise redirect to the version's start page
+                $.ajax({
+                    url: new_url,
+                    success: function () {
+                        window.location.href = new_url;
+                    },
+                    error: function () {
+                        window.location.href = "https://pydata-sphinx-theme.readthedocs.io/en/" + selected;
+                    }
+                });
+            }
+        }
+
+        $(document).ready(function () {
+            // var version = DOCUMENTATION_OPTIONS.VERSION;
+            // Take the first 2 parts of the release (e.g. "3.4.5" -> "3.4")
+            // version = version.split('.').slice(0, 2).join('.');
+
+            // fill the current version in the dropdown
+            document.getElementById("version-dropdown").innerText = 'latest';
+
+            const getVersionLink = () => {
+                return Object.keys(all_versions).map(key => `<button class="dropdown-item">${key}</button>`)
+            }
+            // fill the version menu
+            document.getElementById("version-menu").innerHTML = getVersionLink().join('');
+
+            // bind the changes to this menu to trigger the switching function
+            // TODO: Change this to use the dropdown button's on_select() callback function
+            $('.version-dropdown select').bind('change', on_switch);
+        });
+    })();
+
+</script>
+
+<button id="version-dropdown" class="btn btn-secondary btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <!-- placeholder for javascript filling above -->
+</button>
+<div id="version-menu" class="dropdown-menu" style="min-width: 6rem;">
+    <!-- placeholder for javascript filling above -->
+</div>


### PR DESCRIPTION
This is the start of adding a version dropdown selector as discussed in #23. I don't have a lot of time to work on this now, so if someone wants to borrow any of this or extend it, please feel free to.

I'm not entirely clear what the end goal is here. From what I can see, most people either roll their own javascript that does some form of regular expression parsing of the version numbers or use the built-in readthedocs version switcher that they provide (this hosted theme site already uses that). Do we want to force people into a standard within this theme, or do we want to be really flexible and allow many different url formats, version formats, etc...?

Here is a list of what this has so far:
- Added a new theme option "version_switcher" that takes a dictionary of values to set up the version switching parameters
- Added HTML for the dropdown buttons
- Added javascript to handle the regular expression replacements of the page href

![image](https://user-images.githubusercontent.com/12417828/97131429-ce680480-1709-11eb-8c9d-a96ca3570718.png)

The HTML buttons have a good look/feel, but the javascript needs some work. I also don't know how to pass sphinx theme options into the javascript utility functions, is there a good way to do that? This would make it easy to allow each project to define their own regular expressions for version finding without needing to directly modify the javascript included here.

CPython also has their versions hardcoded in the included js, not a separate versions.json file.
https://github.com/python/cpython/blob/master/Doc/tools/static/switchers.js
They also have a language selector that would be a good extension in a separate PR.