### PR TITLE
Update example to correspond to new Google Analytics ID

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -768,13 +768,13 @@ following configuration to your ``conf.py`` file:
 Google Analytics
 ================
 
-If the ``google_analytics_id`` config option is specified (like ``UA-XXXXXXX``),
+If the ``google_analytics_id`` config option is specified (like ``G-XXXXXXXXXX``),
 Google Analytics' javascript is included in the html pages.
 
 .. code:: python
 
    html_theme_options = {
-       "google_analytics_id": "UA-XXXXXXX",
+       "google_analytics_id": "G-XXXXXXXXXX",
    }
 
 


### PR DESCRIPTION
The Google Universal Analytics (UA) IDs are being phased out, hence I think it makes more sense that the Pydata Sphinx theme example utilizes the new type of Google Analytics ID. Partly so the documentation is valid once the UA ID's discontinues, but also to encourage users to use the new Google Analytics ID version .

Support for the new Google Analytics ID was added in #385 

> Google Analytics 4 is our next-generation measurement solution and is replacing Universal Analytics. On July 1, 2023, Universal Analytics properties will stop processing new hits. If you still rely on Universal Analytics, we recommend that you complete your move to Google Analytics 4.