### PR TITLE
customize display of line numbers in code-block

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -124,7 +124,7 @@ pre {
   border-radius: 0.2rem;
   box-shadow: 1px 1px 1px var(--pst-color-preformatted-shadow);
 
-  .lineos {
+  .linenos {
     opacity: 0.5;
     padding-right: 10px;
   }

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -123,4 +123,9 @@ pre {
   border: 1px solid var(--pst-color-preformatted-border);
   border-radius: 0.2rem;
   box-shadow: 1px 1px 1px var(--pst-color-preformatted-shadow);
+
+  .lineos {
+    opacity: 0.5;
+    padding-right: 10px;
+  }
 }


### PR DESCRIPTION
Fix #260 

I don't like unclosed issues so I was scrolling in the repository to find small stuff that could be updated. I think some adjustment could be beneficial for the code-block directive when it come to line numbers.

The normal implementation place the numbers super close to the code and in the exact same color, making it a bit difficult to read. 

<img width="778" alt="Capture d’écran 2022-05-05 à 00 06 01" src="https://user-images.githubusercontent.com/12596392/166833411-dc4debe0-cbb3-4778-8eae-953236e25405.png">

With this PR I simply add a small padding to the line-number and dim the opacity so that they have less contrast than regular code (in short as in any good IDE).

<img width="784" alt="Capture d’écran 2022-05-05 à 00 04 58" src="https://user-images.githubusercontent.com/12596392/166833427-ec9113e0-81ff-4031-b902-6f567403686e.png">

Let me know what you think.