### PR TITLE
Style code blocks after GitHub

### DIFF
--- a/docs/demo/theme-elements.md
+++ b/docs/demo/theme-elements.md
@@ -79,3 +79,30 @@ Something is modified, check your version number.
 ```{deprecated} 0.1.1
 Something is deprecated, use something else instead.
 ```
+
+## Code blocks
+
+Code block styling is inspired by GitHub's documentation.
+
+```python
+print("A regular code block")
+print("A regular code block")
+print("A regular code block")
+```
+
+```{code-block} python
+:caption: python.py
+
+print("A code block with a caption.")
+print("A code block with a caption.")
+print("A code block with a caption.")
+```
+
+```{code-block} python
+:caption: python.py
+:linenos:
+
+print("A code block with a caption and line numbers.")
+print("A code block with a caption and line numbers.")
+print("A code block with a caption and line numbers.")
+```

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -136,7 +136,7 @@ code {
 
 pre {
   margin: 1.5em 0 1.5em 0;
-  padding: 10px;
+  padding: 1rem;
   background-color: var(--pst-color-surface);
   color: var(--pst-color-text-base);
   line-height: 1.2em;

--- a/src/pydata_sphinx_theme/assets/styles/content/_code.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_code.scss
@@ -1,0 +1,27 @@
+/**
+ * Code block styling
+ */
+// There's a wrapper when the code block has a title
+div.literal-block-wrapper {
+  border: 1px solid var(--pst-color-border);
+  box-shadow: 1px 1px 1px var(--pst-color-shadow);
+  border-radius: 0.2rem; // A bit higher to make sure it doesn't stick out
+
+  // This is where the title goes
+  div.code-block-caption {
+    margin: 0;
+    border-bottom: 1px solid var(--pst-color-border);
+    padding: 0.75rem 0.5rem;
+    font-size: 1rem;
+  }
+
+  // Remove the upper border radius since we want it to connect with the title
+  // Remove the box shadow so the wrapper gets the shadow instead
+  div[class*="highlight-"] {
+    margin: 0;
+    pre {
+      border: none;
+      box-shadow: none;
+    }
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_bootstrap.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_bootstrap.scss
@@ -4,8 +4,9 @@
 
 // Bootstrap adds margin to their general container class. However, sphinx/docutils
 // can also generate output with the container class, but in those cases we should
-// not add the margin from bootstrap.
+// not add the margin from bootstrap. Same for max-width.
 .docutils.container {
   padding-left: unset;
   padding-right: unset;
+  max-width: unset;
 }

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -55,6 +55,7 @@ $grid-breakpoints: (
 // Content blocks in standard Sphinx
 @import "./content/admonitions";
 @import "./content/api";
+@import "./content/code";
 @import "./content/footnotes";
 @import "./content/hacks";
 @import "./content/lists";

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -36,7 +36,7 @@
     overflow-y: auto;
     @include scrollbar-style;
 
-    // On smaller screens, add margin to the navbar start/stop
+    // On smaller screens, add margin to the navbar start + toggle button
     #navbar-start {
       margin-left: 1rem;
     }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -4,4 +4,7 @@
   */
   // This will impact the top offset for many sections
   --pst-header-height: 3rem;
+
+  // Border radius
+  --pst-border-radius: 0.2rem;
 }


### PR DESCRIPTION
This makes a few small modifications to our code blocks to take some inspiration from the GitHub code block styling. Here are the major changes:

- Adds support for code block titles
- Slightly increases the padding of our code blocks to match what GitHub uses (`1rem`)

Below are a few GIFs to show the old / new behavior:

**Code blocks**

![chrome_61osAOURx2](https://user-images.githubusercontent.com/1839645/177286956-5bb032e3-90d9-4215-b2ed-99949f87919d.gif)

**Notebooks**

![chrome_HFrj9ZXvWF](https://user-images.githubusercontent.com/1839645/177286770-7d2f6dad-032a-40d0-b7a3-bd733ee9f260.gif)


closes https://github.com/pydata/pydata-sphinx-theme/issues/783