### PR TITLE
Fix scrollspy so TOC expands when sections are clicked

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -34,7 +34,9 @@
 {% block sidebarsourcelink %}{% endblock %}
 
 {% block body_tag %}
-  <body data-spy="scroll" data-target="#bd-toc-nav" data-offset="60" data-default-mode="{{ default_mode }}">
+  {# set up with scrollspy to update the toc as we scroll #}
+  {# ref: https://getbootstrap.com/docs/4.0/components/scrollspy/ #}
+  <body data-spy="scroll" data-target="#bd-toc-nav" data-offset="180" data-default-mode="{{ default_mode }}">
 {%- endblock %}
 {%- block content %}
     {# Added to support a banner with an alert #}


### PR DESCRIPTION
I noticed that clicking an internal link in the right TOC does not actually "open" that section in the TOC because the scrollspy data offset is too little. So this increases by 3x, so that the TOC is updated when the header is a bit further into the middle of the screen.