### PR TITLE
Test with docutils 0.18.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Install pre-release dependencies
         if: ${{ matrix.dev }}
-        run: pip install --upgrade --pre sphinx jinja2
+        run: |
+          pip install docutils==0.18.1
+          pip install --upgrade --pre sphinx jinja2
 
       # Build the docs
       - name: Build docs to store


### PR DESCRIPTION
**NOT INTENDED FOR MERGING**

There is a bug using 0.18.1 with numpydoc: 
https://github.com/numpy/numpydoc/pull/402

I wanted to see if this project was also having issue and noticed that
```
pip install --upgrade --pre sphinx jinja2
```
only upgrades sphinx, jinja2 was already 3.1.2, and docutils stays at 0.17.1. So I created this PR to manually test.

On numpdoc, I run into the issue when doing this:
```
pip install --pre -r requirements/test.txt -r doc/requirements.txt
```

I don't think we should merge this PR, but maybe we should consider adding a similar test (i.e., testing against all prereleases of the requirements).