### PR TITLE
Add explicit heading aria-level to complement heading role

### DIFF
--- a/pydata_sphinx_theme/__init__.py
+++ b/pydata_sphinx_theme/__init__.py
@@ -61,13 +61,6 @@ def update_templates(app, pagename, templatename, context, doctree):
                     context[section][ii] = template + ".html"
 
 
-def add_missing_aria_level(soup, fallback_level="2"):
-    """ensure _some_ heading level is explicitly provided"""
-
-    for heading in soup(role="heading"):
-        heading["aria-level"] = heading.attrs.get("aria-level", fallback_level)
-
-
 def add_toctree_functions(app, pagename, templatename, context, doctree):
     """Add functions so Jinja templates can add toctree objects."""
 
@@ -105,8 +98,6 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
             toc_sphinx = index_toctree(app, pagename, startdepth, **kwargs)
 
         soup = bs(toc_sphinx, "html.parser")
-
-        add_missing_aria_level(soup)
 
         # pair "current" with "active" since that's what we use w/ bootstrap
         for li in soup("li", {"class": "current"}):
@@ -150,8 +141,6 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
             return ""
 
         soup = bs(context["toc"], "html.parser")
-
-        add_missing_aria_level(soup)
 
         # Add toc-hN + visible classes
         def add_header_level_recursive(ul, level):

--- a/pydata_sphinx_theme/__init__.py
+++ b/pydata_sphinx_theme/__init__.py
@@ -61,6 +61,14 @@ def update_templates(app, pagename, templatename, context, doctree):
                     context[section][ii] = template + ".html"
 
 
+def add_missing_aria_level(soup, fallback_level="2"):
+    """ensure _some_ heading level is explicitly provided"""
+
+    for heading in soup(role="heading"):
+        heading["aria-level"] = heading.attrs.get("aria-level", fallback_level)
+        print(heading)
+
+
 def add_toctree_functions(app, pagename, templatename, context, doctree):
     """Add functions so Jinja templates can add toctree objects."""
 
@@ -98,6 +106,8 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
             toc_sphinx = index_toctree(app, pagename, startdepth, **kwargs)
 
         soup = bs(toc_sphinx, "html.parser")
+
+        add_missing_aria_level(soup)
 
         # pair "current" with "active" since that's what we use w/ bootstrap
         for li in soup("li", {"class": "current"}):
@@ -141,6 +151,8 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
             return ""
 
         soup = bs(context["toc"], "html.parser")
+
+        add_missing_aria_level(soup)
 
         # Add toc-hN + visible classes
         def add_header_level_recursive(ul, level):

--- a/pydata_sphinx_theme/__init__.py
+++ b/pydata_sphinx_theme/__init__.py
@@ -66,7 +66,6 @@ def add_missing_aria_level(soup, fallback_level="2"):
 
     for heading in soup(role="heading"):
         heading["aria-level"] = heading.attrs.get("aria-level", fallback_level)
-        print(heading)
 
 
 def add_toctree_functions(app, pagename, templatename, context, doctree):

--- a/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -15,12 +15,18 @@ class BootstrapHTML5Translator(HTML5Translator):
     """Custom HTML Translator for a Bootstrap-ified Sphinx layout
     This is a specialization of the HTML5 Translator of sphinx.
     Only a couple of functions have been overridden to produce valid HTML to be
-    directly styled with Bootstrap.
+    directly styled with Bootstrap, and fulfill acessibility best practices.
     """
 
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
         self.settings.table_style = "table"
+
+    def starttag(self, *args, **kwargs):
+        """ensure an aria-level is set for any heading role"""
+        if kwargs.get("ROLE") == "heading" and "ARIA-LEVEL" not in kwargs:
+            kwargs["ARIA-LEVEL"] = "2"
+        return super().starttag(*args, **kwargs)
 
     def visit_table(self, node):
         # type: (nodes.Element) -> None

--- a/tests/test_build/test_sidebars_captions.html
+++ b/tests/test_build/test_sidebars_captions.html
@@ -1,6 +1,6 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Section 1
    </span>

--- a/tests/test_build/test_sidebars_level2.html
+++ b/tests/test_build/test_sidebars_level2.html
@@ -1,7 +1,7 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
   <!-- Use deeper level for sidebar -->
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Subsection 1.1
    </span>

--- a/tests/test_build/test_sidebars_nested_page.html
+++ b/tests/test_build/test_sidebars_nested_page.html
@@ -1,6 +1,6 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Section 1
    </span>

--- a/tests/test_build/test_sidebars_single.html
+++ b/tests/test_build/test_sidebars_single.html
@@ -1,7 +1,7 @@
 <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
  <div class="bd-toc-item active">
   <!-- Specify a startdepth of 0 instead of default of 1 -->
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Caption 1
    </span>
@@ -13,7 +13,7 @@
     </a>
    </li>
   </ul>
-  <p class="caption" role="heading">
+  <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">
     Caption 2
    </span>


### PR DESCRIPTION
## References
- fixes #455

## Code Changes
- ensures that _any_ `starttag` which includes a `ROLE` will also get the (implicit) fallback `aria-level` of `2`