### PR TITLE
STYLE: Improve spacing for non-image site title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ html_sidebars = {
 # a list of builtin themes.
 #
 html_theme = "pydata_sphinx_theme"
-html_logo = "_static/pandas.svg"
+# html_logo = "_static/pandas.svg"
 
 html_theme_options = {
     "external_links": [

--- a/src/pydata_sphinx_theme/assets/styles/_navbar.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_navbar.scss
@@ -21,7 +21,16 @@
   height: var(--pst-header-height);
   width: auto;
   padding: 0.5rem 0;
+  display: flex;
+  align-items: center;
 
+  // If there's no logo image, we use a p element w/ the site title
+  p {
+    margin-bottom: 0;
+    margin-left: 1em;
+  }
+
+  // If there's a logo, it'll be in an img block
   img {
     max-width: 100%;
     height: 100%;


### PR DESCRIPTION
When we don't use a logo image, it displays the site title. However we don't have CSS to properly center and space this title, and so it was bunched up on the left. For example, here's my website w/o this change:

![chrome_4kamLAmEle](https://user-images.githubusercontent.com/1839645/146683854-c4500153-4192-4793-9878-925458015ed8.png)

This PR adds a little bit of spacing so that it is spaced more nicely. Here's the spacing w/ this theme:

![image](https://user-images.githubusercontent.com/1839645/146683871-754586f7-312a-4183-8e45-d65b1422037b.png)
