### PR TITLE
ENH: Minor updates and tweaks to Dark theme CSS

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_api.scss
@@ -89,6 +89,7 @@ table.field-list {
 }
 
 // change target color for dark theme
-dt:target {
+dt:target,
+span.highlighted {
   background-color: var(--pst-color-target);
 }

--- a/src/pydata_sphinx_theme/assets/styles/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/_color.scss
@@ -177,7 +177,7 @@ html[data-theme="dark"] {
   // links
   --pst-color-link: var(--pst-color-primary);
   --pst-color-link-hover: rgb(170, 103, 196);
-  --pst-color-target: rgb(117, 148, 195);
+  --pst-color-target: rgb(71, 39, 0);
 
   // headerlinks (the anchors at the end of titles)
   --pst-color-headerlink: rgb(221, 90, 90);

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -545,7 +545,7 @@ nav.bd-links {
   flex-direction: column;
 
   @include media-breakpoint-up(md) {
-    border-right: 1px solid rgba(0, 0, 0, 0.1);
+    border-right: 1px solid var(--pst-color-sidebar-border);
 
     @supports (position: -webkit-sticky) or (position: sticky) {
       position: -webkit-sticky;

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -121,6 +121,7 @@ footer {
     border-radius: 0.2rem;
     border: 1px solid var(--pst-color-search-border);
     padding-left: 35px;
+    color: var(--pst-color-text-base);
 
     // Inner-text of the search bar
     &::placeholder {
@@ -131,6 +132,7 @@ footer {
     &:active,
     &:focus {
       background-color: var(--pst-color-search-background);
+      color: var(--pst-color-search);
     }
   }
 }


### PR DESCRIPTION
I solved som small issues that I saw in the dark theme by using it: 
- change the color of the search field input (it was displayed in grey so completely invisible)
- use variable for sidebar border color
- change target coloring (the used light blue was not working with the new H1 colors and the spans were still in yellow) 

PS: 
Fix #630 