### PR TITLE
Add Sphinx and Python version support policy

### DIFF
--- a/docs/contribute/topics.md
+++ b/docs/contribute/topics.md
@@ -223,7 +223,6 @@ We define "support" as testing against each of these versions, so that users can
 For example, if we made a minor release tomorrow, we'd [look at the EOL schedule for Python](https://endoflife.date/python) and support all of the versions that fall within a 3.5 year window.
 
 [^1]: Our support for Python versions is inspired by [NEP 029](https://numpy.org/neps/nep-0029-deprecation_policy.html).
-
 [^2]: These policies are goals, but not promises. We are a volunteer-led community with limited time. Consider these sections to be our intention, but we recognize that we may not always be able to meet these criteria if we do not have capacity to do so. We welcome contributions from others to help us more sustainably meet these goals!
 
 ## Supporting new Sphinx versions

--- a/docs/contribute/topics.md
+++ b/docs/contribute/topics.md
@@ -1,4 +1,4 @@
-# Topic guides and how-tos
+# Contribution guides
 
 These sections cover common operations and topics that are relevant to developing this theme.
 
@@ -212,15 +212,36 @@ The output of the last command includes:
 - a short summary of the current state of the accessibility rules we are trying to maintain
 - local paths to JSON and HTML reports which contain all of the issues found
 
-## Update support for new Sphinx versions
+## Supporting new Python versions
 
-This theme does not pin the upper version of Sphinx that it supports, but there may be changes that need to happen when Sphinx releases a new version.
-As a general rule, we try to support new major Sphinx versions within 6 months of its release.
+For releases of Python, we aim to follow this approach[^1]:
 
-Here's a list of things to check when Sphinx releases a new version:
+> For a new major/minor release of this theme, we support any minor Python versions released in the last 42 months, as defined in [the EOL schedule for Python](https://endoflife.date/python)[^2].
 
-- [Look at the Sphinx Changelog](https://www.sphinx-doc.org/en/master/changes.html) and make sure there are no obvious breaking changes.
-- [Look at the deprecated API changes](https://www.sphinx-doc.org/en/master/extdev/deprecated.html) and make sure there are no obvious breaking changes.
+We define "support" as testing against each of these versions, so that users can be assured they will not trigger any bugs.
+
+For example, if we made a minor release tomorrow, we'd [look at the EOL schedule for Python](https://endoflife.date/python) and support all of the versions that fall within a 3.5 year window.
+
+[^1]: Our support for Python versions is inspired by [NEP 029](https://numpy.org/neps/nep-0029-deprecation_policy.html).
+[^2]: These policies are goals, but not promises. We are a volunteer-led community with limited time. Consider these sections to be our intention, but we recognize that we may not always be able to meet these criteria if we do not have capacity to do so. We welcome contributions from others to help us more sustainably meet these goals!
+
+## Supporting new Sphinx versions
+
+For supporting versions of Sphinx, we aim to follow this approach:
+
+> We support the latest released version of Sphinx that is **older than 6 months**.
+> We unofficially support earlier released versions of Sphinx, but may increase the lower-bound in our dependency pin without warning if needed[^2].
+
+When a new pre-release of Sphinx is released, we should follow these steps:
+
+- Ensure that our tests are passing. We run our tests with any **pre-releases** of Sphinx, so we can test major errors quickly and make the necessary changes.
+- [Look at the Sphinx Changelog](https://www.sphinx-doc.org/en/master/changes.html) and make sure there are no changes that might break things that aren't captured by our tests.
+- [Look at the deprecated API changes](https://www.sphinx-doc.org/en/master/extdev/deprecated.html) and make sure there are no changes that might break things that aren't captured by our tests.
+
+```{note}
+This theme does not pin the upper version of Sphinx that it supports.
+If a Sphinx release causes major breaking changes for our users, and we do not have the capacity to update our code and release a fix, we may temporarily pin the upper bound of Sphinx we support until this is fixed.
+```
 
 ## Update our kitchen sink documents
 

--- a/docs/contribute/topics.md
+++ b/docs/contribute/topics.md
@@ -216,7 +216,7 @@ The output of the last command includes:
 
 For releases of Python, we aim to follow this approach[^1]:
 
-> For a new major/minor release of this theme, we support any minor Python versions released in the last 42 months, as defined in [the EOL schedule for Python](https://endoflife.date/python)[^2].
+> For a new major/minor release of this theme, we support any minor Python versions released in the last 3.5 years (42 months), as defined in [the EOL schedule for Python](https://endoflife.date/python)[^2].
 
 We define "support" as testing against each of these versions, so that users can be assured they will not trigger any bugs.
 
@@ -237,6 +237,7 @@ When a new pre-release of Sphinx is released, we should follow these steps:
 - Ensure that our tests are passing. We run our tests with any **pre-releases** of Sphinx, so we can test major errors quickly and make the necessary changes.
 - [Look at the Sphinx Changelog](https://www.sphinx-doc.org/en/master/changes.html) and make sure there are no changes that might break things that aren't captured by our tests.
 - [Look at the deprecated API changes](https://www.sphinx-doc.org/en/master/extdev/deprecated.html) and make sure there are no changes that might break things that aren't captured by our tests.
+- [Look at the docutils changelog](https://docutils.sourceforge.io/RELEASE-NOTES.html) in case there's a new docutils version supported that breaks something.
 
 ```{note}
 This theme does not pin the upper version of Sphinx that it supports.


### PR DESCRIPTION
This adds a rough policy for the versions of Python and Sphinx that we support (since these are our two major dependencies).

I proposes:

- Supporting Python versions with security support that are < 3.5 years old.
- Supporting the latest released Sphinx version that is > 6 months old. (unofficial support for older releases, but no promises/testing)

closes https://github.com/pydata/pydata-sphinx-theme/issues/567 closes https://github.com/pydata/pydata-sphinx-theme/issues/446 closes https://github.com/pydata/pydata-sphinx-theme/pull/510