### PR TITLE
Make header links non-selectable

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_base.scss
@@ -41,6 +41,7 @@ a {
     margin-left: 0.2em;
     text-decoration: none;
     transition: all 0.3s ease-out;
+    user-select: none;
 
     &:hover {
       opacity: 1;


### PR DESCRIPTION
I heard reports that it was possible to "copy" the little paragraph symbols in the header links. I can't think of a case where somebody would want to copy that text, so adding a CSS rule to prevent it.