### PR TITLE
MAINT: remove usage of distutils in favor of importlib.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ requires-python = ">=3.7"
 dependencies = [
   "sphinx",
   "beautifulsoup4",
-  "docutils!=0.17.0"
+  "docutils!=0.17.0",
+  "importlib_metadata>=1.4"  # match at least features in py3.8. Drop once 3.8
 ]
 
 license = { file = "LICENSE" }

--- a/src/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/src/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -1,9 +1,12 @@
 """A custom Sphinx HTML Translator for Bootstrap layout
 """
-from distutils.version import LooseVersion
+try:
+    from importlib import metadata
+except ImportError:  # for Python<3.8
+    import importlib_metadata as metadata
+
 from docutils import nodes
 
-import sphinx
 from sphinx.writers.html5 import HTML5Translator
 from sphinx.util import logging
 from sphinx.ext.autosummary import autosummary_table
@@ -34,10 +37,10 @@ class BootstrapHTML5Translator(HTML5Translator):
         # but add 'table' class
 
         # generate_targets_for_table is deprecated in 4.0
-        if LooseVersion(sphinx.__version__) < LooseVersion("4.0"):
+        if metadata.version("sphinx") < "4.0":
             self.generate_targets_for_table(node)
 
-        if LooseVersion(sphinx.__version__) < LooseVersion("4.3"):
+        if metadata.version("sphinx") < "4.3":
             self._table_row_index = 0
         else:
             self._table_row_indices.append(0)


### PR DESCRIPTION
This PR uses `importlib.metadata` instead to check the version of `sphinx`. This was added in Python 3.8, hence `importlib_metadata` is needed for Python 3.7.

Usage of `distutils` prevents proper usage of the theme with Python 3.10. It leads to this warning

```python-traceback
  File ".../lib/python3.10/site-packages/pydata_sphinx_theme/__init__.py", line 14, in <module>
    from .bootstrap_html_translator import BootstrapHTML5Translator
  File ".../lib/python3.10/site-packages/pydata_sphinx_theme/bootstrap_html_translator.py", line 3, in <module>
    from distutils.version import LooseVersion
  File ".../lib/python3.10/distutils/__init__.py", line 19, in <module>
    warnings.warn(_DEPRECATION_MESSAGE,
DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
```