### PR TITLE
Add NBSphinx support for dark theme

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_execution.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_execution.scss
@@ -8,15 +8,20 @@
 
 // Dark theme special-cases
 html[data-theme="dark"] {
-  // MyST-NB outputs should have a white background so content behaves the same
-  .bd-content div.cell_output {
-    img,
-    div.text_html {
-      color: var(--pst-color-on-background);
-      background-color: var(--pst-color-text-base);
-      border-radius: 0.25rem;
-      padding: 0.5rem;
+  // MyST-NB / nbsphinx outputs should have a white background so content behaves the same
+  .bd-content {
+    div.cell_output img, div.cell_output .text_html, .nboutput .rendered_html {
+        color: var(--pst-color-on-background);
+        background-color: var(--pst-color-text-base);
+        border-radius: 0.25rem;
+        padding: 0.5rem;
+      }
     }
+  }
+
+  // NBSphinx
+  .output_area.stderr.docutils.container {
+    background: var(--pst-color-danger);
   }
 
   // Jupyter Sphinx


### PR DESCRIPTION
This adds support for HTML output backgrounds in the dark theme for NBSphinx outputs, similar to what we did for MyST-NB in #723 .

I don't believe that we can demo both nbsphinx and myst-nb in the same docs (they both grab the `ipynb` extension so can only use one). But I believe this does it and we'll need to rely on community reports if functionality breaks.

@blaylockbk want to test that this works OK for your use-case?

closes https://github.com/pydata/pydata-sphinx-theme/issues/739