### PR TITLE
FIX: Admonitions margin

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,11 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
+# -- Extension options -------------------------------------------------------
+
+myst_enable_extensions = [
+    "colon_fence",
+]
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,8 +68,10 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # -- Extension options -------------------------------------------------------
 
 myst_enable_extensions = [
+    # This allows us to use ::: to denote directives, useful for admonitions
     "colon_fence",
 ]
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/src/pydata_sphinx_theme/assets/styles/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_admonitions.scss
@@ -20,7 +20,8 @@ div.admonition,
 
   // Items after the title should be indented
   p.admonition-title ~ * {
-    padding: 0 1.4rem;
+    margin-left: 1.4rem;
+    margin-right: 1.4rem;
   }
 
   // Lists need to have left margin so they don't spill into it


### PR DESCRIPTION
This fixes a little visual bug that messes up nested admonitions.

Before:

![image](https://user-images.githubusercontent.com/1839645/149011635-dc756cad-9c85-4771-a800-d2f73d66fa2c.png)

After:

![image](https://user-images.githubusercontent.com/1839645/149011743-31ec743d-e5ff-4210-b940-c9ed506b6426.png)
