### PR TITLE
Fixing environment.yml for noxfile

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
 - yarn
 - nodejs>=14,<15  # We should use whatever the LTS is at https://nodejs.org/en/
+- "python=3.10"
 - pip
 - pip:
   - -r docs/requirements.txt


### PR DESCRIPTION
I was just about to fix the tables bug, but found that @jorisvandenbossche beat me to it in #508 :-)

However, I found this weird bug in the environment.yml file we use to build the docs, I think because somewhere there is a `python=3.10` YAML error that resolves to `python=3.1`, so this just explicitly defines the python version