### PR TITLE
DOCS: Clarify instructions about modifying search bar position

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -647,9 +647,9 @@ following configuration:
 
 .. note::
 
-   By default the search bar is positioned in the sidebar since this is more
-   suitable for large navigation bars.  
-   Thus, if you plan to move it to the nabvar, rember to initialize the sidebar
+   | By default the search bar is positioned in the sidebar since this is more
+   suitable for large navigation bars.
+   | If you plan to move it to the nabvar, rember to initialize the sidebar
    without such template to avoid duplication.
 
 Configure the search bar text

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -647,10 +647,8 @@ following configuration:
 
 .. note::
 
-   | By default the search bar is positioned in the sidebar since this is more
-   suitable for large navigation bars.
-   | If you plan to move it to the nabvar, rember to initialize the sidebar
-   without such template to avoid duplication.
+   By default the search bar is placed in the sidebar. If you wish to move it to the navbar,
+   explicitly define a list of sidebar templates in `html_sidebars` and omit the `search-field.html` entry.
 
 Configure the search bar text
 =============================

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -645,11 +645,12 @@ following configuration:
        "navbar_end": ["navbar-icon-links.html", "search-field.html"]
    }
 
-
 .. note::
 
    By default the search bar is positioned in the sidebar since this is more
-   suitable for large navigation bars.
+   suitable for large navigation bars.  
+   Thus, if you plan to move it to the nabvar, rember to initialize the sidebar
+   without such template to avoid duplication.
 
 Configure the search bar text
 =============================


### PR DESCRIPTION
Just a small clarification in the docs:

since the search bar is a default template for the sidebar, if one follows the instructions by adding it to the navbar this actually duplicates it.
The sidebar option must be also specified without such a template.