### PR TITLE
Fix docs for configuring pygments themes

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -52,7 +52,7 @@ As the Sphinx theme supports multiple modes, the code highlighting colors can be
 
 .. code-block:: python
 
-   html_context = {
+   html_theme_options = {
       ...
       "pygment_light_style": "tango",
       "pygment_dark_style": "native"


### PR DESCRIPTION
They are configured as part of the `html_theme_options` not in the `html_context`. See https://github.com/pydata/pydata-sphinx-theme/blob/3c7fa00a72178988670766c8b99f22e064289a67/src/pydata_sphinx_theme/__init__.py#L622-L625 for reference.