### PR TITLE
Add Open Graph text tags

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -12,6 +12,7 @@ from sphinx.errors import ExtensionError
 from sphinx.util import logging
 from pygments.formatters import HtmlFormatter
 from pygments.styles import get_all_styles
+import string
 
 from .bootstrap_html_translator import BootstrapHTML5Translator
 
@@ -553,6 +554,24 @@ def setup_edit_url(app, pagename, templatename, context, doctree):
         )
 
     context["get_edit_url"] = get_edit_url
+
+    def get_plain_page_summary():
+        """Return a short text summary for an OpenGraph description."""
+        try:
+            title = jinja2.filters.do_striptags(context["title"])
+            body = jinja2.filters.do_striptags(context["body"])
+        except KeyError:
+            return context["docstitle"]
+        summary = body
+        # The body starts with the title, no need to repeat it in the description.
+        if body.startswith(title):
+            summary = body[len(title) :].lstrip(string.punctuation + string.whitespace)
+        if len(summary) > 200:
+            summary = summary[:199] + "…"
+
+        return summary
+
+    context["get_plain_page_summary"] = get_plain_page_summary
 
     # Ensure that the max TOC level is an integer
     context["theme_show_toc_level"] = int(context.get("theme_show_toc_level", 1))

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -23,6 +23,14 @@
       {% endif %}
     {% endfor %}
 
+    <!-- OpenGraph tags -->
+    <meta property="og:title" content="{{ title|striptags|e }}" />
+    <meta property="og:type" content="article" />
+    <meta property="og:description" content="{{ get_plain_page_summary()|e }}" />
+    {% if pageurl %}
+      <meta property="og:url" content="{{ pageurl }}" />
+    {%endif %}
+
     <!-- Google Analytics -->
     {{ generate_google_analytics_script(id=theme_google_analytics_id) }}
 {%- endblock %}

--- a/tests/sites/base/page1.rst
+++ b/tests/sites/base/page1.rst
@@ -1,2 +1,4 @@
 Page 1
 ======
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -541,3 +541,23 @@ def test_theme_switcher(sphinx_build_factory, file_regression):
     file_regression.check(
         switcher.prettify(), basename="navbar_theme", extension=".html"
     )
+
+
+def test_meta_opengraph(sphinx_build_factory):
+    confoverrides = {
+        "html_baseurl": "http://127.0.0.1:8000/",
+    }
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides)
+    sphinx_build.build()
+    page_html = sphinx_build.html_tree("page1.html")
+
+    expected = {
+        "title": "1. Page 1",
+        "type": "article",
+        "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut …",
+        "url": "http://127.0.0.1:8000/page1.html",
+    }
+    for tag, content in expected.items():
+        meta_og = page_html.select(f"meta[property='og:{tag}']")
+        assert meta_og, f"no meta og:{tag} found"
+        assert meta_og[0].attrs["content"] == content


### PR DESCRIPTION
This adds `<meta property="og:{title,type,description,url}">` [Open Graph metadata](https://ogp.me/) to support link previews.

For example, several Jupyterhub projects use this theme, and the readthedocs sites are often referenced on the [Jupyter Discourse](https://discourse.jupyter.org/). The lack of Open Graph tags means link previews aren't useful, e.g. in the compose mode
![image](https://user-images.githubusercontent.com/1644105/168139447-cf897452-000e-4cd6-8000-5b2df814dcd0.png)

I haven't included `og:image` because I suspect using the sites logo as a link preview isn't very helpful and might end up dominating the preview? Might be OK though. Alternatively could add a new property just for `og:image`.

I couldn't find definitive information on how long the description should be. Various sites suggest 90, 200, 300 chars, so I choose 200 characters.

Other relevant links:
- https://github.com/readthedocs/readthedocs.org/issues/1758
- https://meta.discourse.org/t/onebox-support-for-readthedocs-org/34528/