### PR TITLE
Use different logos for light and dark theme 

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -57,10 +57,11 @@ If you'd like it to link to another page or use an external link instead, use th
        "logo_link": "<other page or external link>"
    }
 
-Customize title
----------------
+Add a logo title
+----------------
 
-If you don't have a brand and you want to add a customize title to you documentation, add ``html_title`` to your documentation. If this parameter is set with a logo, the title will appear next to it.
+To add a title in the brand section of your documentation, define a value for ``html_title``.
+This will appear just after your logo if it is set.
 
 .. code-block:: python
 

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -30,7 +30,7 @@ Different logos for light and dark mode
 If your project logo is not adapted to a dark mode (light background, not enought contrast etc...), this theme allows you to use a different version of your logo in each available mode (``dark``and ``light``).
 As for single logo, put the 2 files in your html static path and set the ``light_logo``adn ``dark_logo`` in ``html_theme_option`` using the relative path to the static dir:
 
-.. code:: python
+.. code-block:: python
 
    html_static_path = ["_static"]
    html_theme_options = {
@@ -38,16 +38,31 @@ As for single logo, put the 2 files in your html static path and set the ``light
        "dark_logo": "logo-dark.png",
    }
 
+.. note::
+
+   The ``light_logo`` and ``dark_logo`` are overriding the initial ``html_logo`` setting. In your doc simply add the ``dark_logo`` and the theme will continue to use the ``html_logo`` for light theme.
+
 Customize logo link
 -------------------
 
 The logo links to ``root_doc`` (usually the first page of your documentation) by default.
 If you'd like it to link to another page or use an external link instead, use the following configuration:
 
-.. code:: python
+.. code-block:: python
 
    html_theme_options = {
        "logo_link": "<other page or external link>"
+   }
+
+Customize title
+---------------
+
+If you don't have a brand and you want to add a customize title to you documentation, add ``html_title`` to your documentation. If this parameter is set with a logo, the title will appear next to it.
+
+.. code-block:: python
+
+   html_theme_options = {
+       "html_title": "My awesome documentation"
    }
 
 

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -12,12 +12,34 @@ you can configure in various ways. This page describes the options available to 
 Configure project logo
 ======================
 
-To add a logo that's placed at the left of your nav bar, put a logo file under your
-doc path's _static folder, and use the following configuration:
+By default the theme will use the name of your project on the left side of the header navbar. This can be replaced by a Logo.
+
+Single logo for light and dark mode
+-----------------------------------
+
+Put a logo file under your doc html static path folder, and use the following configuration:
 
 .. code:: python
 
+   html_static_path = ["_static"]
    html_logo = "_static/logo.png"
+
+Different logo for light and dark mode
+--------------------------------------
+
+If you're project logo is not adapted to a dark theme (light background, not enought contrast etc...), this theme allows you to use a different version of your logo in each available mode (``dark``and ``light``).
+As for single logo, put the 2 files in your html static path and set the ``light_logo``adn ``dark_logo`` in ``html_theme_option`` using the relative path to the static dir:
+
+.. code:: python
+
+   html_static_path = ["_static"]
+   html_theme_options = {
+       "light_logo": "logo-light.png",
+       "dark_logo": "logo-dark.png",
+   }
+
+Customize logo link
+-------------------
 
 The logo links to ``root_doc`` (usually the first page of your documentation) by default.
 If you'd like it to link to another page or use an external link instead, use the following configuration:
@@ -31,8 +53,8 @@ If you'd like it to link to another page or use an external link instead, use th
 
 .. _icon-links:
 
-Configure default theme
-=======================
+Configure default mode
+======================
 
 The theme mode can be changed by the user. By default landing on the documentation will switch the mode to ``auto``. You can specified this value to be one of ``auto``, ``dark``, ``light``.
 

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -13,7 +13,7 @@ Configure project logo and title
 ================================
 
 By default the theme will use the value of ``project`` on the left side of the header navbar.
-This can be replaced by a Logo image, and optionally a custom `html_title` as well.
+This can be replaced by a Logo image, and optionally a custom ``html_title`` as well.
 
 Single logo for light and dark mode
 -----------------------------------

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -43,7 +43,7 @@ To do so, put the 2 image files in a folder that is in ``html_static_path`` and 
 
 .. note::
 
-   The ``light_logo`` and ``dark_logo`` override the initial ``html_logo`` setting. If you only specify ``dark_logo`` and not ``light_logo``, the theme will re-use the path of ``html_logo`` for the light theme.
+   ``light_logo`` overrides the initial ``html_logo`` setting. If you only specify ``dark_logo`` and not ``light_logo``, the theme will re-use the path of ``html_logo`` for the light theme.
 
 Customize logo link
 -------------------

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -9,8 +9,8 @@ All configuration options are passed with the ``html_theme_options`` variable
 in your ``conf.py`` file. This is a dictionary with ``key: val`` pairs that
 you can configure in various ways. This page describes the options available to you.
 
-Configure project logo
-======================
+Configure project logo and title
+================================
 
 By default the theme will use the value of `project` on the left side of the header navbar.
 This can be replaced by a Logo image, and optionally a custom `html_title` as well.

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -12,7 +12,8 @@ you can configure in various ways. This page describes the options available to 
 Configure project logo
 ======================
 
-By default the theme will use the name of your project on the left side of the header navbar. This can be replaced by a Logo.
+By default the theme will use the value of `project` on the left side of the header navbar.
+This can be replaced by a Logo image, and optionally a custom `html_title` as well.
 
 Single logo for light and dark mode
 -----------------------------------

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -24,10 +24,10 @@ Put a logo file under your doc html static path folder, and use the following co
    html_static_path = ["_static"]
    html_logo = "_static/logo.png"
 
-Different logo for light and dark mode
---------------------------------------
+Different logos for light and dark mode
+---------------------------------------
 
-If you're project logo is not adapted to a dark theme (light background, not enought contrast etc...), this theme allows you to use a different version of your logo in each available mode (``dark``and ``light``).
+If your project logo is not adapted to a dark mode (light background, not enought contrast etc...), this theme allows you to use a different version of your logo in each available mode (``dark``and ``light``).
 As for single logo, put the 2 files in your html static path and set the ``light_logo``adn ``dark_logo`` in ``html_theme_option`` using the relative path to the static dir:
 
 .. code:: python

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -28,8 +28,10 @@ Put an image in a folder that is in `html_static_path`, and use the following co
 Different logos for light and dark mode
 ---------------------------------------
 
-If your project logo is not adapted to a dark mode (light background, not enought contrast etc...), this theme allows you to use a different version of your logo in each available mode (``dark``and ``light``).
-As for single logo, put the 2 files in your html static path and set the ``light_logo``adn ``dark_logo`` in ``html_theme_option`` using the relative path to the static dir:
+You may specify use a different version of your logo image for "light" and "dark" modes.
+This is useful if your logo image is not adapted to a dark mode (light background, not enough contrast, etc...).
+
+To do so, put the 2 image files in a folder that is in ``html_static_path`` and configure the relative path to each image with ``light_logo`` and ``dark_logo`` in ``html_theme_options``, like so:
 
 .. code-block:: python
 
@@ -41,7 +43,7 @@ As for single logo, put the 2 files in your html static path and set the ``light
 
 .. note::
 
-   The ``light_logo`` and ``dark_logo`` are overriding the initial ``html_logo`` setting. In your doc simply add the ``dark_logo`` and the theme will continue to use the ``html_logo`` for light theme.
+   The ``light_logo`` and ``dark_logo`` override the initial ``html_logo`` setting. If you only specify ``dark_logo`` and not ``light_logo``, the theme will re-use the path of ``html_logo`` for the light theme.
 
 Customize logo link
 -------------------

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -12,7 +12,7 @@ you can configure in various ways. This page describes the options available to 
 Configure project logo and title
 ================================
 
-By default the theme will use the value of `project` on the left side of the header navbar.
+By default the theme will use the value of ``project`` on the left side of the header navbar.
 This can be replaced by a Logo image, and optionally a custom `html_title` as well.
 
 Single logo for light and dark mode

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -43,7 +43,7 @@ To do so, put the 2 image files in a folder that is in ``html_static_path`` and 
 
 .. note::
 
-   ``light_logo`` overrides the initial ``html_logo`` setting. If you only specify ``dark_logo`` and not ``light_logo``, the theme will re-use the path of ``html_logo`` for the light theme.
+   ``light_logo`` and ``dark_logo`` will override the ``html_logo`` setting. If you only specify one of them, but not the other, then the un-specified setting will re-use ``html_logo``.
 
 Customize logo link
 -------------------

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -18,7 +18,7 @@ This can be replaced by a Logo image, and optionally a custom `html_title` as we
 Single logo for light and dark mode
 -----------------------------------
 
-Put a logo file under your doc html static path folder, and use the following configuration:
+Put an image in a folder that is in `html_static_path`, and use the following configuration:
 
 .. code:: python
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -6,26 +6,13 @@
   {% set href = pathto(theme_logo_link) %}
 {% endif %}
 
-{% if theme_dark_logo and theme_light_logo %}
-
-  <a class="navbar-brand only-light" href="{{ href }}">
-    <img src="{{ pathto('_static/' + theme_light_logo, 1) }}" class="logo" alt="logo">
-  </a>
-
-  <a class="navbar-brand only-dark" href="{{ href }}">
-    <img src="{{ pathto('_static/' + theme_dark_logo, 1) }}" class="logo" alt="logo">
-  </a>
-
-{% elif logo %}
-
 <a class="navbar-brand" href="{{ href }}">
-  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
+  {% set is_logo = theme_dark_logo or theme_light_logo or logo %}
+  {% if is_logo %}
+    <img src="{{ pathto('_static/' + theme_light_logo or logo, 1) }}" class="logo only-light" alt="logo">
+    <img src="{{ pathto('_static/' + theme_dark_logo or logo, 1) }}" class="logo only-dark" alt="logo">
+  {% endif %}
+  {% if not is_logo or theme_html_title %}
+    <p class="title">{{ theme_html_title or project }}</p>
+  {% endif %}
 </a>
-
-{% else %}
-
-  <a class="navbar-brand" href="{{ href }}">
-    <p class="title">{{ project }}</p>
-  </a>
-
-{% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -1,19 +1,31 @@
-{% if logo %}
 {% if not theme_logo_link %}
-<a class="navbar-brand" href="{{ pathto(root_doc) }}">
-  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
-</a>
-{% elif theme_logo_link[:4] == 'http' %}
-<a class="navbar-brand" href="{{ theme_logo_link }}">
-  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
-</a>
+  {% set href = pathto(root_doc) %}
+{% elif theme_logo_link[:4] == "http" %}
+  {% set href = theme_logo_link %}
 {% else %}
-<a class="navbar-brand" href="{{ pathto(theme_logo_link) }}">
-  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
-</a>
+  {% set href = pathto(theme_logo_link) %}
 {% endif %}
-{% else %}
-<a class="navbar-brand" href="{{ pathto(root_doc) }}">
-<p class="title">{{ project }}</p>
+
+{% if theme_dark_logo and theme_light_logo %}
+
+  <a class="navbar-brand only-light" href="{{ href }}">
+    <img src="{{ pathto('_static/' + theme_light_logo, 1) }}" class="logo" alt="logo">
+  </a>
+
+  <a class="navbar-brand only-dark" href="{{ href }}">
+    <img src="{{ pathto('_static/' + theme_dark_logo, 1) }}" class="logo" alt="logo">
+  </a>
+
+{% elif logo %}
+
+<a class="navbar-brand" href="{{ href }}">
+  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
 </a>
+
+{% else %}
+
+  <a class="navbar-brand" href="{{ href }}">
+    <p class="title">{{ project }}</p>
+  </a>
+
 {% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -1,6 +1,6 @@
 {% if not theme_logo_link %}
   {% set href = pathto(root_doc) %}
-{% elif theme_logo_link[:4] == "http" %}
+{% elif theme_logo_link.startswith("http") %}
   {% set href = theme_logo_link %}
 {% else %}
   {% set href = pathto(theme_logo_link) %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -38,3 +38,5 @@ page_sidebar_items = page-toc.html, edit-this-page.html
 switcher =
 pygment_light_style = tango
 pygment_dark_style = native
+light_logo =
+dark_logo =

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -40,3 +40,4 @@ pygment_light_style = tango
 pygment_dark_style = native
 light_logo =
 dark_logo =
+html_title =

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -40,4 +40,3 @@ pygment_light_style = tango
 pygment_dark_style = native
 light_logo =
 dark_logo =
-html_title =


### PR DESCRIPTION
I refactored navbar-logo.html to support 3 different logo structures (2 logos, 1 logo, no logo). I made the following modifications:

### find the link 

As the same link will be used whatever the logo, I decided to set a variable at the begining of the file

### 2 logos

The user set the logos in the defined static folder and set the relative path in the options: 
```python
html_static_path = ["_static"]
html_theme_options = {
    "light_logo": "logo-light-mode.png",
    "dark_logo": "logo-dark-mode.png",
}
```
I then create 2 independant logos, one using `only-dark` the other `only-light`.

This option only works if both the logo are set 

## demo ? 

As long as the theme documentation has not yet a logo (please have look in https://github.com/pydata/pydata-sphinx-theme/issues/373) I cannot really demo it here. you can either trust me (not recomended) or test it on one of your doc and let me know 😄 

Fixes #674 fixes https://github.com/pydata/pydata-sphinx-theme/issues/545
