### PR TITLE
MAINT: New action for lighthouse

### DIFF
--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -1,0 +1,18 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./docs/_build/html",
+      "settings": {
+        "skipAudits": ["canonical"]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.1 }],
+        "categories:accessibility": ["error", { "minScore": 0.96 }],
+        "categories:best-practices": ["error", { "minScore": 0.85 }],
+        "categories:seo": ["error", { "minScore": 0.8 }]
+      }
+    }
+  }
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,19 @@ jobs:
         run: |
           sphinx-build -b html docs/ docs/_build/html
 
+      # The lighthouse audit runs directly on the HTML files, no serving needed
+      - name: Audit with Lighthouse
+        uses: treosh/lighthouse-ci-action@v8
+        with:
+          configPath: ".github/workflows/lighthouserc.json"
+          temporaryPublicStorage: true
+          uploadArtifacts: true
+          runs: 3 # Multiple runs to reduce variance
+          urls: |
+            demo/kitchen-sink/paragraph-markup.html
+            demo/example_pandas.html
+            demo/theme-elements.html
+
       # Serve the docs and wait to be ready
       - name: Serve the built site
         run: |
@@ -135,25 +148,12 @@ jobs:
       - name: Run the accessibility audit
         run: python docs/scripts/a11y.py --no-serve
 
-      # Check the audit for threshold values
-      # TODO: write this someplace after a PR is merged, and load?
-      - name: Assess Lighthouse Check results
-        uses: foo-software/lighthouse-check-status-action@v1.0.1
-        with:
-          lighthouseCheckResults: ${{ steps.lighthouse.outputs.lighthouseCheckResults }}
-          minAccessibilityScore: "96"
-          minBestPracticesScore: "85"
-          minPerformanceScore: "10"
-          minSeoScore: "80"
-        if: always()
-
       - name: Publish Audit reports
         uses: actions/upload-artifact@v2
         with:
-          name: Pa11y and Lighthouse ${{ github.run_number }}
+          name: Pa11y ${{ github.run_number }}
           path: |
             /tmp/pa11y
-            /tmp/lighthouse
         if: always()
 
   publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,36 +119,16 @@ jobs:
             demo/example_pandas.html
             demo/theme-elements.html
 
-      # Serve the docs and wait to be ready
+      # Serve the docs for auditing with pa11y
       - name: Serve the built site
         run: |
           nohup python docs/serve.py --port=${PORT} --host=${HOST} &
           curl --retry 10 --retry-connrefused --retry-max-time 60 ${URL}/index.html
 
-      # Run the audit
-      # TODO: use the hosted API with a secret? would allow for comparison over time...
-      - name: Make folder for Lighthouse reports
-        run: mkdir -p /tmp/lighthouse/lighthouse-${{ github.run_number }}
-
-      - name: Run Lighthouse on Site
-        id: lighthouse
-        uses: foo-software/lighthouse-check-action@v2.0.0
-        with:
-          # TODO: generate this list to audit all html pages
-          urls: >-
-            ${{ env.URL }}/index.html,
-            ${{ env.URL }}/demo/api.html,
-            ${{ env.URL }}/demo/kitchen-sink/paragraph-markup.html,
-            ${{ env.URL }}/demo/kitchen-sink/lists-and-tables.html,
-            ${{ env.URL }}/demo/example_pandas.html,
-            ${{ env.URL }}/user_guide/accessibility.html
-          outputDirectory: /tmp/lighthouse/lighthouse-${{ github.run_number }}
-          verbose: true
-
-      - name: Run the accessibility audit
+      - name: Audit with pa11y
         run: python docs/scripts/a11y.py --no-serve
 
-      - name: Publish Audit reports
+      - name: Publish pa11y report
         uses: actions/upload-artifact@v2
         with:
           name: Pa11y ${{ github.run_number }}


### PR DESCRIPTION
This uses a different lighthouse action where we can automatically preview the report from within GitHub Actions.

It doesn't touch the pa11y stuff - we can hash that out in other issues etc.

This supercedes https://github.com/pydata/pydata-sphinx-theme/pull/548 (because a rebase was confusing me and I wanted to reduce the scope of the PR anyway)

closes #546 