### PR TITLE
MAINT: Use different lighthouse action

### DIFF
--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -1,0 +1,25 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./docs/_build/html",
+      "autodiscoverUrlBlocklist": [
+        "index.html",
+        "demo/api.html",
+        "demo/demo.html",
+        "demo/example_pandas.html",
+        "user_guide/accessibility.html"
+      ],
+      "settings": {
+        "skipAudits": ["canonical"]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.1 }],
+        "categories:accessibility": ["error", { "minScore": 0.96 }],
+        "categories:best-practices": ["error", { "minScore": 0.85 }],
+        "categories:seo": ["error", { "minScore": 0.8 }]
+      }
+    }
+  }
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,61 +102,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install -e .[coverage]
-          yarn --frozen-lockfile
 
       # Build the docs
-      - name: Build docs to store
+      - name: Build docs to audit
         run: |
-          sphinx-build -b html docs/ docs/_build/html -W --keep-going
+          sphinx-build -b html docs/ docs/_build/html
 
-      # Serve the docs and wait to be ready
-      - name: Serve the built site
-        run: |
-          nohup python docs/serve.py --port=${PORT} --host=${HOST} &
-          curl --retry 10 --retry-connrefused --retry-max-time 60 ${URL}/index.html
-
-      # Run the audit
-      # TODO: use the hosted API with a secret? would allow for comparison over time...
-      - name: Make folder for Lighthouse reports
-        run: mkdir -p /tmp/lighthouse/lighthouse-${{ github.run_number }}
-
-      - name: Run Lighthouse on Site
-        id: lighthouse
-        uses: foo-software/lighthouse-check-action@v2.0.0
+      - name: Audit with Lighthouse
+        uses: treosh/lighthouse-ci-action@v8
         with:
-          # TODO: generate this list to audit all html pages
-          urls: >-
-            ${{ env.URL }}/index.html,
-            ${{ env.URL }}/demo/api.html,
-            ${{ env.URL }}/demo/demo.html,
-            ${{ env.URL }}/demo/example_pandas.html,
-            ${{ env.URL }}/user_guide/accessibility.html
-          outputDirectory: /tmp/lighthouse/lighthouse-${{ github.run_number }}
-          verbose: true
-
-      - name: Run the accessibility audit
-        run: python docs/a11y.py --no-serve
-
-      # Check the audit for threshold values
-      # TODO: write this someplace after a PR is merged, and load?
-      - name: Assess Lighthouse Check results
-        uses: foo-software/lighthouse-check-status-action@v1.0.1
-        with:
-          lighthouseCheckResults: ${{ steps.lighthouse.outputs.lighthouseCheckResults }}
-          minAccessibilityScore: "96"
-          minBestPracticesScore: "85"
-          minPerformanceScore: "10"
-          minSeoScore: "80"
-        if: always()
-
-      - name: Publish Audit reports
-        uses: actions/upload-artifact@v2
-        with:
-          name: Pa11y and Lighthouse ${{ github.run_number }}
-          path: |
-            /tmp/pa11y
-            /tmp/lighthouse
-        if: always()
+          configPath: ".github/workflows/lighthouserc.json"
+          temporaryPublicStorage: true
+          uploadArtifacts: true
 
   publish:
     name: Publish to PyPI


### PR DESCRIPTION
This uses a dedicated GitHub Action for lighthouse to analyze and upload reports for our HTML artifacts automatically. It simplifies the configuration of our pages, and also provides reports that are a bit more understandable than our current setup.

It removes the `pa11y` as well - my reasoning for this is the following:

- We already have auditing with Lighthouse, and it's not clear what pa11y provides _on top of lighthouse_
- There is a **lot** of custom configuration for running the pa11y server. I worry that this is not easy to maintain or inspect, and given that we have an alternative with much less configuration, I think that's a better option.

# Question: remove `pa11y`?

There's a lot of other scripting stuff that we _could_ remove if we want to stop relying on pa11y for our accessibility. I think there are pros and cons, but wanted to show off this alternative as a start. What do others think?
closes #546 