### PR TITLE
FIX: Overflow content on configuration

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -8,6 +8,7 @@
   // We shoot for about 100 characters per line instead of 80.
   // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
   max-width: 60em;
+  overflow-x: auto; // Prevent wide content from pushing off the secondary sidebar
   // Give a bit more verticle spacing on wide screens
   padding: 3rem 1.5rem 2rem 3rem;
   @include media-breakpoint-down(md) {


### PR DESCRIPTION
This adds `overflow-x: auto` to prevent wide content from pushing out the secondary sidebar

Old / broken: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/configuring.html
New / fixed: https://pydata-sphinx-theme--772.org.readthedocs.build/en/772/user_guide/configuring.html

closes https://github.com/pydata/pydata-sphinx-theme/issues/771
closes https://github.com/pydata/pydata-sphinx-theme/issues/768
