### PR TITLE
STYLE: Update default anchor link

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,7 @@ def _should_install(session):
 @nox.session
 def compile(session):
     if _should_install(session):
-        session.install(".")
+        session.install("-e", ".")
         session.install("sphinx-theme-builder[cli]")
     session.run("stb", "compile")
 
@@ -38,14 +38,14 @@ def compile(session):
 @nox.session
 def docs(session):
     if _should_install(session):
-        session.install(".[doc]")
+        session.install("-e", ".[doc]")
     session.run("sphinx-build", "-b=html", "docs/", "docs/_build/html")
 
 
 @nox.session(name="docs-live")
 def docs_live(session):
     if _should_install(session):
-        session.install(".[doc]")
+        session.install("-e", ".[doc]")
         session.install("sphinx-theme-builder[cli]")
     session.run("stb", "serve", "docs", "--open-browser")
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -20,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 def update_config(app, env):
     theme_options = app.config["html_theme_options"]
+
+    # DEPRECATE after v0.9
     if theme_options.get("search_bar_position") == "navbar":
         logger.warn(
             (
@@ -27,6 +29,8 @@ def update_config(app, env):
                 "Use `search-field.html` in `navbar_end` template list instead."
             )
         )
+
+    # Validate icon links
     if not isinstance(theme_options.get("icon_links", []), list):
         raise ExtensionError(
             (
@@ -34,6 +38,10 @@ def update_config(app, env):
                 f"type {type(theme_options.get('icon_links'))}."
             )
         )
+
+    # Update the anchor link (it's a tuple, so need to overwrite the whole thing)
+    icon_default = app.config.values["html_permalinks_icon"]
+    app.config.values["html_permalinks_icon"] = ("#", *icon_default[1:])
 
 
 def update_templates(app, pagename, templatename, context, doctree):

--- a/src/pydata_sphinx_theme/assets/styles/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_base.scss
@@ -35,13 +35,15 @@ a {
 
   &.headerlink {
     color: rgba(var(--pst-color-headerlink), 1);
+    opacity: 0.4;
     font-size: 0.8em;
     padding: 0 4px 0 4px;
+    margin-left: 0.2em;
     text-decoration: none;
+    transition: all 0.3s ease-out;
 
     &:hover {
-      background-color: rgba(var(--pst-color-headerlink), 1);
-      color: rgba(var(--pst-color-headerlink-hover), 1);
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
This demonstrates what our docs would look like with a `#` as the default anchor link, rather than the paragraph icon. I also updated some of the CSS for the anchors itself, to be a little bit more visually pleasing, and following the Bootstrap docs style/behavior

OLD:

![chrome_IgTf2LIQmT](https://user-images.githubusercontent.com/1839645/155033503-433f1d86-4808-4d4f-9aa6-a1fbab4f1441.gif)

NEW:

![chrome_cnQVvFcqj6](https://user-images.githubusercontent.com/1839645/155034099-9eeb5787-44f3-467f-ba11-a1951d65d981.gif)



closes #592  