### PR TITLE
Add MNE-Python to theme users list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Sites that are using this theme:
 - MegEngine: https://megengine.org.cn/doc/stable/zh/
 - Fairlearn: https://fairlearn.github.io/main/quickstart.html
 - NetworkX: https://networkx.org/documentation/latest/
+- MNE-Python: https://mne.tools/stable/index.html
 
 
 ## Installation and usage


### PR DESCRIPTION
now that MNE-Python just released, the theme is live in our stable docs (not just dev docs), so we can add ourselves to the list.