### PR TITLE
include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,8 @@ include README.md
 include setup.py
 include docs/requirements.txt
 
+recursive-include tests *
+
 graft pydata_sphinx_theme
 
 # Patterns to exclude from any directory


### PR DESCRIPTION
### References
- fixes #453 

### Changes
- includes the tests in the `.tar.gz`
  - this will allow downstream package maintainers to confidently test the code when re-packaging
- does _not_ 
   - include the tests in the `whl`
   - create an importable _module_ called `tests`, which happens _all over_, because there is no `tests/__init__.py`