### PR TITLE
MAINT: Docutils 0.18 deprecation

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -382,7 +382,9 @@ def _get_local_toctree_for(
         kwargs["maxdepth"] = int(kwargs["maxdepth"])
     kwargs["collapse"] = collapse
 
-    for toctreenode in doctree.traverse(addnodes.toctree):
+    # Can just use "findall" once docutils 0.18+ is required
+    meth = 'findall' if hasattr(doctree, 'findall') else 'traverse'
+    for toctreenode in getattr(doctree, meth)(addnodes.toctree):
         toctree = self.resolve(docname, builder, toctreenode, prune=True, **kwargs)
         if toctree:
             toctrees.append(toctree)

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -382,7 +382,7 @@ def _get_local_toctree_for(
         kwargs["maxdepth"] = int(kwargs["maxdepth"])
     kwargs["collapse"] = collapse
 
-    # Can just use "findall" once docutils 0.18+ is required
+    # FIX: Can just use "findall" once docutils 0.18+ is required
     meth = "findall" if hasattr(doctree, "findall") else "traverse"
     for toctreenode in getattr(doctree, meth)(addnodes.toctree):
         toctree = self.resolve(docname, builder, toctreenode, prune=True, **kwargs)

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -383,7 +383,7 @@ def _get_local_toctree_for(
     kwargs["collapse"] = collapse
 
     # Can just use "findall" once docutils 0.18+ is required
-    meth = 'findall' if hasattr(doctree, 'findall') else 'traverse'
+    meth = "findall" if hasattr(doctree, "findall") else "traverse"
     for toctreenode in getattr(doctree, meth)(addnodes.toctree):
         toctree = self.resolve(docname, builder, toctreenode, prune=True, **kwargs)
         if toctree:


### PR DESCRIPTION
Avoids a PendingDeprecationWarning:
```
Traceback (most recent call last):
  File "/home/larsoner/python/sphinx/sphinx/builders/html/__init__.py", line 1072, in handle_page
    output = self.templates.render(templatename, ctx)
...
  File "/home/larsoner/python/pydata-sphinx-theme/src/pydata_sphinx_theme/__init__.py", line 172, in generate_nav_html
    toc_sphinx = index_toctree(app, pagename, startdepth, **kwargs)
  File "/home/larsoner/python/pydata-sphinx-theme/src/pydata_sphinx_theme/__init__.py", line 428, in index_toctree
  File "/home/larsoner/python/pydata-sphinx-theme/src/pydata_sphinx_theme/__init__.py", line 385, in _get_local_toctree_for
    meth = 'findall' if hasattr(doctree, 'findall') else 'traverse'
  File "/home/larsoner/.local/lib/python3.10/site-packages/docutils/nodes.py", line 240, in traverse
    warnings.warn('nodes.Node.traverse() is obsoleted by Node.findall().',
PendingDeprecationWarning: nodes.Node.traverse() is obsoleted by Node.findall().
```