### PR TITLE
Moving some template links to Python

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -17,16 +17,6 @@
 {%- block extrahead %}
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta name="docsearch:language" content="{{ language }}">
-{% for favicon in theme_favicons %}
-  {% if favicon.href[:4] == 'http'%}
-  <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ favicon.href }}">
-  {% else %}
-  <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ pathto('_static/' + favicon.href, 1) }}">
-  {% endif %}
-{% endfor %}
-
-<!-- Google Analytics -->
-{{ generate_google_analytics_script(id=theme_google_analytics_id) }}
 {%- endblock %}
 
 {% block body_tag %}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -185,14 +185,16 @@ def test_favicons(sphinx_build_factory):
 
     icon_16 = (
         '<link href="https://secure.example.com/favicon/favicon-16x16.png" '
-        'rel="icon" sizes="16x16"/>'
+        'rel="icon" sizes="16x16" type="image/png">'
     )
-    icon_32 = '<link href="_static/favicon-32x32.png" rel="icon" sizes="32x32"/>'
+    icon_32 = (
+        '<link href="_static/favicon-32x32.png" rel="icon" sizes="32x32" '
+        'type="image/png">'
+    )
     icon_180 = (
         '<link href="_static/apple-touch-icon-180x180.png" '
-        'rel="apple-touch-icon" sizes="180x180"/>'
+        'rel="apple-touch-icon" sizes="180x180" type="image/png">'
     )
-
     assert icon_16 in str(index_html.select("head")[0])
     assert icon_32 in str(index_html.select("head")[0])
     assert icon_180 in str(index_html.select("head")[0])


### PR DESCRIPTION
We currently link two theme-specific things in a Jinja `extrahead` block:

- Our favicon links (e.g. for apple icons)
- Our Google Analytics code

However, some themes over-write the extrahead block, and if they don't realize that this functionality needs to be explicitly included, then it will fail silently. For example:

- https://github.com/bokeh/bokeh/issues/12133

So this PR switches this to use Sphinx for linking these files, instead of a custom Jinja template. This should make this behavior less brittle.

cc @bryevdv 