### PR TITLE
Missing release in version switcher

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -13,4 +13,5 @@
 /* If we're on a dev version, make the switcher button orange */
 #version_switcher_button[data-active-version-name*="dev"] {
   background-color: rgb(255 138 62);
+  border-color: rgb(255 138 62);
 }

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -5,9 +5,14 @@
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/latest/"
   },
   {
-    "name": "0.8.0 (stable)",
+    "name": "0.8.1 (stable)",
     "version": "stable",
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/stable/"
+  },
+  {
+    "name": "0.8.1",
+    "version": "v0.8.1",
+    "url": "https://pydata-sphinx-theme.readthedocs.io/en/v0.8.1/"
   },
   {
     "name": "0.8.0",


### PR DESCRIPTION
0.8.1 is missing in the dropdown of the doc.

Also I changed the styling for the dev version to have the same border colour as the background colour. Otherwise there is a small blue which IMHO is not visually pleasing.