### PR TITLE
Prevent theme mamangement to raise error when the mode is fixed

### DIFF
--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -47,7 +47,7 @@ For more information, see :ref:`manage-themes`.
 
 .. tip::
 
-   To completely remove the theme management set the default_mode on the one you want to use in your documentation (``light`` or ``dark``) and then remove the theme-switcher from the header navbar:
+   To completely remove the theme management, configure ``default_mode`` to the value you want in your documentation (``light`` or ``dark``) and then remove the theme-switcher from the ``navbar_end`` section of the header navbar configuration:
 
    .. code-block:: python
 

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -53,6 +53,7 @@ For more information, see :ref:`manage-themes`.
 
       html_theme_options {
           # ...
+          # Note we have omitted `theme-switcher` below
           "navbar_end": ["navbar-icon-links"]
       }
 

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -39,11 +39,22 @@ The theme mode can be changed by the user. By default landing on the documentati
 .. code-block:: python
 
    html_context = {
-      ...
-      "default_mode": "auto"
+      # ...
+      "default_mode": "light"
    }
 
 For more information, see :ref:`manage-themes`.
+
+.. tip::
+
+   To completely remove the theme management set the default_mode on the one you want to use in your documentation (``light`` or ``dark``) and then remove the theme-switcher from the header navbar:
+
+   .. code-block:: python
+
+      html_theme_options {
+          # ...
+          "navbar_end": ["navbar-icon-links"]
+      }
 
 Configure pygment theme
 =======================

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -85,7 +85,9 @@ function addModeListener() {
 
   // Attach event handlers for toggling themes colors
   const btn = document.getElementById("theme-switch");
-  btn.addEventListener("click", cycleMode);
+  if (btn != null) {
+    btn.addEventListener("click", cycleMode);
+  }
 }
 
 /*******************************************************************************


### PR DESCRIPTION
related to #684 

I silence the javascript related to the theme management if the theme switcher is not in the DOM. It removes the errors from the console. 

I completed the documentation with explaination on how to fix the mode to a specific value. 
The code was already there but there was a typo preventing the display in the doc (note for self Pygments warning lead to no display). https://pydata-sphinx-theme--692.org.readthedocs.build/en/692/user_guide/configuring.html#configure-default-theme

To answer the issue more specifically, the default behaviour remain "auto" with the theme swithcer in the navbar but I takes 2 lines in conf.py to silence it (and it's now documented). 