### PR TITLE
ENH: Make scroll bar style more accessible and noticeable

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -7,8 +7,8 @@
 */
 @mixin scrollbar-style() {
   &::-webkit-scrollbar {
-    width: 0.4rem;
-    height: 0.3rem;
+    width: 0.5rem;
+    height: 0.5rem;
   }
 
   &::-webkit-scrollbar-thumb {
@@ -19,21 +19,28 @@
   &::-webkit-scrollbar-track {
     background: transparent;
   }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--pst-color-on-surface);
+  }
+
+  // Hovering behavior for the scrollbar
+  // Include both hovering on the parent and on the thumb in case thumb is outside parent
+  &:hover {
+    &::-webkit-scrollbar-thumb {
+      background: var(--pst-color-text-muted);
+    }
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--pst-color-text-muted);
+  }
 }
 
 /**
  * Fade the scrollbar until the element is hovered, so it is less attention-grabbind
  */
 @mixin scrollbar-on-hover() {
-  &::-webkit-scrollbar-thumb {
-    background: var(--pst-color-on-surface);
-  }
-
-  &:hover {
-    &::-webkit-scrollbar-thumb {
-      background: var(--pst-color-text-muted);
-    }
-  }
 }
 
 /**

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -3,15 +3,16 @@
 *********************************************/
 /**
 * Scrollbars should be thinner and slightly rounded, with a grey background
+* ref: https://www.nngroup.com/articles/scrolling-and-scrollbars/
 */
 @mixin scrollbar-style() {
   &::-webkit-scrollbar {
-    width: 0.3rem;
+    width: 0.4rem;
     height: 0.3rem;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: #c1c1c1; // This is the default color in Chrome (variables don't seem to work in mixinx)
+    background: var(--pst-color-text-muted);
     border-radius: 0.25rem;
   }
 
@@ -21,12 +22,16 @@
 }
 
 /**
- * Hide the scrollbar until the element is overed, so keep the page clean
+ * Fade the scrollbar until the element is hovered, so it is less attention-grabbind
  */
 @mixin scrollbar-on-hover() {
-  &:not(:hover) {
+  &::-webkit-scrollbar-thumb {
+    background: var(--pst-color-on-surface);
+  }
+
+  &:hover {
     &::-webkit-scrollbar-thumb {
-      visibility: hidden;
+      background: var(--pst-color-text-muted);
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -144,7 +144,6 @@ pre {
   box-shadow: 1px 1px 1px var(--pst-color-shadow);
 
   @include scrollbar-style();
-  @include scrollbar-on-hover();
 
   .linenos {
     opacity: 0.5;

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -14,7 +14,6 @@ body {
   flex-direction: column;
 
   @include scrollbar-style();
-  @include scrollbar-on-hover();
 
   // hack to avoid the black background on some browser including Safari
   &::-webkit-scrollbar-track {

--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -10,7 +10,6 @@
   overflow: auto;
 
   @include scrollbar-style();
-  @include scrollbar-on-hover();
 
   mjx-container {
     flex-grow: 1;

--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -28,5 +28,4 @@ table {
   overflow: auto;
 
   @include scrollbar-style();
-  @include scrollbar-on-hover();
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -17,7 +17,6 @@
   }
 
   @include scrollbar-style();
-  @include scrollbar-on-hover();
 
   &.no-sidebar {
     border-right: 0;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -36,7 +36,6 @@
   }
 
   @include scrollbar-style();
-  @include scrollbar-on-hover();
 }
 
 // Each entry of the in-page TOC

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -69,7 +69,7 @@ $pst-semantic-colors: (
   // on_surface: object on top of surface object (without shadows)
   "on-surface":
     (
-      "light": rgb(255, 255, 238),
+      "light": rgb(225, 225, 225),
       "dark": rgb(55, 55, 55),
     ),
 );


### PR DESCRIPTION
This makes a few improvements to the scroll bar, to address some of the concerns in #775 . Here's a summary:

- Width is a bit higher
- Scrollbars are always visible, but dimmed for most UI elements
- Hovering will make them have stronger color
- This _doesn't_ apply to the main body, which is always visible
- We now use variables to control the color
- I also noticed that the `on-surface` color on light theme had a slight yellow tint to it, rather than just following the shading gradient from light to dark (which is what we do on the dark theme). So this changes that color's default value...happy to discuss that one if there's a rationale for wanting to use yellow

Preview:

![chrome_YLNTprJFb8](https://user-images.githubusercontent.com/1839645/176762716-8964d80a-bc95-4ed3-88e5-1133c99cdd5c.gif)


closes #775