### PR TITLE
ENH: simplify color variables

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -16,7 +16,7 @@ body {
 p {
   margin-bottom: 1.15rem;
   font-size: 1em;
-  color: var(--pst-color-paragraph);
+  color: var(--pst-color-text-base);
 
   /* section header in docstring pages */
   &.rubric {
@@ -38,7 +38,7 @@ a {
   }
 
   &.headerlink {
-    color: var(--pst-color-headerlink);
+    color: var(--pst-color-danger);
     opacity: 0.4;
     font-size: 0.8em;
     padding: 0 4px 0 4px;
@@ -64,37 +64,37 @@ h1 {
   @extend .heading-style;
   margin-top: 0;
   font-size: var(--pst-font-size-h1);
-  color: var(--pst-color-h1);
+  color: var(--pst-color-primary);
 }
 
 h2 {
   @extend .heading-style;
   font-size: var(--pst-font-size-h2);
-  color: var(--pst-color-h2);
+  color: var(--pst-color-primary);
 }
 
 h3 {
   @extend .heading-style;
   font-size: var(--pst-font-size-h3);
-  color: var(--pst-color-h3);
+  color: var(--pst-color-text-base);
 }
 
 h4 {
   @extend .heading-style;
   font-size: var(--pst-font-size-h4);
-  color: var(--pst-color-h4);
+  color: var(--pst-color-text-base);
 }
 
 h5 {
   @extend .heading-style;
   font-size: var(--pst-font-size-h5);
-  color: var(--pst-color-h5);
+  color: var(--pst-color-text-base);
 }
 
 h6 {
   @extend .heading-style;
   font-size: var(--pst-font-size-h6);
-  color: var(--pst-color-h6);
+  color: var(--pst-color-text-base);
 }
 
 small,
@@ -114,6 +114,12 @@ samp {
   font-family: var(--pst-font-family-monospace);
 }
 
+kbd {
+  // use theme negative
+  background-color: var(--pst-color-text-base);
+  color: var(--pst-color-background);
+}
+
 code {
   color: var(--pst-color-inline-code);
 }
@@ -121,12 +127,12 @@ code {
 pre {
   margin: 1.5em 0 1.5em 0;
   padding: 10px;
-  background-color: var(--pst-color-preformatted-background);
-  color: var(--pst-color-preformatted-text);
+  background-color: var(--pst-color-surface);
+  color: var(--pst-color-text-base);
   line-height: 1.2em;
-  border: 1px solid var(--pst-color-preformatted-border);
+  border: 1px solid var(--pst-color-border);
   border-radius: 0.2rem;
-  box-shadow: 1px 1px 1px var(--pst-color-preformatted-shadow);
+  box-shadow: 1px 1px 1px var(--pst-color-shadow);
 
   .linenos {
     opacity: 0.5;

--- a/src/pydata_sphinx_theme/assets/styles/base/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_color.scss
@@ -11,135 +11,33 @@ html[data-theme="light"] {
   // main colors
   --pst-color-primary: rgb(19, 6, 84);
   --pst-color-success: rgb(40, 167, 69);
-  --pst-color-info: rgb(0, 123, 255); /*23, 162, 184;*/
+  --pst-color-info: rgb(0, 123, 255);
   --pst-color-warning: rgb(255, 193, 7);
   --pst-color-danger: rgb(220, 53, 69);
   --pst-color-text-base: rgb(51, 51, 51);
+  --pst-color-text-muted: rgb(77, 77, 77);
   --pst-color-background: rgb(255, 255, 255);
-  --pst-color-background-up: rgb(240, 240, 240); // for 3D effects
-  --pst-color-background-up-up: rgb(255, 255, 238); // for 3D effects
-  --pst-color-deactivate: rgb(77, 77, 77);
+  --pst-color-on-background: rgb(255, 255, 255);
+  --pst-color-surface: rgb(240, 240, 240);
+  --pst-color-on-surface: rgb(255, 255, 238);
   --pst-color-border: rgb(201, 201, 201);
   --pst-color-shadow: rgb(216, 216, 216);
-
-  // headers
-  --pst-color-h1: var(--pst-color-primary);
-  --pst-color-h2: var(--pst-color-primary);
-  --pst-color-h3: var(--pst-color-text-base);
-  --pst-color-h4: var(--pst-color-text-base);
-  --pst-color-h5: var(--pst-color-text-base);
-  --pst-color-h6: var(--pst-color-text-base);
-  --pst-color-paragraph: var(--pst-color-text-base);
 
   // links
   --pst-color-link: rgb(0, 91, 129);
   --pst-color-link-hover: rgb(227, 46, 0);
   --pst-color-target: rgb(251, 229, 78);
 
-  // headerlinks (the anchors at the end of titles)
-  --pst-color-headerlink: rgb(198, 15, 15);
-
-  // navigation
-  --pst-color-active-navigation: var(--pst-color-primary);
-  --pst-color-deactive-navigation: var(--pst-color-deactivate);
-
-  /*****************************************************************************
-  * roles
-  */
-
   // inline code
   --pst-color-inline-code: rgb(232, 62, 140);
-
-  // guilabel
-  --pst-color-guilabel-background: rgb(231, 242, 250);
-  --pst-color-guilabel-border: rgb(127, 187, 227);
-  --pst-color-guilabel-text: var(--pst-color-guilabel-border);
-
-  // kbd
-  --pst-color-kbd-text: rgb(255, 255, 255);
-  --pst-color-kbd-background: rgb(33, 37, 41);
-
-  /*****************************************************************************
-  * directives
-  */
-
-  // admonitions
-  --pst-color-admonition-default: var(--pst-color-info);
-  --pst-color-admonition-note: var(--pst-color-info);
-  --pst-color-admonition-attention: var(--pst-color-warning);
-  --pst-color-admonition-caution: var(--pst-color-warning);
-  --pst-color-admonition-warning: var(--pst-color-warning);
-  --pst-color-admonition-danger: var(--pst-color-danger);
-  --pst-color-admonition-error: var(--pst-color-danger);
-  --pst-color-admonition-hint: var(--pst-color-success);
-  --pst-color-admonition-tip: var(--pst-color-success);
-  --pst-color-admonition-important: var(--pst-color-success);
-  --pst-color-admonition-background: var(--pst-color-background);
-  --pst-color-admonition-shadow: var(--pst-color-shadow);
-
-  // viersion modified
-  --pst-color-versionmodified-default: var(--pst-color-info);
-  --pst-color-versionmodified-added: var(--pst-color-success);
-  --pst-color-versionmodified-changed: var(--pst-color-warning);
-  --pst-color-versionmodified-deprecated: var(--pst-color-danger);
-
-  // preformatted
-  --pst-color-preformatted-text: rgb(34, 34, 34);
-  --pst-color-preformatted-border: var(--pst-color-border);
-  --pst-color-preformatted-background: var(--pst-color-background-up);
-  --pst-color-preformatted-shadow: var(--pst-color-shadow);
 
   // targeted viewcode
   --pst-color-viewcode-target-border: rgb(170, 204, 153);
   --pst-color-viewcode-target-background: rgb(244, 222, 191);
 
-  /*****************************************************************************
-  * layout
-  */
-
-  // navbar
-  --pst-color-navbar-background: var(--pst-color-background);
-  --pst-color-navbar-link: var(--pst-color-deactivate);
-  --pst-color-navbar-link-hover: var(--pst-color-active-navigation);
-  --pst-color-navbar-link-active: var(--pst-color-active-navigation);
-
-  // toc
-  --pst-color-toc-link: var(--pst-color-deactivate);
-  --pst-color-toc-link-hover: var(--pst-color-active-navigation);
-  --pst-color-toc-link-active: var(--pst-color-active-navigation);
-  --pst-color-toc-border: var(--pst-color-border);
-
-  // sidebar
-  --pst-color-sidebar-link: var(--pst-color-deactivate);
-  --pst-color-sidebar-link-hover: var(--pst-color-active-navigation);
-  --pst-color-sidebar-link-active: var(--pst-color-active-navigation);
-  --pst-color-sidebar-expander-background-hover: var(--pst-color-background-up);
-  --pst-color-sidebar-caption: var(--pst-color-text-base);
-  --pst-color-sidebar-border: var(--pst-color-border);
-
-  // footer
-  --pst-color-footer-border: var(--pst-color-border);
-
   // alert
   // higher contrast of links in info boxes
   --pst-color-alert-link: rgb(232, 62, 140);
-
-  // prev-next
-  --pst-color-prev-next: var(--pst-color-primary);
-  --pst-color-prev-next-btn: var(--pst-color-deactivate);
-
-  // search
-  --pst-color-search-background: var(--pst-color-background);
-  --pst-color-search: var(--pst-color-border);
-  --pst-color-search-border: var(--pst-color-border);
-
-  // ethical ad
-  --pst-color-ad-text: var(--pst-color-text-base);
-  --pst-color-ad-background: var(--pst-color-background);
-  --pst-color-ad-border: var(--pst-color-border);
-
-  // navbar-toogler
-  --pst-color-navbar-toggler: var(--pst-color-deactivate);
 
   // blockquote
   --pst-color-blockquote-border: rgb(221, 221, 221);
@@ -152,7 +50,7 @@ html[data-theme="light"] {
 */
 html[data-theme="dark"] {
   /*****************************************************************************
-  * theme colors
+  * colors
   */
 
   // main colors
@@ -162,130 +60,29 @@ html[data-theme="dark"] {
   --pst-color-warning: rgb(193, 162, 69);
   --pst-color-danger: rgb(203, 70, 83);
   --pst-color-text-base: rgb(201, 209, 217);
+  --pst-color-text-muted: rgb(192, 192, 192);
   --pst-color-background: rgb(18, 18, 18);
-  --pst-color-background-up: rgb(22, 22, 22); // for 3D effect in dark theme
-  --pst-color-background-up-up: rgb(55, 55, 55); // for 3D effects
-  --pst-color-deactivate: rgb(192, 192, 192);
-  --pst-color-border: var(--pst-color-deactivate);
+  --pst-color-on-background: rgb(22, 22, 22);
+  --pst-color-surface: rgb(22, 22, 22);
+  --pst-color-on-surface: rgb(55, 55, 55);
+  --pst-color-border: rgb(192, 192, 192);
   --pst-color-shadow: var(--pst-color-background);
-
-  // headers
-  --pst-color-h1: var(--pst-color-primary);
-  --pst-color-h2: var(--pst-color-primary);
-  --pst-color-h3: var(--pst-color-text-base);
-  --pst-color-h4: var(--pst-color-text-base);
-  --pst-color-h5: var(--pst-color-text-base);
-  --pst-color-h6: var(--pst-color-text-base);
-  --pst-color-paragraph: var(--pst-color-text-base);
 
   // links
   --pst-color-link: var(--pst-color-primary);
   --pst-color-link-hover: rgb(170, 103, 196);
   --pst-color-target: rgb(71, 39, 0);
 
-  // headerlinks (the anchors at the end of titles)
-  --pst-color-headerlink: rgb(221, 90, 90);
-
-  // navigation
-  --pst-color-active-navigation: var(--pst-color-primary);
-  --pst-color-deactive-navigation: var(--pst-color-deactivate);
-
-  /*****************************************************************************
-  * roles
-  */
-
   // inline code
   --pst-color-inline-code: rgb(221, 158, 194);
-
-  // guilabel
-  --pst-color-guilabel-background: rgb(242, 196, 166);
-  --pst-color-guilabel-border: rgb(83, 56, 38);
-  --pst-color-guilabel-text: var(--pst-color-guilabel-border);
-
-  // kbd
-  --pst-color-kbd-text: rgb(33, 37, 41);
-  --pst-color-kbd-background: rgb(245, 245, 245);
-
-  /*****************************************************************************
-  * directives
-  */
-
-  // admonitions
-  --pst-color-admonition-default: var(--pst-color-info);
-  --pst-color-admonition-note: var(--pst-color-info);
-  --pst-color-admonition-attention: var(--pst-color-warning);
-  --pst-color-admonition-caution: var(--pst-color-warning);
-  --pst-color-admonition-warning: var(--pst-color-warning);
-  --pst-color-admonition-danger: var(--pst-color-danger);
-  --pst-color-admonition-error: var(--pst-color-danger);
-  --pst-color-admonition-hint: var(--pst-color-success);
-  --pst-color-admonition-tip: var(--pst-color-success);
-  --pst-color-admonition-important: var(--pst-color-success);
-  --pst-color-admonition-background: var(--pst-color-background-up);
-  --pst-color-admonition-shadow: var(--pst-color-shadow);
-
-  // viersion modified
-  --pst-color-versionmodified-default: var(--pst-color-info);
-  --pst-color-versionmodified-added: var(--pst-color-success);
-  --pst-color-versionmodified-changed: var(--pst-color-warning);
-  --pst-color-versionmodified-deprecated: var(--pst-color-danger);
-
-  // preformatted
-  --pst-color-preformatted-text: rgb(210, 210, 210);
-  --pst-color-preformatted-border: rgb(83, 83, 83);
-  --pst-color-preformatted-background: var(--pst-color-background-up);
-  --pst-color-preformatted-shadow: var(--pst-color-shadow);
 
   // targeted viewcode
   --pst-color-viewcode-target-border: rgb(170, 204, 153);
   --pst-color-viewcode-target-background: rgb(35, 55, 83);
 
-  /*****************************************************************************
-  * layout
-  */
-
-  // navbar
-  --pst-color-navbar-background: var(--pst-color-background-up);
-  --pst-color-navbar-link: var(--pst-color-deactivate);
-  --pst-color-navbar-link-hover: var(--pst-color-active-navigation);
-  --pst-color-navbar-link-active: var(--pst-color-active-navigation);
-
-  // toc
-  --pst-color-toc-link: var(--pst-color-deactivate);
-  --pst-color-toc-link-hover: var(--pst-color-active-navigation);
-  --pst-color-toc-link-active: var(--pst-color-active-navigation);
-  --pst-color-toc-border: var(--pst-color-border);
-
-  // sidebar
-  --pst-color-sidebar-link: var(--pst-color-deactivate);
-  --pst-color-sidebar-link-hover: var(--pst-color-active-navigation);
-  --pst-color-sidebar-link-active: var(--pst-color-active-navigation);
-  --pst-color-sidebar-expander-background-hover: var(--pst-color-background-up);
-  --pst-color-sidebar-caption: var(--pst-color-text-base);
-  --pst-color-sidebar-border: var(--pst-color-border);
-
-  // footer
-  --pst-color-footer-border: var(--pst-color-border);
-
   // alert
-  --pst-color-alert-link: rgb(232, 62, 140); // higher contrast of links
-
-  // prev-next
-  --pst-color-prev-next: var(--pst-color-link);
-  --pst-color-prev-next-btn: var(--pst-color-deactivate);
-
-  // search
-  --pst-color-search-background: var(--pst-color-background);
-  --pst-color-search: var(--pst-color-border);
-  --pst-color-search-border: var(--pst-color-border);
-
-  // ethical ad
-  --pst-color-ad-text: var(--pst-color-text-base);
-  --pst-color-ad-background: var(--pst-color-background);
-  --pst-color-ad-border: var(--pst-color-border);
-
-  // navbar-toogler
-  --pst-color-navbar-toggler: var(--pst-color-deactivate);
+  // higher contrast of links in info boxes
+  --pst-color-alert-link: rgb(232, 62, 140);
 
   // blockquote
   --pst-color-blockquote-border: rgb(117, 117, 117);

--- a/src/pydata_sphinx_theme/assets/styles/base/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_color.scss
@@ -5,10 +5,9 @@
 */
 html[data-theme="light"] {
   /*****************************************************************************
-  * colors
+  * main colors
   */
 
-  // main colors
   --pst-color-primary: rgb(19, 6, 84);
   --pst-color-success: rgb(40, 167, 69);
   --pst-color-info: rgb(0, 123, 255);
@@ -23,24 +22,19 @@ html[data-theme="light"] {
   --pst-color-border: rgb(201, 201, 201);
   --pst-color-shadow: rgb(216, 216, 216);
 
+  /*****************************************************************************
+  * extra
+  */
+
   // links
   --pst-color-link: rgb(0, 91, 129);
   --pst-color-link-hover: rgb(227, 46, 0);
-  --pst-color-target: rgb(251, 229, 78);
 
   // inline code
   --pst-color-inline-code: rgb(232, 62, 140);
 
-  // targeted viewcode
-  --pst-color-viewcode-target-border: rgb(170, 204, 153);
-  --pst-color-viewcode-target-background: rgb(244, 222, 191);
-
-  // alert
-  // higher contrast of links in info boxes
-  --pst-color-alert-link: rgb(232, 62, 140);
-
-  // blockquote
-  --pst-color-blockquote-border: rgb(221, 221, 221);
+  // targeted content
+  --pst-color-target: rgb(251, 229, 78);
 }
 
 /*******************************************************************************
@@ -50,10 +44,9 @@ html[data-theme="light"] {
 */
 html[data-theme="dark"] {
   /*****************************************************************************
-  * colors
+  * main colors
   */
 
-  // main colors
   --pst-color-primary: rgb(76, 145, 219);
   --pst-color-success: rgb(72, 135, 87);
   --pst-color-info: rgb(64, 125, 191);
@@ -68,24 +61,19 @@ html[data-theme="dark"] {
   --pst-color-border: rgb(192, 192, 192);
   --pst-color-shadow: var(--pst-color-background);
 
+  /*****************************************************************************
+  * extra
+  */
+
   // links
   --pst-color-link: var(--pst-color-primary);
   --pst-color-link-hover: rgb(170, 103, 196);
-  --pst-color-target: rgb(71, 39, 0);
 
   // inline code
   --pst-color-inline-code: rgb(221, 158, 194);
 
-  // targeted viewcode
-  --pst-color-viewcode-target-border: rgb(170, 204, 153);
-  --pst-color-viewcode-target-background: rgb(35, 55, 83);
-
-  // alert
-  // higher contrast of links in info boxes
-  --pst-color-alert-link: rgb(232, 62, 140);
-
-  // blockquote
-  --pst-color-blockquote-border: rgb(117, 117, 117);
+  // targeted content
+  --pst-color-target: rgb(71, 39, 0);
 
   // specific brightness applied on images
   img {

--- a/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
@@ -19,11 +19,11 @@
     padding: 10px;
     max-width: 45%;
     overflow-x: hidden;
-    color: var(--pst-color-prev-next-btn);
+    color: var(--pst-color-text-muted);
     text-decoration: none;
 
     p.prev-next-title {
-      color: var(--pst-color-prev-next);
+      color: var(--pst-color-primary);
       font-weight: 600;
       font-size: 1.1em;
     }

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -6,27 +6,27 @@
 
   .icon {
     position: absolute;
-    color: var(--pst-color-search);
+    color: var(--pst-color-border);
     left: 25px;
   }
 
   input {
-    background-color: var(--pst-color-search-background);
+    background-color: var(--pst-color-background);
     border-radius: 0.2rem;
-    border: 1px solid var(--pst-color-search-border);
+    border: 1px solid var(--pst-color-border);
     padding-left: 35px;
     color: var(--pst-color-text-base);
 
     // Inner-text of the search bar
     &::placeholder {
-      color: var(--pst-color-search);
+      color: var(--pst-color-border);
     }
 
     // Background should always be same color regardless of active or nor
     &:active,
     &:focus {
-      background-color: var(--pst-color-search-background);
-      color: var(--pst-color-search);
+      background-color: var(--pst-color-background);
+      color: var(--pst-color-border);
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -1,19 +1,19 @@
 // the icons for theme change
 #theme-switch {
-  border-color: var(--pst-color-navbar-link-hover);
+  border-color: var(--pst-color-primary);
   margin-right: 0.4rem;
 
   a {
-    color: var(--pst-color-navbar-link-hover);
+    color: var(--pst-color-primary);
     display: none;
   }
 
   &:hover {
-    border-color: var(--pst-color-navbar-background);
-    background-color: var(--pst-color-navbar-link-hover);
+    border-color: var(--pst-color-on-background);
+    background-color: var(--pst-color-primary);
 
     a {
-      color: var(--pst-color-navbar-background);
+      color: var(--pst-color-on-background);
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -9,7 +9,6 @@
   }
 
   &:hover {
-    border-color: var(--pst-color-on-background);
     background-color: var(--pst-color-primary);
 
     a {

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -1,4 +1,4 @@
 #version_switcher_button {
-  background-color: var(--pst-color-active-navigation);
-  border-color: var(--pst-color-active-navigation);
+  background-color: var(--pst-color-primary);
+  border-color: var(--pst-color-primary);
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -7,7 +7,7 @@ div.deprecated {
   overflow: hidden;
   page-break-inside: avoid;
   border-left: 0.2rem solid;
-  border-color: var(--pst-color-versionmodified-default);
+  border-color: var(--pst-color-info);
   border-radius: 0.2rem;
   box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.05),
     0 0 0.0625rem rgba(0, 0, 0, 0.1);
@@ -27,33 +27,33 @@ div.deprecated {
       position: absolute;
       left: 0;
       top: 0;
-      background-color: var(--pst-color-admonition-default);
+      background-color: var(--pst-color-info);
       opacity: 0.1;
     }
   }
 }
 
 div.versionadded {
-  border-color: var(--pst-color-versionmodified-added);
+  border-color: var(--pst-color-success);
 
   p:before {
-    background-color: var(--pst-color-versionmodified-added);
+    background-color: var(--pst-color-success);
   }
 }
 
 div.versionchanged {
-  border-color: var(--pst-color-versionmodified-changed);
+  border-color: var(--pst-color-warning);
 
   p:before {
-    background-color: var(--pst-color-versionmodified-changed);
+    background-color: var(--pst-color-warning);
   }
 }
 
 div.deprecated {
-  border-color: var(--pst-color-versionmodified-deprecated);
+  border-color: var(--pst-color-danger);
 
   p:before {
-    background-color: var(--pst-color-versionmodified-deprecated);
+    background-color: var(--pst-color-danger);
   }
 }
 
@@ -63,7 +63,7 @@ span.versionmodified {
   &:before {
     font-style: normal;
     margin-right: 0.6rem;
-    color: var(--pst-color-versionmodified-default);
+    color: var(--pst-color-info);
     font-family: "Font Awesome 5 Free";
     font-weight: 900;
     content: var(--pst-icon-versionmodified-default);
@@ -72,21 +72,21 @@ span.versionmodified {
 
 span.versionmodified.added {
   &:before {
-    color: var(--pst-color-versionmodified-added);
+    color: var(--pst-color-success);
     content: var(--pst-icon-versionmodified-added);
   }
 }
 
 span.versionmodified.changed {
   &:before {
-    color: var(--pst-color-versionmodified-changed);
+    color: var(--pst-color-warning);
     content: var(--pst-icon-versionmodified-changed);
   }
 }
 
 span.versionmodified.deprecated {
   &:before {
-    color: var(--pst-color-versionmodified-deprecated);
+    color: var(--pst-color-danger);
     content: var(--pst-icon-versionmodified-deprecated);
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -9,8 +9,8 @@ div.deprecated {
   border-left: 0.2rem solid;
   border-color: var(--pst-color-info);
   border-radius: 0.2rem;
-  box-shadow: 0 0.2rem 0.5rem rgba(0, 0, 0, 0.05),
-    0 0 0.0625rem rgba(0, 0, 0, 0.1);
+  box-shadow: 0 0.2rem 0.5rem var(--pst-color-shadow),
+    0 0 0.0625rem var(--pst-color-shadow);
   transition: color 250ms, background-color 250ms, border-color 250ms;
   position: relative;
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -7,12 +7,12 @@ div.admonition,
   overflow: hidden;
   page-break-inside: avoid;
   border-left: 0.2rem solid;
-  border-color: var(--pst-color-admonition-default);
+  border-color: var(--pst-color-info);
   border-radius: 0.2rem;
-  box-shadow: 0 0.2rem 0.5rem var(--pst-color-admonition-shadow),
-    0 0 0.0625rem var(--pst-color-admonition-shadow);
+  box-shadow: 0 0.2rem 0.5rem var(--pst-color-shadow),
+    0 0 0.0625rem var(--pst-color-shadow);
   transition: color 250ms, background-color 250ms, border-color 250ms;
-  background-color: var(--pst-color-admonition-background);
+  background-color: var(--pst-color-surface);
 
   // Last item should have no spacing since we'll control that w/ padding
   *:last-child {
@@ -43,7 +43,7 @@ div.admonition,
       left: 0.6rem;
       width: 1rem;
       height: 1rem;
-      color: var(--pst-color-admonition-default);
+      color: var(--pst-color-info);
       font-family: "Font Awesome 5 Free";
       font-weight: 900;
       content: var(--pst-icon-admonition-default);
@@ -59,7 +59,7 @@ div.admonition,
       position: absolute;
       left: 0;
       top: 0;
-      background-color: var(--pst-color-admonition-default);
+      background-color: var(--pst-color-info);
       opacity: 0.1;
     }
 
@@ -70,126 +70,126 @@ div.admonition,
   }
 
   &.attention {
-    border-color: var(--pst-color-admonition-attention);
+    border-color: var(--pst-color-warning);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-attention);
+        background-color: var(--pst-color-warning);
       }
 
       &:before {
-        color: var(--pst-color-admonition-attention);
+        color: var(--pst-color-warning);
         content: var(--pst-icon-admonition-attention);
       }
     }
   }
 
   &.caution {
-    border-color: var(--pst-color-admonition-caution);
+    border-color: var(--pst-color-warning);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-caution);
+        background-color: var(--pst-color-warning);
       }
 
       &:before {
-        color: var(--pst-color-admonition-caution);
+        color: var(--pst-color-warning);
         content: var(--pst-icon-admonition-caution);
       }
     }
   }
 
   &.warning {
-    border-color: var(--pst-color-admonition-warning);
+    border-color: var(--pst-color-warning);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-warning);
+        background-color: var(--pst-color-warning);
       }
 
       &:before {
-        color: var(--pst-color-admonition-warning);
+        color: var(--pst-color-warning);
         content: var(--pst-icon-admonition-warning);
       }
     }
   }
 
   &.danger {
-    border-color: var(--pst-color-admonition-danger);
+    border-color: var(--pst-color-danger);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-danger);
+        background-color: var(--pst-color-danger);
       }
 
       &:before {
-        color: var(--pst-color-admonition-danger);
+        color: var(--pst-color-danger);
         content: var(--pst-icon-admonition-danger);
       }
     }
   }
 
   &.error {
-    border-color: var(--pst-color-admonition-error);
+    border-color: var(--pst-color-danger);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-error);
+        background-color: var(--pst-color-danger);
       }
 
       &:before {
-        color: var(--pst-color-admonition-error);
+        color: var(--pst-color-danger);
         content: var(--pst-icon-admonition-error);
       }
     }
   }
 
   &.hint {
-    border-color: var(--pst-color-admonition-hint);
+    border-color: var(--pst-color-success);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-hint);
+        background-color: var(--pst-color-success);
       }
 
       &:before {
-        color: var(--pst-color-admonition-hint);
+        color: var(--pst-color-success);
         content: var(--pst-icon-admonition-hint);
       }
     }
   }
 
   &.tip {
-    border-color: var(--pst-color-admonition-tip);
+    border-color: var(--pst-color-success);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-tip);
+        background-color: var(--pst-color-success);
       }
 
       &:before {
-        color: var(--pst-color-admonition-tip);
+        color: var(--pst-color-success);
         content: var(--pst-icon-admonition-tip);
       }
     }
   }
 
   &.important {
-    border-color: var(--pst-color-admonition-important);
+    border-color: var(--pst-color-success);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-important);
+        background-color: var(--pst-color-success);
       }
 
       &:before {
-        color: var(--pst-color-admonition-important);
+        color: var(--pst-color-success);
         content: var(--pst-icon-admonition-important);
       }
     }
   }
 
   &.note {
-    border-color: var(--pst-color-admonition-note);
+    border-color: var(--pst-color-info);
     > .admonition-title {
       &:after {
-        background-color: var(--pst-color-admonition-note);
+        background-color: var(--pst-color-info);
       }
 
       &:before {
-        color: var(--pst-color-admonition-note);
+        color: var(--pst-color-info);
         content: var(--pst-icon-admonition-note);
       }
     }
@@ -198,12 +198,12 @@ div.admonition,
 
 // Similar content blocks that are not technically admonitions.
 .topic {
-  background-color: var(--pst-color-background-up);
+  background-color: var(--pst-color-surface);
   border-color: var(--pst-color-border);
 }
 
 aside.sidebar {
-  background-color: var(--pst-color-background-up-up);
+  background-color: var(--pst-color-on-surface);
   border-color: var(--pst-color-border);
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_api.scss
@@ -99,7 +99,20 @@ span.highlighted {
 }
 
 .viewcode-block:target {
-  background-color: var(--pst-color-viewcode-target-background);
-  border-top: 1px solid var(--pst-color-viewcode-target-border);
-  border-bottom: 1px solid var(--pst-color-viewcode-target-border);
+  border-top: 1px solid var(--pst-color-border);
+  border-bottom: 1px solid var(--pst-color-border);
+  position: relative;
+
+  // This is a hack to control the opacity for admonitions with our color variables
+  // ref: https://stackoverflow.com/a/56951626/6734243
+  &:before {
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: var(--pst-color-target);
+    opacity: 0.1;
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_api.scss
@@ -13,7 +13,7 @@ table.field-list {
   th.field-name {
     padding: 1px 8px 1px 5px;
     white-space: nowrap;
-    background-color: var(--pst-color-background-up);
+    background-color: var(--pst-color-surface);
   }
 
   /* italic font for parameter types */

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -1,6 +1,6 @@
 // GitHub blockquote style
 blockquote {
   padding: 0 1em;
-  color: var(--pst-color-deactivate);
+  color: var(--pst-color-text-muted);
   border-left: 0.25em solid var(--pst-color-blockquote-border);
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -4,11 +4,25 @@
 
 span.guilabel {
   border: 1px solid var(--pst-color-info);
-  background: var(--pst-color-info);
+  //background: var(--pst-color-info);
   color: var(--pst-color-info);
   font-size: 80%;
   font-weight: 700;
   border-radius: 4px;
   padding: 2.4px 6px;
   margin: auto 2px;
+  position: relative;
+
+  // This is a hack to control the opacity for admonitions with our color variables
+  // ref: https://stackoverflow.com/a/56951626/6734243
+  &:before {
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: var(--pst-color-info);
+    opacity: 0.1;
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -3,9 +3,9 @@
  */
 
 span.guilabel {
-  border: 1px solid var(--pst-color-guilabel-border);
-  background: var(--pst-color-guilabel-background);
-  color: var(--pst-color-guilabel-text);
+  border: 1px solid var(--pst-color-info);
+  background: var(--pst-color-info);
+  color: var(--pst-color-info);
   font-size: 80%;
   font-weight: 700;
   border-radius: 4px;

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -4,7 +4,6 @@
 
 span.guilabel {
   border: 1px solid var(--pst-color-info);
-  //background: var(--pst-color-info);
   color: var(--pst-color-info);
   font-size: 80%;
   font-weight: 700;

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_ethical-ads.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_ethical-ads.scss
@@ -8,15 +8,15 @@
   .ethical-footer a:visited,
   .ethical-footer a:hover,
   .ethical-footer a:active {
-    color: var(--pst-color-ad-text);
+    color: var(--pst-color-text-base);
   }
 
   .ethical-sidebar,
   .ethical-footer {
-    background-color: var(--pst-color-ad-background);
-    border: 1px solid var(--pst-color-ad-border);
+    background-color: var(--pst-color-background);
+    border: 1px solid var(--pst-color-border);
     border-radius: 5px;
-    color: var(--pst-color-ad-text);
+    color: var(--pst-color-text-base);
     font-size: 14px;
     line-height: 20px;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_footer.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_footer.scss
@@ -1,6 +1,6 @@
 footer {
   width: 100%;
-  border-top: 1px solid var(--pst-color-footer-border);
+  border-top: 1px solid var(--pst-color-border);
   padding: 10px;
 
   .footer-item p {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -55,7 +55,7 @@
 .navbar-light {
   // Overrides bootstrap
   background: var(--pst-color-on-background) !important;
-  box-shadow: 0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.11);
+  box-shadow: 0 0.125rem 0.25rem 0 var(--pst-color-shadow); //rgba(0, 0, 0, 0.11);
 
   .navbar-nav {
     li a.nav-link {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -16,8 +16,8 @@
 
     button.navbar-toggler {
       margin-right: 1em;
-      border-color: var(--pst-color-navbar-toggler);
-      color: var(--pst-color-navbar-toggler);
+      border-color: var(--pst-color-text-muted);
+      color: var(--pst-color-text-muted);
     }
   }
 
@@ -53,28 +53,27 @@
 // If we want the shadow to only point downward in the future, set
 // box-shadow to: 0 0.125rem 0.25rem -0.125rem rgba(0, 0, 0, 0.11);
 .navbar-light {
-  background: var(
-    --pst-color-navbar-background
-  ) !important; // Overrides bootstrap
+  // Overrides bootstrap
+  background: var(--pst-color-on-background) !important;
   box-shadow: 0 0.125rem 0.25rem 0 rgba(0, 0, 0, 0.11);
 
   .navbar-nav {
     li a.nav-link {
       padding: 0 0.5rem;
-      color: var(--pst-color-navbar-link);
+      color: var(--pst-color-text-muted);
 
       &:hover {
-        color: var(--pst-color-navbar-link-hover);
+        color: var(--pst-color-primary);
       }
 
       &:focus {
-        color: var(--pst-color-navbar-link-hover);
+        color: var(--pst-color-primary);
       }
     }
 
     > .active > .nav-link {
       font-weight: 600;
-      color: var(--pst-color-navbar-link-active);
+      color: var(--pst-color-primary);
     }
   }
 }
@@ -92,9 +91,9 @@
 
 .toc-entry > .nav-link.active {
   font-weight: 600;
-  color: var(--pst-color-toc-link-active);
+  color: var(--pst-color-primary);
   background-color: transparent;
-  border-left: 2px solid var(--pst-color-toc-link-active);
+  border-left: 2px solid var(--pst-color-primary);
 }
 
 .nav-link:hover {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -9,7 +9,7 @@
   flex-direction: column;
 
   @include media-breakpoint-up(md) {
-    border-right: 1px solid var(--pst-color-sidebar-border);
+    border-right: 1px solid var(--pst-color-border);
 
     @supports (position: -webkit-sticky) or (position: sticky) {
       position: -webkit-sticky;
@@ -58,7 +58,7 @@
     align-items: center;
 
     &:hover {
-      background: var(--pst-color-sidebar-expander-background-hover);
+      background: var(--pst-color-surface);
     }
 
     i {
@@ -66,7 +66,7 @@
       font-size: 0.75rem;
       text-align: center;
       &:hover {
-        color: var(--pst-color-sidebar-link-hover);
+        color: var(--pst-color-primary);
       }
     }
   }
@@ -97,10 +97,10 @@ nav.bd-links {
   li > a {
     display: block;
     padding: 0.25rem 1.5rem;
-    color: var(--pst-color-sidebar-link);
+    color: var(--pst-color-text-muted);
 
     &:hover {
-      color: var(--pst-color-sidebar-link-hover);
+      color: var(--pst-color-primary);
       text-decoration: none;
       background-color: transparent;
     }
@@ -120,7 +120,7 @@ nav.bd-links {
     > a,
     &:hover > a {
       font-weight: 600;
-      color: var(--pst-color-sidebar-link-active);
+      color: var(--pst-color-primary);
     }
   }
 
@@ -133,7 +133,7 @@ nav.bd-links {
     margin-top: 1.25em;
     margin-bottom: 0.5em;
     padding: 0 1.5rem;
-    color: var(--pst-color-sidebar-caption);
+    color: var(--pst-color-text-base);
     &:first-child {
       margin-top: 0;
     }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -5,7 +5,7 @@
 // Each TOC item is wrapped in this
 .tocsection {
   padding-left: 10px;
-  border-left: 1px solid var(--pst-color-toc-border);
+  border-left: 1px solid var(--pst-color-border);
   padding: 0.3rem 1.5rem;
 
   i {
@@ -16,7 +16,7 @@
 // The list of in-page TOC
 .section-nav {
   padding-left: 0;
-  border-left: 1px solid var(--pst-color-toc-border);
+  border-left: 1px solid var(--pst-color-border);
   border-bottom: none;
 
   ul {
@@ -51,14 +51,14 @@
   a {
     display: block;
     padding: 0.125rem 1.5rem;
-    color: var(--pst-color-toc-link);
+    color: var(--pst-color-text-muted);
 
     @include media-breakpoint-up(xl) {
       padding-right: 0;
     }
 
     &:hover {
-      color: var(--pst-color-toc-link-hover);
+      color: var(--pst-color-primary);
       text-decoration: none;
     }
   }
@@ -82,6 +82,6 @@
   padding-top: 2rem;
 
   a {
-    color: var(--pst-color-sidebar-link-active);
+    color: var(--pst-color-primary);
   }
 }


### PR DESCRIPTION
## summary 

Reduction of the color variables from 79 to 17, respecting the guidelines from material colors. 

- classic 7 colors (`primary` ... `danger`) palette
- 2 text colors (`base`, `muted`) 
- 4 depth levels: `background`, `on-background`, `surface`, `on-surface` (in depth order) 
- 1 border and 1 shadow 
- I kept the inline code color (it's kinda the theme signature to me)
- I kept the custom link color as well 
- I kept the target color as it's well designed and never conflicts with anything

## customization 

These modifications required some adjustments, in the directive color scheme: 
- "kbd" directives are now the negative of the `background` and `text-base` (ref)
- Preformatted uses the `text-base` color 
- Header links are in `danger` color
- Guilabel in `info` and the background is treated as the admonition one (ref)
- Switcher theme component keeps its border on hover (that was looking weird)
- Remove never used colors (e.g. `--pst-color-alert-link`)
- blockquote border will be the same as all the other borders
- targeted code is now using the `target` and border colors (ref)
- the previous trick is maintained, `surface` color is the same as `background` on light theme (depth is performed by shadows), and `surface` color is the same as `on-background` in dark theme

## question

Why is there a transition in admonition css (ref) ? It creates a funny behavior when switching from light to dark theme (ref). Let me know if you think it should be removed

## finally 

What do you think ? 