### PR TITLE
Replace distutils Version class with `packaging.version`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ requires-python = ">=3.7"
 dependencies = [
   "sphinx",
   "beautifulsoup4",
-  "docutils!=0.17.0"
+  "docutils!=0.17.0",
+  "packaging"
 ]
 
 license = { file = "LICENSE" }

--- a/src/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/src/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -1,6 +1,6 @@
 """A custom Sphinx HTML Translator for Bootstrap layout
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 from docutils import nodes
 
 import sphinx
@@ -34,10 +34,10 @@ class BootstrapHTML5Translator(HTML5Translator):
         # but add 'table' class
 
         # generate_targets_for_table is deprecated in 4.0
-        if LooseVersion(sphinx.__version__) < LooseVersion("4.0"):
+        if Version(sphinx.__version__) < Version("4.0"):
             self.generate_targets_for_table(node)
 
-        if LooseVersion(sphinx.__version__) < LooseVersion("4.3"):
+        if Version(sphinx.__version__) < Version("4.3"):
             self._table_row_index = 0
         else:
             self._table_row_indices.append(0)


### PR DESCRIPTION
Using `distutils.version` classes emits a `DeprecationWarning` when building docs with `setuptools>=60.0.0` and Sphinx fails:

```
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```

The new way to compare versions is using `packaging.version`. This PR replaces the use of `disutils.version` with `packaging.version`. Does this need any tests?