### PR TITLE
DOC: Add a few more projects that have adopted the theme.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,9 @@ elements.
 Other sites that are using this theme:
 
 - Pandas: https://pandas.pydata.org/docs/
-- NumPy: https://numpy.org/devdocs/
+- NumPy: https://numpy.org/doc/stable/
+- SciPy: https://scipy.github.io/devdocs/
+- NetworkX: https://networkx.org/documentation/latest/
 - Bokeh: https://docs.bokeh.org/en/latest/
 - JupyterHub and Binder: https://docs.mybinder.org/, http://z2jh.jupyter.org/en/latest/, https://repo2docker.readthedocs.io/en/latest/, https://jupyterhub-team-compass.readthedocs.io/en/latest/
 - Jupyter Book beta version uses an extension of this theme: https://beta.jupyterbook.org


### PR DESCRIPTION
SciPy and NetworkX have also adopted this theme for their documentation --- added them to the list of adoptees on the landing page. Also updated NumPy link from devdocs -> stable.

Note that both NetworkX and SciPy have rc's out right now, so if you want to hold off merging for a week or two we can instead point to the stable docs of those projects after the official releases.