### PR TITLE
Add codecov and coverage threshold, hoist test requirements to setup.py

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,12 +27,29 @@ jobs:
       with:
         node-version: '10.x'
 
+    - name: Cache python wheels
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'docs/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
+    - name: Cache node_modules
+      uses: actions/cache@v2
+      with:
+        path: 'node_modules'
+        key: |
+          ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
         python -m pip install --upgrade pre-commit
         python -m pip install -e .
-        yarn
+        yarn --frozen-lockfile
 
     - name: Lint
       run: |
@@ -53,6 +70,17 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Cache python wheels
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'docs/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
@@ -92,7 +120,18 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install pre-dependencies
+
+    - name: Cache python wheels
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'docs/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.python-version }}-
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools
         python -m pip install -e .[test]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: continuous-integration
 on: [push, pull_request]
 
 env:
-  COVERAGE_THRESHOLD: 63
+  COVERAGE_THRESHOLD: 62
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        python -m pip install -e .[test]
+        python -m pip install -e .[coverage]
 
     # Build the docs
     - name: Build docs to store
@@ -134,7 +134,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools
-        python -m pip install -e .[test]
+        python -m pip install -e .[coverage]
 
     # Build the docs
     - name: Build docs to store

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,9 +55,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
-        python -m pip install -r docs/requirements.txt
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install -e .[test]
 
     # Build the docs
     - name: Build docs to store
@@ -96,7 +95,6 @@ jobs:
     - name: Install pre-dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools
-    - name: Install package and test dependencies
         python -m pip install -e .[test]
 
     # Build the docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: continuous-integration
 
 on: [push, pull_request]
 
+env:
+  COVERAGE_THRESHOLD: 63
+
 jobs:
 
   lint:
@@ -26,9 +29,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         python -m pip install --upgrade pre-commit
-        pip install -e .
+        python -m pip install -e .
         yarn
 
     - name: Lint
@@ -53,8 +56,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r docs/requirements.txt
+        python -m pip install -e .
+        python -m pip install -r docs/requirements.txt
 
     # Build the docs
     - name: Build docs to store
@@ -62,9 +65,12 @@ jobs:
         export PATH="$HOME/miniconda/bin:$PATH"
         sphinx-build -b html docs/ docs/_build/html -W --keep-going
 
-    # Run tests
+    # Run tests under coverage
     - name: Run the tests
-      run: pytest
+      run: pytest --cov pydata_sphinx_theme --no-cov-on-fail --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
+
+    - name: Upload coverage
+      run: codecov
 
   # Run local Lighthouse audit against built site
   audit:
@@ -86,11 +92,11 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install pre-dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .
-        pip install -r docs/requirements.txt
+        python -m pip install --upgrade pip wheel setuptools
+    - name: Install package and test dependencies
+        python -m pip install -e .[test]
 
     # Build the docs
     - name: Build docs to store
@@ -154,7 +160,7 @@ jobs:
           python-version: 3.7
       - name: Build package
         run: |
-          pip install wheel
+          python -m pip install -U pip setuptools wheel
           python setup.py sdist bdist_wheel
       - name: Publish
         uses: pypa/gh-action-pypi-publish@v1.1.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,9 +67,10 @@ jobs:
 
     # Run tests under coverage
     - name: Run the tests
-      run: pytest --cov pydata_sphinx_theme --no-cov-on-fail --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
+      run: pytest --cov pydata_sphinx_theme --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
 
     - name: Upload coverage
+      if: ${{ always() }}
       run: codecov
 
   # Run local Lighthouse audit against built site

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include MANIFEST.in
 include LICENSE
 include README.md
 include setup.py
+include docs/requirements.txt
 
 graft pydata_sphinx_theme
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,6 +10,3 @@ jupyter_sphinx
 plotly
 numpy
 xarray
-# For coverage and CI
-pytest-cov
-codecov

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,6 @@ jupyter_sphinx
 plotly
 numpy
 xarray
+# For coverage and CI
+pytset-cov
+codecov

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,5 +11,5 @@ plotly
 numpy
 xarray
 # For coverage and CI
-pytset-cov
+pytest-cov
 codecov

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ setup(
     # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
     entry_points={"sphinx.html_themes": ["pydata_sphinx_theme = pydata_sphinx_theme"]},
     install_requires=["sphinx", "beautifulsoup4"],
-    extras_require={"test": tests_require},
+    extras_require={
+        "test": tests_require,
+        "coverage": ["pytest-cov", "codecov", *tests_require],
+    },
     python_requires=">=3.5",
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ def find_version(*file_paths):
 with open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
+tests_require = [
+    line.strip()
+    for line in read("docs", "requirements.txt").splitlines()
+    if not line.strip().startswith("#")
+]
 
 setup(
     name="pydata-sphinx-theme",
@@ -44,6 +49,7 @@ setup(
     # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
     entry_points={"sphinx.html_themes": ["pydata_sphinx_theme = pydata_sphinx_theme"]},
     install_requires=["sphinx", "beautifulsoup4"],
+    extras_require={"test": tests_require},
     python_requires=">=3.5",
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
> motivated by https://github.com/pydata/pydata-sphinx-theme/pull/346#issuecomment-806811360

- [x] adds `docs/requirements.txt` to `MANIFEST.in`
- [x] reads the requirements file during build for `[test]`
- [x] adds a `[coverage]`  with `codecov` and `pytest-cov`
- [x] adds a coverage threshold (set to the current value) to fail in CI
- [x] uploads to codecov at the end of a CI run (only the first fail will upload, however, due to `fail-fast` (which is fine))
  - > the [reports](https://app.codecov.io/gh/pydata/pydata-sphinx-theme/) get (more) useful once merged to HEAD,
  - > and it can be configured for badges, posting a report to PRs, etc.
- [x] cache wheels and node_modules 
  - > appears to knock off ~30s
