### PR TITLE
Add README badges, branch coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: continuous-integration
 on: [push, pull_request]
 
 env:
-  COVERAGE_THRESHOLD: 62
+  COVERAGE_THRESHOLD: 60
 
 jobs:
 
@@ -94,7 +94,7 @@ jobs:
 
     # Run tests under coverage
     - name: Run the tests
-      run: pytest --cov pydata_sphinx_theme --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
+      run: pytest --cov pydata_sphinx_theme --cov-report term-missing:skip-covered --cov-branch --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
 
     - name: Upload coverage
       if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pydata-sphinx-theme
 
+![pypi](https://img.shields.io/pypi/v/pydata-sphinx-theme) [![conda-forge](https://img.shields.io/conda/vn/conda-forge/pydata-sphinx-theme.svg)](https://anaconda.org/conda-forge/pydata-sphinx-theme) [![continuous-integration](https://github.com/pydata/pydata-sphinx-theme/actions/workflows/tests.yml/badge.svg)](https://github.com/pydata/pydata-sphinx-theme/actions/workflows/tests.yml) [![docs](https://readthedocs.org/projects/pydata-sphinx-theme/badge/)](https://readthedocs.org/projects/pydata-sphinx-theme/builds/) [![codecov](https://codecov.io/gh/pydata/pydata-sphinx-theme/branch/master/graph/badge.svg?token=NwOObjYacn)](https://codecov.io/gh/pydata/pydata-sphinx-theme)
+
 A Bootstrap-based Sphinx theme from the PyData community.
 
 Demo site: https://pydata-sphinx-theme.readthedocs.io/en/latest/


### PR DESCRIPTION
- follow-on to #348
- mostly just want to see if we start getting the codecov PR comment, and if i can fix it with what perms i have...
- [x] adds the codecov badge (and friends) to README with links to various sources
- [x] enables branch coverage, which is slightly more pedantic about whether, e.g. a function with two separate `if..elif..else` statements executes the permutations of the full set
