### PR TITLE
Support Sphinx 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 
 requires-python = ">=3.7"
 dependencies = [
-  "sphinx>=3.5.4,<5",
+  "sphinx>=4,<6",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "packaging"


### PR DESCRIPTION
I am still in favor of dropping the upper bound (see #661). But while we think about how to handle that PR, it seemed like supporting the two most recent major Sphinx releases was less controversial. Sphinx 5 is scheduled for release in a couple weeks.

Assuming this is acceptable, I would like to request a pre-release of pydata-sphinx-theme soon. That would help us test numpydoc on sphinx 5. Then, ideally, I would like to coordinate new releases of numpydoc and pydata-sphinx-theme soon after Sphinx 5 is released.

I am more than happy to help with the release. If that would help, I suspect I would need access to this repo and PyPI.