### PR TITLE
fix Fairlearn link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Sites that are using this theme:
 - Jupyter Book beta version uses an extension of this theme: https://beta.jupyterbook.org
 - CuPy: https://docs.cupy.dev/en/latest/
 - MegEngine: https://megengine.org.cn/doc/stable/zh/
-- Fairlearn: https://fairlearn.github.io/main/quickstart.html
+- Fairlearn: https://fairlearn.org/main/quickstart.html
 - NetworkX: https://networkx.org/documentation/latest/
 - MNE-Python: https://mne.tools/stable/index.html
 - PyVista: https://docs.pyvista.org

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Sites that are using this theme:
 - Jupyter Book beta version uses an extension of this theme: https://beta.jupyterbook.org
 - CuPy: https://docs.cupy.dev/en/latest/
 - MegEngine: https://megengine.org.cn/doc/stable/zh/
-- Fairlearn: https://fairlearn.org/main/quickstart.html
+- Fairlearn: https://fairlearn.org/main/about/
 - NetworkX: https://networkx.org/documentation/latest/
 - MNE-Python: https://mne.tools/stable/index.html
 - PyVista: https://docs.pyvista.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Other sites that are using this theme:
 - Bokeh: https://docs.bokeh.org/en/latest/
 - JupyterHub and Binder: https://docs.mybinder.org/, http://z2jh.jupyter.org/en/latest/, https://repo2docker.readthedocs.io/en/latest/, https://jupyterhub-team-compass.readthedocs.io/en/latest/
 - Jupyter Book beta version uses an extension of this theme: https://beta.jupyterbook.org
-- Fairlearn: https://fairlearn.github.io/quickstart.html
+- Fairlearn: https://fairlearn.org/main/about/
 
 
 .. toctree::


### PR DESCRIPTION
The previous links were broken. Updating according to the multiversion setup Fairlearn is using now.