### PR TITLE
🐛 FIX: fix undefined sphinx var "meta" in jinja

### DIFF
--- a/pydata_sphinx_theme/layout.html
+++ b/pydata_sphinx_theme/layout.html
@@ -69,7 +69,7 @@
 
           {% block docs_toc %}
           <div class="d-none d-xl-block col-xl-2 bd-toc">
-            {% if not (meta is not none and 'notoc' in meta) %}
+            {% if meta is defined and not (meta is not none and 'notoc' in meta) %}
               {% for toc_item in theme_page_sidebar_items %}
               <div class="toc-item">
                 {% include toc_item %}


### PR DESCRIPTION
closes #394 

As far as I can tell, the site still renders fine after this change, but I would welcome a second pair of eyes.