### PR TITLE
Fix color regression in sphinx_design and sphinx_panels

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -18,15 +18,15 @@
  */
 
 .bd-content .sd-card {
-  border: 1px solid var(--pst-color-preformatted-border);
+  border: 1px solid var(--pst-color-border);
 
   .sd-card-header {
     background-color: var(--pst-color-panel-background);
-    border-bottom: 1px solid var(--pst-color-preformatted-border);
+    border-bottom: 1px solid var(--pst-color-border);
   }
   .sd-card-footer {
     background-color: var(--pst-color-panel-background);
-    border-top: 1px solid var(--pst-color-preformatted-border);
+    border-top: 1px solid var(--pst-color-border);
   }
 
   .sd-card-body {
@@ -47,26 +47,26 @@
   > input {
     // Active tab label
     &:checked + label {
-      border-color: var(--pst-color-active-navigation);
-      color: var(--pst-color-active-navigation);
+      border-color: var(--pst-color-primary);
+      color: var(--pst-color-primary);
     }
 
     // hover label
     &:not(:checked) + label:hover {
-      border-color: var(--pst-color-active-navigation);
-      color: var(--pst-color-active-navigation);
+      border-color: var(--pst-color-primary);
+      color: var(--pst-color-primary);
       opacity: 0.5;
     }
   }
 
   // Tab label
   > label {
-    color: var(--pst-color-deactive-navigation);
+    color: var(--pst-color-text-muted);
 
     // Hovered label
     html &:hover {
-      color: var(--pst-color-active-navigation);
-      border-color: var(--pst-color-active-navigation);
+      color: var(--pst-color-primary);
+      border-color: var(--pst-color-primary);
       opacity: 0.5;
     }
   }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_panels.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_panels.scss
@@ -19,15 +19,15 @@
  */
 
 .sphinx-bs .card {
-  border: 1px solid var(--pst-color-preformatted-border);
+  border: 1px solid var(--pst-color-border);
   background-color: var(--pst-color-panel-background);
 
   .card-header {
-    border-bottom: 1px solid var(--pst-color-preformatted-border);
+    border-bottom: 1px solid var(--pst-color-border);
   }
 
   .card-footer {
-    border-top: 1px solid var(--pst-color-preformatted-border);
+    border-top: 1px solid var(--pst-color-border);
   }
 }
 
@@ -39,31 +39,31 @@
   > input {
     // Active tab label
     &:checked + label {
-      border-color: var(--pst-color-active-navigation);
-      color: var(--pst-color-active-navigation);
+      border-color: var(--pst-color-primary);
+      color: var(--pst-color-primary);
     }
 
     // hover label
     &:not(:checked) + label:hover {
-      border-color: var(--pst-color-active-navigation);
-      color: var(--pst-color-active-navigation);
+      border-color: var(--pst-color-primary);
+      color: var(--pst-color-primary);
       opacity: 0.5;
     }
   }
 
   // Tab label
   > label {
-    color: var(--pst-color-deactive-navigation);
+    color: var(--pst-color-text-muted);
 
     // Hovered label
     html &:hover {
-      color: var(--pst-color-active-navigation);
-      border-color: var(--pst-color-active-navigation);
+      color: var(--pst-color-primary);
+      border-color: var(--pst-color-primary);
       opacity: 0.5;
     }
   }
 
   > .tabbed-content {
-    border-color: var(pst-color-border);
+    border-color: var(--pst-color-border);
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -35,7 +35,7 @@ html[data-theme="light"] {
   * extentions
   */
 
-  --pst-color-panel-background: var(--pst-color-background);
+  --pst-color-panel-background: var(--pst-color-on-background);
 
   /*****************************************************************************
   * layout
@@ -94,7 +94,7 @@ html[data-theme="dark"] {
   * extentions
   */
 
-  --pst-color-panel-background: var(--pst-color-background-up);
+  --pst-color-panel-background: var(--pst-color-on-background);
 
   /*****************************************************************************
   * layout


### PR DESCRIPTION
Fix color regression in sphinx_design and sphinx_panels from #659 

I pointed the following variables to the new versions. @12rambau, please check that it makes sense: 

`--pst-color-preformatted-border` -> `--pst-color-border`
`--pst-color-active-navigation` -> `--pst-color-primary`
`--pst-color-deactive-navigation` -> `--pst-color-text-muted`


fixes: #727


This PR also fixes that `--pst-color-background-up`  was not defined. 
Replacing with `--pst-color-on-background`