### PR TITLE
fix: apply the centered directive

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -22,6 +22,10 @@ p {
   &.rubric {
     border-bottom: 1px solid var(--pst-color-border);
   }
+
+  &.centered {
+    text-align: center;
+  }
 }
 
 a {


### PR DESCRIPTION
everything is in the title. fix #338.

the element here: https://pydata-sphinx-theme--652.org.readthedocs.build/en/652/demo/kitchen-sink/paragraph-markup.html?#centered-text