### PR TITLE
[switcher] default `activeVersion` and `activeVersionName` values

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/_templates/version-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/_templates/version-switcher.html
@@ -39,6 +39,9 @@ function checkPageExistsAndRedirect(event) {
 (function () {
     $.getJSON("{{ theme_switcher.get('json_url') }}", function(data, textStatus, jqXHR) {
         const currentFilePath = "{{ pagename }}.html";
+        let btn = document.getElementById("version_switcher_button");
+        btn.dataset["activeVersionName"] = "";
+        btn.dataset["activeVersion"] = "";
         // create links to the corresponding page in the other docs versions
         $.each(data, function(index, entry) {
             // if no custom name specified (e.g., "latest"), use version string
@@ -66,7 +69,6 @@ function checkPageExistsAndRedirect(event) {
             // version's entry
             if (entry.version == "{{ theme_switcher.get('version_match') }}") {
                 node.classList.add("active");
-                let btn = document.getElementById("version_switcher_button");
                 btn.innerText = btn.dataset["activeVersionName"] = entry.name;
                 btn.dataset["activeVersion"] = entry.version;
             }

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/_templates/version-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/_templates/version-switcher.html
@@ -40,6 +40,7 @@ function checkPageExistsAndRedirect(event) {
     $.getJSON("{{ theme_switcher.get('json_url') }}", function(data, textStatus, jqXHR) {
         const currentFilePath = "{{ pagename }}.html";
         let btn = document.getElementById("version_switcher_button");
+        // Set empty strings for active button by default so we can demo in developer mode
         btn.dataset["activeVersionName"] = "";
         btn.dataset["activeVersion"] = "";
         // create links to the corresponding page in the other docs versions

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/_templates/version-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/_templates/version-switcher.html
@@ -40,7 +40,7 @@ function checkPageExistsAndRedirect(event) {
     $.getJSON("{{ theme_switcher.get('json_url') }}", function(data, textStatus, jqXHR) {
         const currentFilePath = "{{ pagename }}.html";
         let btn = document.getElementById("version_switcher_button");
-        // Set empty strings for active button by default so we can demo in developer mode
+        // Set empty strings by default so that these attributes exist and can be used in CSS selectors
         btn.dataset["activeVersionName"] = "";
         btn.dataset["activeVersion"] = "";
         // create links to the corresponding page in the other docs versions


### PR DESCRIPTION
In PRs, I find it handy to have the PR indicator as the version name in the switcher.

But then, because there is no entry in the json, the button is missing the dataset attributes `activeVersion` and `activeVersionName`. This PR adds a default empty string (and from codes I could see, this seems to be standard).

This would allow to have access to an empty dataset attribute and use it as CSS selector.

Use case in NumPy here: https://github.com/numpy/numpy/pull/21451
And I would do the same for SciPy if this behaviour is confirmed 😃 