### PR TITLE
Reduce border-radius on search bar

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -108,7 +108,7 @@ footer {
   }
 
   input {
-    border-radius: 8px;
+    border-radius: 0.2rem;
     border: 1px solid #e5e5e5;
     padding-left: 35px;
   }


### PR DESCRIPTION
This matches the border radius on code blocks, and matches the general
boxy-ness of the rest of the layout.