### PR TITLE
UPDATE: NodeJS 16.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["sphinx-theme-builder >= 0.2.0a7"]
 build-backend = "sphinx_theme_builder"
 
 [tool.sphinx-theme-builder]
-node-version = "14.18.1"
+node-version = "16.13.2"
 theme-name = "pydata_sphinx_theme"
 additional-compiled-static-assets = [
   "webpack-macros.html",


### PR DESCRIPTION
This updates our NodeJS version to the latest LTS release.

@pradyunsg I wasn't sure if `sphinx-theme-builder` allows you to specify something like `node-version = 16.x` so I just pinned the full version, but if you tell me that it is possible then I'm happy to make a quick docs PR to note this in the STB

closes #551 closes https://github.com/pydata/pydata-sphinx-theme/issues/537