### PR TITLE
Add classes for multi-theme content support

### DIFF
--- a/docs/user_guide/customizing.rst
+++ b/docs/user_guide/customizing.rst
@@ -78,6 +78,27 @@ For example to define a different background color for both the light and dark t
 
 A complete list of the used colors for this theme can be found in the `pydata default css colors file <pydata-css-colors_>`__.
 
+Use specific content in each theme
+----------------------------------
+
+It is possible to use different content for light and dark mode, by setting :code:`only-dark` and :code:`only-light` classes on the content.
+This is the easiest approach for handling images with backgrounds.
+
+.. code-block:: rst
+
+    .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+        :class: only-dark
+
+    .. image:: https://source.unsplash.com/200x200/daily?cute+dog
+        :class: only-light
+
+
+.. image:: https://source.unsplash.com/200x200/daily?cute+cat
+    :class: only-dark
+
+.. image:: https://source.unsplash.com/200x200/daily?cute+dog
+    :class: only-light
+
 Define custom JavaScript to react to theme changes
 --------------------------------------------------
 

--- a/docs/user_guide/customizing.rst
+++ b/docs/user_guide/customizing.rst
@@ -78,11 +78,20 @@ For example to define a different background color for both the light and dark t
 
 A complete list of the used colors for this theme can be found in the `pydata default css colors file <pydata-css-colors_>`__.
 
-Use specific content in each theme
-----------------------------------
+Use theme-dependent content
+---------------------------
 
-It is possible to use different content for light and dark mode, by setting :code:`only-dark` and :code:`only-light` classes on the content.
-This is the easiest approach for handling images with backgrounds.
+It is possible to use different content for light and dark mode, so that the content only shows up when a particular theme is active.
+This is useful if your content depends on the theme's style, such as a PNG image with a light or a dark background.
+
+There are **two CSS helper classes** to specify items on the page as theme-specific.
+These are:
+
+- :code:`only-dark`: Only display an element when the dark theme is active.
+- :code:`only-light` Only display an element when the light theme is active.
+
+For example, the following page content defines two images, each of which uses a different one of the classes above.
+Change the theme and a new image should be displayed.
 
 .. code-block:: rst
 
@@ -91,7 +100,6 @@ This is the easiest approach for handling images with backgrounds.
 
     .. image:: https://source.unsplash.com/200x200/daily?cute+dog
         :class: only-light
-
 
 .. image:: https://source.unsplash.com/200x200/daily?cute+cat
     :class: only-dark

--- a/src/pydata_sphinx_theme/assets/styles/base/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_color.scss
@@ -143,6 +143,11 @@ html[data-theme="light"] {
 
   // blockquote
   --pst-color-blockquote-border: rgb(221, 221, 221);
+
+  // hide any content that should not be displayed in the light theme
+  .only-dark {
+    display: none !important;
+  }
 }
 
 /*******************************************************************************
@@ -289,6 +294,11 @@ html[data-theme="dark"] {
 
   // blockquote
   --pst-color-blockquote-border: rgb(117, 117, 117);
+
+  // hide any content that should not be displayed in the dark theme
+  .only-light {
+    display: none !important;
+  }
 
   // specific brightness applied on images
   img {


### PR DESCRIPTION
FIx #658 

As suggested by @choldgraf, The theme is now allowing the devs to use `only-dark` and `only-light` to use different images based on the selected mode. 

It works with any elements (I'll use it for example to render multiple instance of jupyterlite in one of my documentation). Thus it's not documentated in images section but in the customization section. 

Let me know if you think about any loopholes.

PS: the doc demo:  https://pydata-sphinx-theme--673.org.readthedocs.build/en/673/user_guide/customizing.html#use-specific-content-in-each-theme