### PR TITLE
TST: update role for caption in expected html output (sphinx 4.1)

### DIFF
--- a/tests/test_build/test_sidebars_captions.html
+++ b/tests/test_build/test_sidebars_captions.html
@@ -1,6 +1,6 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
-  <p class="caption">
+  <p class="caption" role="heading">
    <span class="caption-text">
     Section 1
    </span>

--- a/tests/test_build/test_sidebars_level2.html
+++ b/tests/test_build/test_sidebars_level2.html
@@ -1,7 +1,7 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
   <!-- Use deeper level for sidebar -->
-  <p class="caption">
+  <p class="caption" role="heading">
    <span class="caption-text">
     Subsection 1.1
    </span>

--- a/tests/test_build/test_sidebars_nested_page.html
+++ b/tests/test_build/test_sidebars_nested_page.html
@@ -1,6 +1,6 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
-  <p class="caption">
+  <p class="caption" role="heading">
    <span class="caption-text">
     Section 1
    </span>

--- a/tests/test_build/test_sidebars_single.html
+++ b/tests/test_build/test_sidebars_single.html
@@ -1,7 +1,7 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
   <!-- Specify a startdepth of 0 instead of default of 1 -->
-  <p class="caption">
+  <p class="caption" role="heading">
    <span class="caption-text">
     Caption 1
    </span>
@@ -13,7 +13,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption">
+  <p class="caption" role="heading">
    <span class="caption-text">
     Caption 2
    </span>


### PR DESCRIPTION
Sphinx 4.1 added a `role="heading"` to the caption `<p>` (https://github.com/sphinx-doc/sphinx/pull/9358), so this updates the expected output to get CI passing again.

In general, do we have some way to deal with such cross-sphinx-version differences? Or just test the output with the latest sphinx and ensure the expected html is up to date with that? (although ideally we would test against multiple sphinx versions?)

Closes #437