### PR TITLE
Pin sphinx to >=3.5.4,<5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 
 requires-python = ">=3.7"
 dependencies = [
-  "sphinx",
+  "sphinx>=3.5.4,<5",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "packaging"


### PR DESCRIPTION
This pins our version to Sphinx 3.5.4, because this is the first time that they introduced a pin for `docutils`. It also pins below Sphinx 5, because when it is released it will almost certainly break the theme (it will also bring a new docutils, I believe).

supercedes https://github.com/pydata/pydata-sphinx-theme/pull/506