### PR TITLE
ENH: Improve quotes display CSS

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -46,6 +46,7 @@
     position: absolute;
     left: 0;
     top: 0;
+    z-index: -1;
     background-color: var(#{$color-variable});
     opacity: $opacity;
   }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -46,7 +46,6 @@
     position: absolute;
     left: 0;
     top: 0;
-    z-index: -1;
     background-color: var(#{$color-variable});
     opacity: $opacity;
   }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -39,8 +39,6 @@
   // using our css color variables
   // ref: https://stackoverflow.com/a/56951626/6734243
 
-  position: relative;
-
   &:before {
     content: "";
     width: 100%;

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -21,12 +21,34 @@
 }
 
 /**
-  * Hide the scrollbar until the element is overed, so keep the page clean
-  */
+* Hide the scrollbar until the element is overed, so keep the page clean
+*/
 @mixin scrollbar-on-hover() {
   &:not(:hover) {
     &::-webkit-scrollbar-thumb {
       visibility: hidden;
     }
+  }
+}
+
+/**
+* create a low opacity background behind object using our variable colors
+*/
+@mixin background-from-color-variable($color-variable, $opacity: 0.1) {
+  // This is a hack to create a light background with controlled opacity
+  // using our css color variables
+  // ref: https://stackoverflow.com/a/56951626/6734243
+
+  position: relative;
+
+  &:before {
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: var(#{$color-variable});
+    opacity: $opacity;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -21,8 +21,8 @@
 }
 
 /**
-* Hide the scrollbar until the element is overed, so keep the page clean
-*/
+ * Hide the scrollbar until the element is overed, so keep the page clean
+ */
 @mixin scrollbar-on-hover() {
   &:not(:hover) {
     &::-webkit-scrollbar-thumb {
@@ -32,8 +32,8 @@
 }
 
 /**
-* create a low opacity background behind object using our variable colors
-*/
+ * create a low opacity background behind object using our variable colors
+ */
 @mixin background-from-color-variable($color-variable, $opacity: 0.1) {
   // This is a hack to create a light background with controlled opacity
   // using our css color variables

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -13,6 +13,7 @@ div.deprecated {
     0 0 0.0625rem var(--pst-color-shadow);
   transition: color 250ms, background-color 250ms, border-color 250ms;
   background-color: var(--pst-color-on-background);
+  position: relative;
 
   > p {
     margin-bottom: 0.6rem;

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -12,25 +12,13 @@ div.deprecated {
   box-shadow: 0 0.2rem 0.5rem var(--pst-color-shadow),
     0 0 0.0625rem var(--pst-color-shadow);
   transition: color 250ms, background-color 250ms, border-color 250ms;
-  position: relative;
   background-color: var(--pst-color-on-background);
 
   > p {
     margin-bottom: 0.6rem;
     margin-top: 0.6rem;
 
-    // This is a hack to control the opacity for version tags with our color variables
-    // ref: https://stackoverflow.com/a/56951626/6734243
-    &:before {
-      content: "";
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      left: 0;
-      top: 0;
-      background-color: var(--pst-color-info);
-      opacity: 0.1;
-    }
+    @include background-from-color-variable(--pst-color-info);
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -35,6 +35,7 @@ div.admonition,
     margin: 0 -0.6rem;
     padding: 0.4rem 0.6rem 0.4rem 2rem;
     font-weight: 700;
+    position: relative;
 
     &:after {
       position: absolute;

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -36,7 +36,7 @@ div.admonition,
     padding: 0.4rem 0.6rem 0.4rem 2rem;
     font-weight: 700;
 
-    &:before {
+    &:after {
       position: absolute;
       left: 0.6rem;
       width: 1rem;
@@ -63,7 +63,7 @@ div.admonition,
         background-color: var(--pst-color-warning);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-warning);
         content: var(--pst-icon-admonition-attention);
       }
@@ -77,7 +77,7 @@ div.admonition,
         background-color: var(--pst-color-warning);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-warning);
         content: var(--pst-icon-admonition-caution);
       }
@@ -91,7 +91,7 @@ div.admonition,
         background-color: var(--pst-color-warning);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-warning);
         content: var(--pst-icon-admonition-warning);
       }
@@ -105,7 +105,7 @@ div.admonition,
         background-color: var(--pst-color-danger);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-danger);
         content: var(--pst-icon-admonition-danger);
       }
@@ -119,7 +119,7 @@ div.admonition,
         background-color: var(--pst-color-danger);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-danger);
         content: var(--pst-icon-admonition-error);
       }
@@ -133,7 +133,7 @@ div.admonition,
         background-color: var(--pst-color-success);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-success);
         content: var(--pst-icon-admonition-hint);
       }
@@ -147,7 +147,7 @@ div.admonition,
         background-color: var(--pst-color-success);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-success);
         content: var(--pst-icon-admonition-tip);
       }
@@ -161,7 +161,7 @@ div.admonition,
         background-color: var(--pst-color-success);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-success);
         content: var(--pst-icon-admonition-important);
       }
@@ -175,7 +175,7 @@ div.admonition,
         background-color: var(--pst-color-info);
       }
 
-      &:before {
+      &:after {
         color: var(--pst-color-info);
         content: var(--pst-icon-admonition-note);
       }

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -32,7 +32,6 @@ div.admonition,
 
   // Defaults for all admonitions
   > .admonition-title {
-    position: relative;
     margin: 0 -0.6rem;
     padding: 0.4rem 0.6rem 0.4rem 2rem;
     font-weight: 700;
@@ -49,18 +48,7 @@ div.admonition,
       opacity: 1;
     }
 
-    // This is a hack to control the opacity for admonitions with our color variables
-    // ref: https://stackoverflow.com/a/56951626/6734243
-    &:after {
-      content: "";
-      width: 100%;
-      height: 100%;
-      position: absolute;
-      left: 0;
-      top: 0;
-      background-color: var(--pst-color-info);
-      opacity: 0.1;
-    }
+    @include background-from-color-variable(--pst-color-info);
 
     // Next element after title needs some extra upper-space
     + * {
@@ -71,7 +59,7 @@ div.admonition,
   &.attention {
     border-color: var(--pst-color-warning);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-warning);
       }
 
@@ -85,7 +73,7 @@ div.admonition,
   &.caution {
     border-color: var(--pst-color-warning);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-warning);
       }
 
@@ -99,7 +87,7 @@ div.admonition,
   &.warning {
     border-color: var(--pst-color-warning);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-warning);
       }
 
@@ -113,7 +101,7 @@ div.admonition,
   &.danger {
     border-color: var(--pst-color-danger);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-danger);
       }
 
@@ -127,7 +115,7 @@ div.admonition,
   &.error {
     border-color: var(--pst-color-danger);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-danger);
       }
 
@@ -141,7 +129,7 @@ div.admonition,
   &.hint {
     border-color: var(--pst-color-success);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-success);
       }
 
@@ -155,7 +143,7 @@ div.admonition,
   &.tip {
     border-color: var(--pst-color-success);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-success);
       }
 
@@ -169,7 +157,7 @@ div.admonition,
   &.important {
     border-color: var(--pst-color-success);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-success);
       }
 
@@ -183,7 +171,7 @@ div.admonition,
   &.note {
     border-color: var(--pst-color-info);
     > .admonition-title {
-      &:after {
+      &:before {
         background-color: var(--pst-color-info);
       }
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -21,4 +21,9 @@ blockquote {
   }
 
   @include background-from-color-variable(--pst-color-border);
+
+  //hack to make the text in the bloquote selectable
+  &:before {
+    z-index: -1;
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -4,23 +4,10 @@ blockquote {
   color: var(--pst-color-text-muted);
   border-left: 0.25em solid var(--pst-color-border);
   border-radius: 0.2rem;
-  position: relative;
 
   p {
     color: var(--pst-color-text-muted);
   }
 
-  // This is a hack to control the opacity for admonitions with our color variables
-  // ref: https://stackoverflow.com/a/56951626/6734243
-  &:after {
-    content: "";
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    left: 0;
-    top: 0;
-    background-color: var(--pst-color-border);
-    opacity: 0.1;
-    border-radius: 0.2rem;
-  }
+  @include background-from-color-variable(--pst-color-border);
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -4,6 +4,7 @@ blockquote {
   color: var(--pst-color-text-muted);
   border-left: 0.25em solid var(--pst-color-border);
   border-radius: 0.2rem;
+  position: relative;
 
   p {
     color: var(--pst-color-text-muted);

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -1,6 +1,6 @@
 // GitHub blockquote style
 blockquote {
-  padding: 0 1em;
+  padding: 1em 1em;
   color: var(--pst-color-text-muted);
   border-left: 0.25em solid var(--pst-color-border);
   border-radius: 0.2rem;

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -10,5 +10,15 @@ blockquote {
     color: var(--pst-color-text-muted);
   }
 
+  // remove padding from included line-block to avoid duplication
+  .line-block {
+    margin: 0 0;
+  }
+
+  // remove margin bottom for the last p
+  p:last-child {
+    margin-bottom: 0;
+  }
+
   @include background-from-color-variable(--pst-color-border);
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -2,5 +2,25 @@
 blockquote {
   padding: 0 1em;
   color: var(--pst-color-text-muted);
-  border-left: 0.25em solid var(--pst-color-blockquote-border);
+  border-left: 0.25em solid var(--pst-color-border);
+  border-radius: 0.2rem;
+  position: relative;
+
+  p {
+    color: var(--pst-color-text-muted);
+  }
+
+  // This is a hack to control the opacity for admonitions with our color variables
+  // ref: https://stackoverflow.com/a/56951626/6734243
+  &:after {
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: var(--pst-color-border);
+    opacity: 0.1;
+    border-radius: 0.2rem;
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -10,18 +10,6 @@ span.guilabel {
   border-radius: 4px;
   padding: 2.4px 6px;
   margin: auto 2px;
-  position: relative;
 
-  // This is a hack to control the opacity for guilabel with our color variables
-  // ref: https://stackoverflow.com/a/56951626/6734243
-  &:before {
-    content: "";
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    left: 0;
-    top: 0;
-    background-color: var(--pst-color-info);
-    opacity: 0.1;
-  }
+  @include background-from-color-variable(--pst-color-info);
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -10,6 +10,7 @@ span.guilabel {
   border-radius: 4px;
   padding: 2.4px 6px;
   margin: auto 2px;
+  position: relative;
 
   @include background-from-color-variable(--pst-color-info);
 }


### PR DESCRIPTION
Fix #454

The quotes were using a legacy color. 
Used the now-classic trick of admonition to display quotes in light grey using a left border (grey as well. It looks more like what we see on other platforms like GitHub and is working with any quote directive including `epigraph`, `highlight` and `pull-quote`.
<img width="1001" alt="Capture d’écran 2022-06-20 à 10 21 20" src="https://user-images.githubusercontent.com/12596392/174558504-3c861640-f1c0-49dd-9ad2-ae701bc52fc2.png">

