### PR TITLE
Set minimum version of supported pygments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ dependencies = [
   "sphinx>=4.0.2",
   "beautifulsoup4",
   "docutils!=0.17.0",
-  "packaging"
+  "packaging",
+  "pygments>=2.7"
 ]
 
 license = { file = "LICENSE" }


### PR DESCRIPTION
With older versions, you get an exception:

    'HtmlFormatter' object has no attribute 'get_linenos_style_defs'

because that method was only added in 2.7.

See also https://github.com/pradyunsg/furo/discussions/308