### PR TITLE
Use a variable for the color of editthispage

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -492,7 +492,7 @@ nav.bd-links {
   padding-top: 2rem;
 
   a {
-    color: #130754;
+    color: var(--pst-color-sidebar-link-active);
   }
 }
 


### PR DESCRIPTION
In the [documentation](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/customizing.html), every single link is customizable but not the editthispage one because it is still piloted by a hard color value in the main css file