### PR TITLE
FIX: Left scroll JS proper selector

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -46,15 +46,20 @@ function scrollToActive() {
   if (!isNaN(storedScrollTop)) {
     // If we've got a saved scroll position, just use that
     sidebar.scrollTop = storedScrollTop;
+    console.log("[PST]: Scrolled sidebar using stored browser position...");
   } else {
     // Otherwise, calculate a position to scroll to based on the lowest `active` link
     var active_pages = sidebarNav.querySelectorAll(".active");
     if (active_pages.length > 0) {
       // Use the last active page as the offset since it's the page we're on
-      var offset = active_pages[active_pages.length - 1].offsetTop;
+      var latest_active = active_pages[active_pages.length - 1];
+      var offset =
+        latest_active.getBoundingClientRect().y -
+        sidebar.getBoundingClientRect().y;
       // Only scroll the navbar if the active link is lower than 50% of the page
       if (offset > sidebar.clientHeight * 0.5) {
         sidebar.scrollTop = offset - sidebar.clientHeight * 0.2;
+        console.log("[PST]: Scrolled sidebar using last active link...");
       }
     }
   }

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -73,5 +73,5 @@ function scrollToActive() {
 
 // This is equivalent to the .ready() function as described in
 // https://api.jquery.com/ready/
-$(scrollToActive());
-$(addTOCInteractivity());
+$(scrollToActive);
+$(addTOCInteractivity);

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -59,7 +59,7 @@ function scrollToActive() {
         sidebar.getBoundingClientRect().y;
       // Only scroll the navbar if the active link is lower than 50% of the page
       if (offset > sidebar.clientHeight * 0.5) {
-        sidebar.scrollTop = offset - sidebar.clientHeight * 0.1;
+        sidebar.scrollTop = offset - sidebar.clientHeight * 0.3;
         console.log("[PST]: Scrolled sidebar using last active link...");
       }
     }

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -50,7 +50,6 @@ function scrollToActive() {
     // Otherwise, calculate a position to scroll to based on the lowest `active` link
     var sidebarNav = document.getElementById("bd-docs-nav");
     var active_pages = sidebarNav.querySelectorAll(".active");
-    debugger;
     if (active_pages.length > 0) {
       // Use the last active page as the offset since it's the page we're on
       var latest_active = active_pages[active_pages.length - 1];

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -34,7 +34,6 @@ function addTOCInteractivity() {
 // Navigation sidebar scrolling to active page
 function scrollToActive() {
   var sidebar = document.querySelector("div.bd-sidebar");
-  var sidebarNav = document.getElementById("bd-docs-nav");
 
   // Remember the sidebar scroll position between page loads
   // Inspired on source of revealjs.com
@@ -49,7 +48,9 @@ function scrollToActive() {
     console.log("[PST]: Scrolled sidebar using stored browser position...");
   } else {
     // Otherwise, calculate a position to scroll to based on the lowest `active` link
+    var sidebarNav = document.getElementById("bd-docs-nav");
     var active_pages = sidebarNav.querySelectorAll(".active");
+    debugger;
     if (active_pages.length > 0) {
       // Use the last active page as the offset since it's the page we're on
       var latest_active = active_pages[active_pages.length - 1];
@@ -58,7 +59,7 @@ function scrollToActive() {
         sidebar.getBoundingClientRect().y;
       // Only scroll the navbar if the active link is lower than 50% of the page
       if (offset > sidebar.clientHeight * 0.5) {
-        sidebar.scrollTop = offset - sidebar.clientHeight * 0.2;
+        sidebar.scrollTop = offset - sidebar.clientHeight * 0.1;
         console.log("[PST]: Scrolled sidebar using last active link...");
       }
     }

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -33,7 +33,8 @@ function addTOCInteractivity() {
 
 // Navigation sidebar scrolling to active page
 function scrollToActive() {
-  var sidebar = document.getElementById("bd-docs-nav");
+  var sidebar = document.querySelector("div.bd-sidebar");
+  var sidebarNav = document.getElementById("bd-docs-nav");
 
   // Remember the sidebar scroll position between page loads
   // Inspired on source of revealjs.com
@@ -45,7 +46,7 @@ function scrollToActive() {
   if (!isNaN(storedScrollTop)) {
     sidebar.scrollTop = storedScrollTop;
   } else {
-    var active_pages = sidebar.querySelectorAll(".active");
+    var active_pages = sidebarNav.querySelectorAll(".active");
     var offset = 0;
     var i;
     for (i = active_pages.length - 1; i > 0; i--) {
@@ -68,7 +69,7 @@ function scrollToActive() {
   });
 }
 
-$(document).ready(() => {
-  scrollToActive();
-  addTOCInteractivity();
-});
+// This is equivalent to the .ready() function as described in
+// https://api.jquery.com/ready/
+$(scrollToActive());
+$(addTOCInteractivity());

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -57,8 +57,8 @@ function scrollToActive() {
         latest_active.getBoundingClientRect().y -
         sidebar.getBoundingClientRect().y;
       // Only scroll the navbar if the active link is lower than 50% of the page
-      if (latest_active.getBoundingClientRect().y > (window.innerHeight * 0.5)) {
-        let buffer = 0.25;  // Buffer so we have some space above the scrolled item
+      if (latest_active.getBoundingClientRect().y > window.innerHeight * 0.5) {
+        let buffer = 0.25; // Buffer so we have some space above the scrolled item
         sidebar.scrollTop = offset - sidebar.clientHeight * buffer;
         console.log("[PST]: Scrolled sidebar using last active link...");
       }

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -57,8 +57,9 @@ function scrollToActive() {
         latest_active.getBoundingClientRect().y -
         sidebar.getBoundingClientRect().y;
       // Only scroll the navbar if the active link is lower than 50% of the page
-      if (offset > sidebar.clientHeight * 0.5) {
-        sidebar.scrollTop = offset - sidebar.clientHeight * 0.3;
+      if (latest_active.getBoundingClientRect().y > (window.innerHeight * 0.5)) {
+        let buffer = 0.25;  // Buffer so we have some space above the scrolled item
+        sidebar.scrollTop = offset - sidebar.clientHeight * buffer;
         console.log("[PST]: Scrolled sidebar using last active link...");
       }
     }

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -44,22 +44,18 @@ function scrollToActive() {
   );
 
   if (!isNaN(storedScrollTop)) {
+    // If we've got a saved scroll position, just use that
     sidebar.scrollTop = storedScrollTop;
   } else {
+    // Otherwise, calculate a position to scroll to based on the lowest `active` link
     var active_pages = sidebarNav.querySelectorAll(".active");
-    var offset = 0;
-    var i;
-    for (i = active_pages.length - 1; i > 0; i--) {
-      var active_page = active_pages[i];
-      if (active_page !== undefined) {
-        offset += active_page.offsetTop;
+    if (active_pages.length > 0) {
+      // Use the last active page as the offset since it's the page we're on
+      var offset = active_pages[active_pages.length - 1].offsetTop;
+      // Only scroll the navbar if the active link is lower than 50% of the page
+      if (offset > sidebar.clientHeight * 0.5) {
+        sidebar.scrollTop = offset - sidebar.clientHeight * 0.2;
       }
-    }
-    offset -= sidebar.offsetTop;
-
-    // Only scroll the navbar if the active link is lower than 50% of the page
-    if (active_page !== undefined && offset > sidebar.clientHeight * 0.5) {
-      sidebar.scrollTop = offset - sidebar.clientHeight * 0.2;
     }
   }
 


### PR DESCRIPTION
This is an attempt at getting the left scrollbar auto-scroll working again.

It simply adds an extra selector, and applies the offset to the parent div, not the nav div, since the parent div is the one that does the actual scrolling

fixes https://github.com/pydata/pydata-sphinx-theme/issues/535