### PR TITLE
Bump to dev version + update versions in switcher.json

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,11 +1,13 @@
 [
   {
     "name": "dev",
-    "version": "latest"
+    "version": "latest",
+    "extra_classes": ["dev"]
   },
   {
     "name": "0.8.0 (stable)",
-    "version": "stable"
+    "version": "stable",
+    "extra_classes": ["stable"]
   },
   {
     "name": "0.8.0",

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,51 +1,34 @@
 [
   {
-    "name": "v0.7.1 (stable)",
-    "version": "0.7.1"
+    "name": "0.9.0 (dev)",
+    "version": "latest"
   },
   {
-    "version": "0.7.0"
+    "name": "0.8.0 (stable)",
+    "version": "stable"
   },
   {
-    "version": "0.6.3"
+    "name": "0.8.0",
+    "version": "v0.8.0"
   },
   {
-    "version": "0.6.2"
+    "name": "0.7.2",
+    "version": "v0.7.2"
   },
   {
-    "version": "0.6.1"
+    "name": "0.6.3",
+    "version": "v0.6.3"
   },
   {
-    "version": "0.6.0"
+    "name": "0.5.2",
+    "version": "v0.5.2"
   },
   {
-    "version": "0.5.2"
+    "name": "0.4.3",
+    "version": "v0.4.3"
   },
   {
-    "version": "0.5.1"
-  },
-  {
-    "version": "0.5.0"
-  },
-  {
-    "version": "0.4.3"
-  },
-  {
-    "version": "0.4.2"
-  },
-  {
-    "version": "0.4.1"
-  },
-  {
-    "version": "0.4.0"
-  },
-  {
-    "version": "0.3.2"
-  },
-  {
-    "version": "0.3.1"
-  },
-  {
-    "version": "0.3.0"
+    "name": "0.3.2",
+    "version": "v0.3.2"
   }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "0.9.0 (dev)",
+    "name": "dev",
     "version": "latest"
   },
   {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,8 +24,6 @@ author = "PyData Community"
 
 import pydata_sphinx_theme
 
-release = pydata_sphinx_theme.__version__
-version = release.replace("dev0", "")
 
 # -- General configuration ---------------------------------------------------
 
@@ -80,10 +78,17 @@ myst_enable_extensions = [
 html_theme = "pydata_sphinx_theme"
 # html_logo = "_static/pandas.svg"  # For testing
 
-if "dev" in release:
-    version_match = "dev"
+# Define the version we use for matching in the version switcher.
+if os.environ.get("READTHEDOCS_VERSION"):
+    # If we detect a READTHEDOCS version, just use this.
+    version_match = os.environ.get("READTHEDOCS_VERSION")
 else:
-    version_match = "v" + release
+    # For local development, infer the version to match from the package.
+    release = pydata_sphinx_theme.__version__
+    if "dev" in release:
+        version_match = "latest"
+    else:
+        version_match = "v" + release
 
 html_theme_options = {
     "external_links": [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,10 +79,10 @@ html_theme = "pydata_sphinx_theme"
 # html_logo = "_static/pandas.svg"  # For testing
 
 # Define the version we use for matching in the version switcher.
-if os.environ.get("READTHEDOCS_VERSION"):
-    # If we detect a READTHEDOCS version, just use this.
-    version_match = os.environ.get("READTHEDOCS_VERSION")
-else:
+version_match = os.environ.get("READTHEDOCS_VERSION")
+# If READTHEDOCS_VERSION doesn't exist, we're not on RTD
+# If it is an integer, we're in a PR build and the version isn't correct.
+if not version_match or version_match.isdigit():
     # For local development, infer the version to match from the package.
     release = pydata_sphinx_theme.__version__
     if "dev" in release:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,8 +116,8 @@ html_theme_options = {
     "switcher": {
         # "json_url": "/_static/switcher.json",
         "json_url": "https://pydata-sphinx-theme.readthedocs.io/en/latest/_static/switcher.json",
-        "url_template": "https://pydata-sphinx-theme.readthedocs.io/en/v{version}/",
-        "version_match": version,
+        "url_template": "https://pydata-sphinx-theme.readthedocs.io/en/{version}/",
+        "version_match": "v" + version,
     },
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,6 +80,11 @@ myst_enable_extensions = [
 html_theme = "pydata_sphinx_theme"
 # html_logo = "_static/pandas.svg"  # For testing
 
+if "dev" in release:
+    version_match = "dev"
+else:
+    version_match = "v" + release
+
 html_theme_options = {
     "external_links": [
         {
@@ -117,7 +122,7 @@ html_theme_options = {
         # "json_url": "/_static/switcher.json",
         "json_url": "https://pydata-sphinx-theme.readthedocs.io/en/latest/_static/switcher.json",
         "url_template": "https://pydata-sphinx-theme.readthedocs.io/en/{version}/",
-        "version_match": "v" + version,
+        "version_match": version_match,
     },
 }
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -13,7 +13,7 @@ from sphinx.util import logging
 
 from .bootstrap_html_translator import BootstrapHTML5Translator
 
-__version__ = "0.8.0"
+__version__ = "0.9.0.dev0"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Related to the discussion in https://github.com/pydata/pydata-sphinx-theme/issues/556, and trying to improve the versions in the dropdown in our own demo docs.

cc @drammock 

- I added stable and latest versions, and therefore needed to remove the harcoded "v" in the template url
- I trimmed down the list of versions a bit