### PR TITLE
Pin Sphinx to >= 4.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 
 requires-python = ">=3.7"
 dependencies = [
-  "sphinx>=4",
+  "sphinx>=4.0.2",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "packaging"


### PR DESCRIPTION
We're already pinning to >=4, so this just bumps that up by 2 patches so we can close https://github.com/pydata/pydata-sphinx-theme/issues/614

closes https://github.com/pydata/pydata-sphinx-theme/issues/614