### PR TITLE
ENH: Include navbar in the left sidebar on home page

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -95,7 +95,11 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
         or BeautifulSoup object (if kind == "raw")
         """
         if startdepth is None:
-            startdepth = 1 if kind == "sidebar" else 0
+            if kind == "sidebar" and pagename != context["root_doc"]:
+                # Start at the second level if we're not on the landing page
+                startdepth = 1
+            else:
+                startdepth = 0
 
         if startdepth == 0:
             toc_sphinx = context["toctree"](**kwargs)


### PR DESCRIPTION
This is a minimal change needed to make the navigation links show up in the left sidebar only on the root page.

It's on by default, which I *think* is reasonable. Even if the links are redundant with the top navbar on the root page, that is still probably better than an awkward white space. And if people want to remove them, they can do so via:

```
html_sidebars = {root-doc-name: []}
```

New behavior:

![image](https://user-images.githubusercontent.com/1839645/148134275-866805b8-efef-4a57-8d44-0ddd6dafe529.png)

Old behavior:

![image](https://user-images.githubusercontent.com/1839645/148134304-011384fa-aead-4f4e-b02a-4d67091d7ee0.png)

closes https://github.com/pydata/pydata-sphinx-theme/issues/221