### PR TITLE
Improve sidebar search presentation

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -105,13 +105,11 @@ footer {
     position: absolute;
     color: #a4a6a7;
     left: 25px;
-    top: 25px;
   }
 
   input {
-    border-radius: 0;
-    border: 0;
-    border-bottom: 1px solid #e5e5e5;
+    border-radius: 8px;
+    border: 1px solid #e5e5e5;
     padding-left: 35px;
   }
 }


### PR DESCRIPTION
Use a complete rounded-border, instead of a bottom border.

Old:

![image](https://user-images.githubusercontent.com/1839645/151246046-01d3eb8e-f0a8-4a9b-ba65-c81ac10cf497.png)

New:

![image](https://user-images.githubusercontent.com/1839645/151246019-53843616-5129-409e-a3c6-cb4c53d15315.png)
