### PR TITLE
Set lighthouse to run on kitchen sink

### DIFF
--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -8,7 +8,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.8 }],
+        "categories:performance": ["error", { "minScore": 0.5 }],
         "categories:accessibility": ["error", { "minScore": 0.8 }],
         "categories:best-practices": ["error", { "minScore": 0.8 }],
         "categories:seo": ["error", { "minScore": 0.8 }]

--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -8,9 +8,9 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.1 }],
-        "categories:accessibility": ["error", { "minScore": 0.96 }],
-        "categories:best-practices": ["error", { "minScore": 0.85 }],
+        "categories:performance": ["error", { "minScore": 0.8 }],
+        "categories:accessibility": ["error", { "minScore": 0.8 }],
+        "categories:best-practices": ["error", { "minScore": 0.8 }],
         "categories:seo": ["error", { "minScore": 0.8 }]
       }
     }

--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./docs/_build/html",
+      "staticDistDir": "./docs/_build/html/demo/kitchen-sink",
       "settings": {
         "skipAudits": ["canonical"]
       }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,10 +114,6 @@ jobs:
           temporaryPublicStorage: true
           uploadArtifacts: true
           runs: 3 # Multiple runs to reduce variance
-          urls: |
-            demo/kitchen-sink/paragraph-markup.html
-            demo/example_pandas.html
-            demo/theme-elements.html
 
       # Serve the docs for auditing with pa11y
       - name: Serve the built site


### PR DESCRIPTION
This sets our lighthouse action to run only on the kitchen sink HTML files. The `urls:` parameter wasn't behaving as expected and so we were running it on all of the root HTML files.