### PR TITLE
Update docs on version switcher dictionary

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -437,7 +437,7 @@ The switcher requires the following configuration steps:
    switcher should show on each page.
 
 2. Add a configuration dictionary called ``switcher`` to the
-   ``html_theme_options`` dict in ``conf.py``. ``switcher`` should have 3 keys:
+   ``html_theme_options`` dict in ``conf.py``. ``switcher`` should have 2 keys:
 
    - ``json_url``: the persistent location of the JSON file described above.
    - ``version_match``: a string stating the version of the documentation that


### PR DESCRIPTION
Currently, the `switcher` dictionary supports 2 keys, not three.