### PR TITLE
ENH: Clean up navbar spacing on mobile

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -31,4 +31,13 @@
   img.icon-link-image {
     height: 1.5em;
   }
+
+  // inline the element in the navbar as long as they fit and use display block when colapsing
+  @include media-breakpoint-down(md) {
+    flex-direction: row;
+
+    a {
+      margin-right: 0.1em;
+    }
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
@@ -15,3 +15,10 @@
     display: block;
   }
 }
+
+.toc-entry > .nav-link.active {
+  font-weight: 600;
+  color: var(--pst-color-toc-link-active);
+  background-color: transparent;
+  border-left: 2px solid var(--pst-color-toc-link-active);
+}

--- a/src/pydata_sphinx_theme/assets/styles/components/header/_header-logo.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/header/_header-logo.scss
@@ -1,0 +1,20 @@
+.navbar-brand {
+  position: relative;
+  height: var(--pst-header-height);
+  width: auto;
+  padding: 0.5rem 0;
+  display: flex;
+  align-items: center;
+
+  // If there's no logo image, we use a p element w/ the site title
+  p {
+    margin-bottom: 0;
+  }
+
+  // If there's a logo, it'll be in an img block
+  img {
+    max-width: 100%;
+    height: 100%;
+    width: auto;
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -31,6 +31,7 @@ $grid-breakpoints: (
 
 // Re-usable components across the theme
 @import "./components/icon-links";
+@import "./components/header/header-logo";
 @import "./components/prev-next";
 @import "./components/search";
 @import "./components/switcher-theme";

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -19,6 +19,17 @@
       border-color: var(--pst-color-navbar-toggler);
       color: var(--pst-color-navbar-toggler);
     }
+
+    #navbar-end {
+      margin-bottom: 0.5em;
+    }
+
+    #navbar-center,
+    #navbar-end {
+      > * {
+        margin-top: 0.5em;
+      }
+    }
   }
 
   @include media-breakpoint-up(lg) {
@@ -84,7 +95,7 @@
 }
 
 // inline the element in the navbar as long as they fit and use display block when colapsing
-@media (min-width: 768px) {
+@include media-breakpoint-up(md) {
   .navbar-center-item {
     display: inline-block;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -8,6 +8,11 @@
     height: 100%;
   }
 
+  #navbar-end {
+    display: flex;
+    align-items: center;
+  }
+
   // On smaller screens, add margin to the navbar start/stop
   @include media-breakpoint-down(lg) {
     #navbar-start {
@@ -30,34 +35,6 @@
         margin-top: 0.5em;
       }
     }
-  }
-
-  @include media-breakpoint-up(lg) {
-    // navbar-end-items should be on one line if possible
-    #navbar-end > .navbar-end-item {
-      display: inline-block;
-    }
-  }
-}
-
-.navbar-brand {
-  position: relative;
-  height: var(--pst-header-height);
-  width: auto;
-  padding: 0.5rem 0;
-  display: flex;
-  align-items: center;
-
-  // If there's no logo image, we use a p element w/ the site title
-  p {
-    margin-bottom: 0;
-  }
-
-  // If there's a logo, it'll be in an img block
-  img {
-    max-width: 100%;
-    height: 100%;
-    width: auto;
   }
 }
 


### PR DESCRIPTION
This is a small improvement to the spacing of icons on mobile. It adds a bit of vertical spacing and makes the icon links stack horizontally.

See this before/after GIF:

![chrome_gEJS4Znaea](https://user-images.githubusercontent.com/1839645/165294477-ab31cf6f-b805-4fec-a845-bf3b89a56c3d.gif)

