### PR TITLE
ENH: Add left sidebar end section to bottom

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,6 +98,7 @@ html_theme_options = {
     # "navbar_start": ["navbar-logo", "navbar-version"],
     # "navbar_center": ["navbar-nav", "navbar-version"],  # Just for testing
     "navbar_end": ["version-switcher", "navbar-icon-links"],
+    # "left_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
     # "footer_items": ["copyright", "sphinx-version", ""]
     "switcher": {
         # "json_url": "/_static/switcher.json",

--- a/docs/user_guide/sections.rst
+++ b/docs/user_guide/sections.rst
@@ -66,6 +66,25 @@ By default, it has the following configuration:
         "**": ["search-field", "sidebar-nav-bs", "sidebar-ethical-ads"]
     }
 
+Left sidebar end sections
+=========================
+
+There is a special ``<div>`` within the left sidebar that appears at the
+bottom of the page, regardless of the content that is above it.
+
+To control the HTML templates that are within this div, use
+``html_theme_options['left_sidebar_end']`` in ``conf.py``.
+
+By default, it has the following templates:
+
+.. code-block:: python
+
+    html_theme_options = {
+      ...
+      "left_sidebar_end": ["sidebar-ethical-ads"],
+      ...
+    }
+
 
 The right in-page sidebar
 =========================
@@ -136,7 +155,7 @@ could do so with the following steps:
       <!-- This will display the version of the docs -->
       {{ version }}
 
-1. Now add the file to your menu items for one of the sections above. For example:
+2. Now add the file to your menu items for one of the sections above. For example:
 
    .. code-block:: python
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -44,6 +44,7 @@ def update_templates(app, pagename, templatename, context, doctree):
         "theme_navbar_end",
         "theme_footer_items",
         "theme_page_sidebar_items",
+        "theme_left_sidebar_end",
         "sidebars",
     ]
 

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -191,7 +191,7 @@ footer {
 
   .sidebar-end-items {
     margin-top: auto;
-    margin-bottom: 0.5em;
+    margin-bottom: 1em;
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -170,6 +170,8 @@ footer {
 .bd-sidebar {
   padding-top: 1em;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 
   @include media-breakpoint-up(md) {
     border-right: 1px solid rgba(0, 0, 0, 0.1);
@@ -185,6 +187,11 @@ footer {
 
   &.no-sidebar {
     border-right: 0;
+  }
+
+  .sidebar-end-items {
+    margin-top: auto;
+    margin-bottom: 0.5em;
   }
 }
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -51,9 +51,16 @@
             {% if sidebars %}
             <!-- Only show if we have sidebars configured, else just a small margin  -->
             <div class="col-12 col-md-3 bd-sidebar">
+              <div class="sidebar-start-items">
                 {%- for sidebartemplate in sidebars %}
                 {%- include sidebartemplate %}
                 {%- endfor %}
+              </div>
+              <div class="sidebar-end-items">
+                {%- for leftsidebartemplate in theme_left_sidebar_end %}
+                {%- include leftsidebartemplate %}
+                {%- endfor %}
+              </div>
             </div>
             {% else %}
             <div class="col-12 col-md-1 col-xl-2 bd-sidebar no-sidebar"></div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -2,7 +2,7 @@
 inherit = basic
 stylesheet = styles/pydata-sphinx-theme.css
 pygments_style = tango
-sidebars = search-field.html, sidebar-nav-bs.html, sidebar-ethical-ads.html
+sidebars = search-field.html, sidebar-nav-bs.html
 
 [options]
 sidebarwidth = 270
@@ -30,6 +30,7 @@ navbar_align = content
 navbar_start = navbar-logo.html
 navbar_center = navbar-nav.html
 navbar_end = navbar-icon-links.html
+left_sidebar_end = sidebar-ethical-ads.html
 footer_items = copyright.html, sphinx-version.html
 page_sidebar_items = page-toc.html, edit-this-page.html
 switcher =

--- a/tests/test_build/sidebar_ix.html
+++ b/tests/test_build/sidebar_ix.html
@@ -1,11 +1,15 @@
 <div class="col-12 col-md-3 bd-sidebar">
- <form action="search.html" class="bd-search d-flex align-items-center" method="get">
-  <i class="icon fas fa-search">
-  </i>
-  <input aria-label="Search the docs ..." autocomplete="off" class="form-control" id="search-input" name="q" placeholder="Search the docs ..." type="search"/>
- </form>
- <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
-  <div class="bd-toc-item active">
-  </div>
- </nav>
+ <div class="sidebar-start-items">
+  <form action="search.html" class="bd-search d-flex align-items-center" method="get">
+   <i class="icon fas fa-search">
+   </i>
+   <input aria-label="Search the docs ..." autocomplete="off" class="form-control" id="search-input" name="q" placeholder="Search the docs ..." type="search"/>
+  </form>
+  <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+   <div class="bd-toc-item active">
+   </div>
+  </nav>
+ </div>
+ <div class="sidebar-end-items">
+ </div>
 </div>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -1,18 +1,22 @@
 <div class="col-12 col-md-3 bd-sidebar">
- <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
-  <div class="bd-toc-item active">
-   <ul class="nav bd-sidenav">
-    <li class="toctree-l1">
-     <a class="reference internal" href="page1.html">
-      3.1. Section 1 page1
-     </a>
-    </li>
-    <li class="toctree-l1">
-     <a class="reference external" href="https://google.com">
-      https://google.com
-     </a>
-    </li>
-   </ul>
-  </div>
- </nav>
+ <div class="sidebar-start-items">
+  <nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+   <div class="bd-toc-item active">
+    <ul class="nav bd-sidenav">
+     <li class="toctree-l1">
+      <a class="reference internal" href="page1.html">
+       3.1. Section 1 page1
+      </a>
+     </li>
+     <li class="toctree-l1">
+      <a class="reference external" href="https://google.com">
+       https://google.com
+      </a>
+     </li>
+    </ul>
+   </div>
+  </nav>
+ </div>
+ <div class="sidebar-end-items">
+ </div>
 </div>


### PR DESCRIPTION
This adds an extra div to the bottom (called "end" in our classes etc) of the left sidebar. This means that by default, the ReadTheDocs "ethical ads" div will snap to the bottom of the page rather than coming just after the left navigation content. 
It also makes this section extensible in the way others on the page are, via the `left_sidebar_end` key.

This is preferable for pages that have only a small amount of left sidebar content, because it'll mean that the ethical ads thing isn't in the middle of the page.

It's a bit hard to demo because ReadTheDocs doesn't show the ethical ads on PR previews, but if I manually increase the height of that div and show where it is, you get the idea:

![image](https://user-images.githubusercontent.com/1839645/148628341-ffe1b20c-e1b1-43d2-9852-a630ce62dc9d.png)

(sorry for the red tint, that's not included in the PR 😅