### PR TITLE
FIX: Make hover color work on version switcher

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -10,6 +10,10 @@
     background-color: var(--pst-color-on-background);
     color: var(--pst-color-text-base);
     border-color: var(--pst-color-border);
+
+    &:hover {
+      background-color: var(--pst-color-surface);
+    }
   }
 
   // Over-rides Bootstrap default blue for the current one


### PR DESCRIPTION
This adds :hover highlighting to elements in the version switcher. I think this used to work before the various scss refactorings / color variable standardizations (which are great BTW!)... I think so because when building our site based on current `main` of the theme I see this in the inspector:

![Screenshot_2022-06-14_09-28-19](https://user-images.githubusercontent.com/1810515/173618376-4e12b687-c701-4418-a45f-10396994026e.png)

but `git grep "248, 249, 250"` fails as does `git grep -i f8f9fa` so I'm assuming that rule's been cleaned up/removed already?