### PR TITLE
Manage the bottom of small pages

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -5,12 +5,14 @@ html {
 
 body {
   padding-top: var(--pst-header-height);
-
   background-color: var(--pst-color-background);
   font-family: var(--pst-font-family-base);
   font-weight: 400;
   line-height: 1.65;
   color: var(--pst-color-text-base);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 
   @include scrollbar-style();
   @include scrollbar-on-hover();

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -33,6 +33,7 @@ $grid-breakpoints: (
 @import "./base/base";
 
 // Major theme layout, skeleton, and whitespace
+@import "./sections/container";
 @import "./sections/article";
 @import "./sections/footer";
 @import "./sections/footer-article";

--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -2,6 +2,8 @@
  * Main content area
  */
 .bd-content {
+  display: flex;
+  flex-direction: column;
   // Give a bit more verticle spacing on wide screens
   padding: 3rem 1.5rem 2rem 3rem;
   @include media-breakpoint-down(md) {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_container.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_container.scss
@@ -1,0 +1,9 @@
+.bd-container {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+
+  .bd-container__inner {
+    flex-grow: 1;
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/sections/_footer-article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_footer-article.scss
@@ -1,5 +1,4 @@
 .bd-footer-article {
   display: flex;
   margin-top: auto;
-  // width: 100%;
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_footer-article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_footer-article.scss
@@ -1,4 +1,5 @@
 .bd-footer-article {
   display: flex;
-  margin-top: 20px;
+  margin-top: auto;
+  // width: 100%;
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -10,14 +10,10 @@
 
   @include media-breakpoint-up(md) {
     border-right: 1px solid var(--pst-color-border);
-
-    @supports (position: -webkit-sticky) or (position: sticky) {
-      position: -webkit-sticky;
-      position: sticky;
-      top: var(--pst-header-height);
-      z-index: 1000;
-      max-height: calc(100vh - var(--pst-header-height));
-    }
+    position: sticky;
+    top: var(--pst-header-height);
+    z-index: 1000;
+    max-height: calc(100vh - var(--pst-header-height));
   }
 
   @include scrollbar-style();

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -16,7 +16,7 @@
       position: sticky;
       top: var(--pst-header-height);
       z-index: 1000;
-      height: calc(100vh - var(--pst-header-height));
+      max-height: calc(100vh - var(--pst-header-height));
     }
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -27,16 +27,10 @@
 .bd-toc {
   -ms-flex-order: 2;
   order: 2;
-  max-height: calc(100vh - 2rem);
+  max-height: calc(100vh - 5rem);
   overflow-y: auto;
-
-  @supports (position: -webkit-sticky) or (position: sticky) {
-    position: -webkit-sticky;
-    position: sticky;
-    top: var(--pst-header-height);
-    max-height: calc(100vh - 5rem);
-    overflow-y: auto;
-  }
+  top: var(--pst-header-height);
+  position: sticky;
 
   .onthispage {
     color: var(--pst-color-text-base);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -27,15 +27,14 @@
 .bd-toc {
   -ms-flex-order: 2;
   order: 2;
-
-  height: calc(100vh - 2rem);
+  max-height: calc(100vh - 2rem);
   overflow-y: auto;
 
   @supports (position: -webkit-sticky) or (position: sticky) {
     position: -webkit-sticky;
     position: sticky;
     top: var(--pst-header-height);
-    height: calc(100vh - 5rem);
+    max-height: calc(100vh - 5rem);
     overflow-y: auto;
   }
 


### PR DESCRIPTION
Fix #56 
Fix #497 

The display of empty pages was a bit off as the prev-next button were displayed at the end of article instead of the bottom of the page and the footer was always offscreen event if the article content was small than 100vh.

## prev-next

I added a flex rule on `bd-content` to always display the footer at the bottom with margin auto

## footer

I added a container rule so that the body min-height (100vh) is transmitted to the `bd-container__inner`. then instead of forcing the height of the sidebars I force their `max-height`.

seems to work on a small page: https://pydata-sphinx-theme--694.org.readthedocs.build/en/694/demo/no-sidebar.html
and don't disturb long one: https://pydata-sphinx-theme--694.org.readthedocs.build/en/694/demo/kitchen-sink/paragraph-markup.html