### PR TITLE
Add color support for copy and toggle buttons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,8 @@ extensions = [
     "sphinxext.rediraffe",
     "sphinx_design",
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
+    "sphinx_togglebutton",
 ]
 
 # -- Internationalization ------------------------------------------------
@@ -139,6 +141,7 @@ html_theme_options = {
 }
 
 html_sidebars = {
+    "index": ["search-field"],
     "contribute/index": [
         "sidebar-nav-bs",
         "custom-template",

--- a/docs/demo/kitchen-sink/web-components.rst
+++ b/docs/demo/kitchen-sink/web-components.rst
@@ -163,3 +163,27 @@ Tabs
 
             PROGRAM main
             END PROGRAM main
+
+Copybuttons
+===========
+
+`sphinx-copybutton <https://sphinx-copybutton.readthedocs.io/en/latest/>`__ adds a copy button to each of your code cells.
+You can see it in action by hovering over the code cell below:
+
+.. code-block:: python
+
+    print("A copybutton in the top-right!")
+
+Toggle buttons
+==============
+
+`sphinx-togglebutton <https://sphinx-togglebutton.readthedocs.io/en/latest/>`__ allows you to convert admonitions into toggle-able elements.
+
+.. admonition:: Click me to toggle!
+   :class: dropdown
+
+   This will be hidden until a click!
+
+.. toggle::
+
+    A standalone toggle button!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,9 @@ doc = [
   "matplotlib",
   "numpy",
   "xarray",
+  "sphinx-copybutton",
   "sphinx-design",
+  "sphinx-togglebutton",
   # Install nbsphinx in case we want to test it locally even though we can't load
   # it at the same time as MyST-NB.
   "nbsphinx"

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
@@ -1,0 +1,27 @@
+/**
+ * Sphinx Copybutton
+ * ref: https://sphinx-copybutton.readthedocs.io/
+ */
+
+div.highlight button.copybtn {
+  // Nicer spacing
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  // Removes the button background so we more naturally blend with the code cell.
+  background-color: var(--pst-color-surface);
+  color: var(--pst-color-muted);
+  border: none;
+
+  &:hover {
+    color: var(--pst-color-text);
+    background-color: var(--pst-color-surface);
+  }
+
+  // Tooltip styling
+  &.o-tooltip--left:after {
+    color: var(--pst-color-text);
+    background-color: var(--pst-color-surface);
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -1,0 +1,27 @@
+/**
+ * Sphinx Togglebutton
+ * ref: https://sphinx-togglebutton.readthedocs.io/en/latest/
+ */
+
+div.admonition.dropdown {
+  // Over-ride the vertical height shrinking in sphinx-togglebutton
+  // since we use max-height
+  &.toggle-hidden {
+    max-height: 2.4rem;
+  }
+
+  button.toggle-button {
+    color: var(--pst-color-muted);
+  }
+}
+
+// Standalone toggle buttons
+// Use opacity to highlight in hover, not background color
+details.toggle-details summary.toggle-details__summary {
+  background: var(--pst-color-surface);
+  opacity: 0.9;
+  &:hover {
+    opacity: 1;
+    background: var(--pst-color-surface);
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -13,15 +13,26 @@ div.admonition.dropdown {
   button.toggle-button {
     color: var(--pst-color-muted);
   }
+
+  // Opacity slightly shifts on hover to mark as a button or when open
+  p.admonition-title {
+    &::before {
+      transition: opacity 0.2s ease-out;
+    }
+
+    &:hover::before {
+      opacity: 0.15;
+    }
+  }
 }
 
 // Standalone toggle buttons
 // Use opacity to highlight in hover, not background color
 details.toggle-details summary.toggle-details__summary {
   background: var(--pst-color-surface);
-  opacity: 0.9;
+  transition: box-shadow 0.2s ease-out;
   &:hover {
-    opacity: 1;
+    box-shadow: inset 0 0 2rem 0rem var(--pst-color-shadow);
     background: var(--pst-color-surface);
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -66,11 +66,13 @@ $grid-breakpoints: (
 
 // Content blocks from Sphinx extensions
 @import "./extensions/bootstrap";
+@import "./extensions/copybutton";
 @import "./extensions/ethical-ads";
 @import "./extensions/execution";
 @import "./extensions/pydata";
 @import "./extensions/sphinx_design";
 @import "./extensions/sphinx_panels";
+@import "./extensions/togglebutton";
 
 // Page-specific CSS
 @import "./pages/search";

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -32,7 +32,6 @@ $pst-semantic-colors: (
   "shadow": (
     "light": rgb(216, 216, 216),
     "dark": rgb(33, 33, 33),
-    // Same as surface
   ),
   "border": (
     "light": rgb(201, 201, 201),

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -31,7 +31,8 @@ $pst-semantic-colors: (
   ),
   "shadow": (
     "light": rgb(216, 216, 216),
-    "dark": rgb(18, 18, 18),
+    "dark": rgb(33, 33, 33),
+    // Same as surface
   ),
   "border": (
     "light": rgb(201, 201, 201),


### PR DESCRIPTION
This adds color support for two more web component extensions: sphinx-copybutton and sphinx-togglebutton. It does this by adding another SCSS `extensions` file for each, and adds them to our docs.