### PR TITLE
FIX: Rendering external URL in logo.link option

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -1,7 +1,7 @@
 {% if not theme_logo.get("link") %}
   {% set href = pathto(root_doc) %}
 {% elif theme_logo.get("link").startswith("http") %}
-  {# Logo link is to external URL}
+  {# Logo link is to external URL #}
   {% set href = theme_logo.get("link") %}
 {% else %}
   {# Logo link is to internal page #}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -175,6 +175,21 @@ def test_logo_two_images(sphinx_build_factory):
     assert "emptydarklogo" in index_str
     assert "Foo Title" in index_str
 
+def test_logo_external_link(sphinx_build_factory):
+    """Test that the logo link is correct for external URLs."""
+    # Test with a specified external logo link
+    test_url = "https://secure.example.com"
+    confoverrides = {
+        "html_theme_options": {
+            "logo": {
+                "link": test_url,
+            }
+        },
+    }
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
+    index_html = sphinx_build.html_tree("index.html")
+    index_str = str(index_html.select(".navbar-brand")[0])
+    assert f"href=\"{test_url}\"" in index_str
 
 def test_favicons(sphinx_build_factory):
     """Test that arbitrary favicons are included."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -175,6 +175,7 @@ def test_logo_two_images(sphinx_build_factory):
     assert "emptydarklogo" in index_str
     assert "Foo Title" in index_str
 
+
 def test_logo_external_link(sphinx_build_factory):
     """Test that the logo link is correct for external URLs."""
     # Test with a specified external logo link
@@ -189,7 +190,8 @@ def test_logo_external_link(sphinx_build_factory):
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     index_html = sphinx_build.html_tree("index.html")
     index_str = str(index_html.select(".navbar-brand")[0])
-    assert f"href=\"{test_url}\"" in index_str
+    assert f'href="{test_url}"' in index_str
+
 
 def test_favicons(sphinx_build_factory):
     """Test that arbitrary favicons are included."""


### PR DESCRIPTION
This is a fairly trivial fix: An incorrect comment end tag in `navbar-logo.html` caused external links in the `logo.link` option to be rendered as internal links.

Added a simple unit test checking the output URL.