### PR TITLE
FIX: Navbar margin on mobile

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ html_sidebars = {
 # a list of builtin themes.
 #
 html_theme = "pydata_sphinx_theme"
-# html_logo = "_static/pandas.svg"
+# html_logo = "_static/pandas.svg"  # For testing
 
 html_theme_options = {
     "external_links": [

--- a/src/pydata_sphinx_theme/assets/styles/_navbar.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_navbar.scss
@@ -8,6 +8,17 @@
     height: 100%;
   }
 
+  // On smaller screens, add margin to the navbar start/stop
+  @include media-breakpoint-down(lg) {
+    #navbar-start {
+      margin-left: 1em;
+    }
+
+    button.navbar-toggler {
+      margin-right: 1em;
+    }
+  }
+
   @include media-breakpoint-up(lg) {
     // navbar-end-items should be on one line if possible
     #navbar-end > .navbar-end-item {
@@ -27,7 +38,6 @@
   // If there's no logo image, we use a p element w/ the site title
   p {
     margin-bottom: 0;
-    margin-left: 1em;
   }
 
   // If there's a logo, it'll be in an img block


### PR DESCRIPTION
This applies the same fix as https://github.com/pydata/pydata-sphinx-theme/pull/526 but in a more generic fashion. I realized that the problem was not unique to having a text-based site title. On mobile this is how it would look:

(note the mis-alignment with the content block below for the logo, and how the dropdown button is right up against the screen edge on the right)

![chrome_WpBTFeVW53](https://user-images.githubusercontent.com/1839645/148620807-8dadfe8a-b98c-4dce-a732-9c7fc3ffa289.png)

With this fix, we add margin to the navbar-start and navbar-end `div` elements, so that no matter what is inside them, they'll have nicer padding. Here's how it looks on mobile now:

![chrome_OZpxIkvEm3](https://user-images.githubusercontent.com/1839645/148620851-7c9e643f-f433-41ee-abc1-a1ff94ea2524.png)


