### PR TITLE
Raise exception if icon_links conf val is not a dict.

### DIFF
--- a/pydata_sphinx_theme/__init__.py
+++ b/pydata_sphinx_theme/__init__.py
@@ -28,6 +28,13 @@ def update_config(app, env):
                 "Use `search-field.html` in `navbar_end` template list instead."
             )
         )
+    if not isinstance(theme_options.get("icon_links", []), list):
+        raise ExtensionError(
+            (
+                "`icon_links` must be a list of dictionaries keyed by "
+                "'name', 'url', and 'icon'."
+            )
+        )
 
 
 def update_templates(app, pagename, templatename, context, doctree):

--- a/pydata_sphinx_theme/__init__.py
+++ b/pydata_sphinx_theme/__init__.py
@@ -31,8 +31,8 @@ def update_config(app, env):
     if not isinstance(theme_options.get("icon_links", []), list):
         raise ExtensionError(
             (
-                "`icon_links` must be a list of dictionaries keyed by "
-                "'name', 'url', and 'icon'."
+                "`icon_links` must be a list of dictionaries, you provided "
+                f"type {type(theme_options.get("icon_links"))}."
             )
         )
 

--- a/pydata_sphinx_theme/__init__.py
+++ b/pydata_sphinx_theme/__init__.py
@@ -32,7 +32,7 @@ def update_config(app, env):
         raise ExtensionError(
             (
                 "`icon_links` must be a list of dictionaries, you provided "
-                f"type {type(theme_options.get("icon_links"))}."
+                f"type {type(theme_options.get('icon_links'))}."
             )
         )
 


### PR DESCRIPTION
A suggestion based on a silly configuration mistake I made that took me a long time to track down.

I wanted to supply a single `icon_link` and since it was only one item, I forgot to provide it as an item in a list and instead accidentally specified it as a dictionary, e.g.

```python
html_theme_options = {
    "icon_links" : {   # Here's the mistake - should be a *list* of dictionaries
        "name": GitHub,
        "url": github.com/foo/bar,
        "icon": "fab fa-github-square"
    }
```

Currently, if the user makes this configuration mistake, the sphinx-build process completes with no indication that anything was amiss and the icon will not appear in the navbar as expected. This PR addresses this by raising an `ExtensionError` if the `icon_links` config value is not a list.