### PR TITLE
ENH: Dark theme support for ethical ads

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_color.scss
@@ -129,10 +129,10 @@ html[data-theme="light"] {
   --pst-color-search: var(--pst-color-border);
   --pst-color-search-border: var(--pst-color-border);
 
-  // ethical add
-  --pst-color-add-text: var(--pst-color-text-base);
-  --pst-color-add-background: var(--pst-color-background);
-  --pst-color-add-border: var(--pst-color-border);
+  // ethical ad
+  --pst-color-ad-text: var(--pst-color-text-base);
+  --pst-color-ad-background: var(--pst-color-background);
+  --pst-color-ad-border: var(--pst-color-border);
 
   // navbar-toogler
   --pst-color-navbar-toggler: var(--pst-color-deactivate);
@@ -271,10 +271,10 @@ html[data-theme="dark"] {
   --pst-color-search: var(--pst-color-border);
   --pst-color-search-border: var(--pst-color-border);
 
-  // ethical add
-  --pst-color-add-text: var(--pst-color-text-base);
-  --pst-color-add-background: var(--pst-color-background);
-  --pst-color-add-border: var(--pst-color-border);
+  // ethical ad
+  --pst-color-ad-text: var(--pst-color-text-base);
+  --pst-color-ad-background: var(--pst-color-background);
+  --pst-color-ad-border: var(--pst-color-border);
 
   // navbar-toogler
   --pst-color-navbar-toggler: var(--pst-color-deactivate);

--- a/src/pydata_sphinx_theme/assets/styles/_ethical-ads.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_ethical-ads.scss
@@ -1,21 +1,23 @@
 // adapt ethical ad to the theme
-.ethical-sidebar a,
-.ethical-sidebar a:visited,
-.ethical-sidebar a:hover,
-.ethical-sidebar a:active,
-.ethical-footer a,
-.ethical-footer a:visited,
-.ethical-footer a:hover,
-.ethical-footer a:active {
-  color: var(--pst-color-ad-text);
-}
+#ethical-ad-placement {
+  .ethical-sidebar a,
+  .ethical-sidebar a:visited,
+  .ethical-sidebar a:hover,
+  .ethical-sidebar a:active,
+  .ethical-footer a,
+  .ethical-footer a:visited,
+  .ethical-footer a:hover,
+  .ethical-footer a:active {
+    color: var(--pst-color-ad-text);
+  }
 
-.ethical-sidebar,
-.ethical-footer {
-  background-color: var(--pst-color-ad-background);
-  border: 1px solid var(--pst-color-ad-border);
-  border-radius: 5px;
-  color: var(--pst-color-ad-text);
-  font-size: 14px;
-  line-height: 20px;
+  .ethical-sidebar,
+  .ethical-footer {
+    background-color: var(--pst-color-ad-background);
+    border: 1px solid var(--pst-color-ad-border);
+    border-radius: 5px;
+    color: var(--pst-color-ad-text);
+    font-size: 14px;
+    line-height: 20px;
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/_ethical-ads.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_ethical-ads.scss
@@ -1,4 +1,4 @@
-// adapt ethical add to the theme
+// adapt ethical ad to the theme
 .ethical-sidebar a,
 .ethical-sidebar a:visited,
 .ethical-sidebar a:hover,
@@ -7,15 +7,15 @@
 .ethical-footer a:visited,
 .ethical-footer a:hover,
 .ethical-footer a:active {
-  color: var(--pst-color-add-text);
+  color: var(--pst-color-ad-text);
 }
 
 .ethical-sidebar,
 .ethical-footer {
-  background-color: var(--pst-color-add-background);
-  border: 1px solid var(--pst-color-add-border);
+  background-color: var(--pst-color-ad-background);
+  border: 1px solid var(--pst-color-ad-border);
   border-radius: 5px;
-  color: var(--pst-color-add-text);
+  color: var(--pst-color-ad-text);
   font-size: 14px;
   line-height: 20px;
 }


### PR DESCRIPTION
Fix #622 Eveything is in the title. 
As the ads are only visible on RDT build I'm forced to push all my changes in this draft to see if it works, sorry for the noise.

## EDIT

it worked at first try so no in the end, no noise