### PR TITLE
ENH: Version switcher dark mode support

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -8,6 +8,10 @@
   position: relative;
 }
 
+#version_switcher a[data-version-name*="stable"] span {
+  color: var(--pst-color-success);
+}
+
 #version_switcher a[data-version-name*="stable"] span:before {
   content: "";
   width: 100%;

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,5 +5,5 @@
 
 /* Background of stsable should be green */
 #version_switcher a[data-version-name*="stable"] {
-  background-color: #e2ffe2;
+  background-color: var(--pst-color-success);
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -5,5 +5,16 @@
 
 /* Background of stsable should be green */
 #version_switcher a[data-version-name*="stable"] {
+  position: relative;
+}
+
+#version_switcher a[data-version-name*="stable"] span:before {
+  content: "";
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
   background-color: var(--pst-color-success);
+  opacity: 0.1;
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -4,6 +4,8 @@
 }
 
 #version_switcher_menu {
+  border-color: var(--pst-color-border);
+
   a.list-group-item {
     background-color: var(--pst-color-on-background);
     color: var(--pst-color-text-base);

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -5,7 +5,7 @@
 
 #version_switcher_menu {
   a.list-group-item {
-    background-color: var(--pst-color-on-surface);
+    background-color: var(--pst-color-on-background);
     color: var(--pst-color-text-base);
     border-color: var(--pst-color-border);
   }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -14,7 +14,17 @@
 
   // Over-rides Bootstrap default blue for the current one
   a.list-group-item.active {
-    background-color: var(--pst-color-primary);
-    border-color: var(--pst-color-primary);
+    color: var(--pst-color-primary);
+
+    span:before {
+      content: "";
+      width: 100%;
+      height: 100%;
+      position: absolute;
+      left: 0;
+      top: 0;
+      background-color: var(--pst-color-primary);
+      opacity: 0.1;
+    }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -4,7 +4,13 @@
 }
 
 #version_switcher_menu {
-  // Over-rides Bootstrap default blue
+  a.list-group-item {
+    background-color: var(--pst-color-on-surface);
+    color: var(--pst-color-text-base);
+    border-color: var(--pst-color-border);
+  }
+
+  // Over-rides Bootstrap default blue for the current one
   a.list-group-item.active {
     background-color: var(--pst-color-primary);
     border-color: var(--pst-color-primary);

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -19,7 +19,7 @@ div.deprecated {
     margin-bottom: 0.6rem;
     margin-top: 0.6rem;
 
-    // This is a hack to control the opacity for verson tags with our color variables
+    // This is a hack to control the opacity for version tags with our color variables
     // ref: https://stackoverflow.com/a/56951626/6734243
     &:before {
       content: "";

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/version-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/version-switcher.html
@@ -50,10 +50,14 @@ function checkPageExistsAndRedirect(event) {
                 entry.name = entry.version;
             }
             // create the node
+            const span = document.createElement("span");
+            span.textContent = `${entry.name}`;
+
             const node = document.createElement("a");
             node.setAttribute("class", "list-group-item list-group-item-action py-1");
-            node.textContent = `${entry.name}`;
             node.setAttribute("href", `${entry.url}${currentFilePath}`);
+            node.appendChild(span);
+
             // on click, AJAX calls will check if the linked page exists before
             // trying to redirect, and if not, will redirect to the homepage
             // for that version of the docs.


### PR DESCRIPTION
Fix #711 

Edit the theme switcher so that it fits the dark theme. 

normal items: on-background color.
stable item (in our doc only): transparent success background + success text color 
active item: transparent primary background + primary text color