### PR TITLE
CLN: use str instead of os.fsdecode for converting Path

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -508,7 +508,7 @@ def setup(app):
     here = Path(__file__).parent.resolve()
     theme_path = here / "theme" / "pydata_sphinx_theme"
 
-    app.add_html_theme("pydata_sphinx_theme", os.fsdecode(theme_path))
+    app.add_html_theme("pydata_sphinx_theme", str(theme_path))
 
     app.set_translator("html", BootstrapHTML5Translator)
     # Read the Docs uses ``readthedocs`` as the name of the build, and also
@@ -523,6 +523,6 @@ def setup(app):
     app.connect("html-page-context", update_templates)
 
     # Include templates for sidebar
-    app.config.templates_path.append(os.fsdecode(theme_path / "_templates"))
+    app.config.templates_path.append(str(theme_path / "_templates"))
 
     return {"parallel_read_safe": True, "parallel_write_safe": True}


### PR DESCRIPTION
See https://github.com/pydata/pydata-sphinx-theme/pull/565#discussion_r786310474

This is a bit cleaner IMO, and avoids anyone in the future to wonder why this is using `os.fsdecode`