### PR TITLE
specify `sphinx` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     include_package_data=True,
     # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
     entry_points={"sphinx.html_themes": ["pydata_sphinx_theme = pydata_sphinx_theme"]},
-    install_requires=["sphinx", "beautifulsoup4", "docutils!=0.17.0"],
+    install_requires=["sphinx", "beautifulsoup4", "docutils<0.17"],
     extras_require={
         "test": tests_require,
         "coverage": ["pytest-cov", "codecov", *tests_require],

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     include_package_data=True,
     # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
     entry_points={"sphinx.html_themes": ["pydata_sphinx_theme = pydata_sphinx_theme"]},
-    install_requires=["sphinx", "beautifulsoup4", "docutils<0.17"],
+    install_requires=["sphinx>=4", "beautifulsoup4", "docutils!=0.17.0"],
     extras_require={
         "test": tests_require,
         "coverage": ["pytest-cov", "codecov", *tests_require],


### PR DESCRIPTION
Problem: `docutils==0.18` was recently pushed and breaks the same as `docutils==0.17`.
Solution: Use `docutils<0.17` instead of `docutils!=0.17.0`