### PR TITLE
Update black pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         exclude: .+((\.html)|index\.(.+)\.css)$
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
This updates black in our pre-commit hook so that it can install properly.

Will merge this if the pre-commit job is happy.