### PR TITLE
Update topic and contents directive style

### DIFF
--- a/docs/demo/theme-elements.md
+++ b/docs/demo/theme-elements.md
@@ -3,6 +3,10 @@
 There are a few elements that are unique or particularly important to this theme.
 This page is a reference for how these look.
 
+```{contents} Page contents
+:local:
+```
+
 ## Mathematics
 
 Most Sphinx sites support math, but it is particularly important for scientific computing and so we illustrate support here as well.

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -202,6 +202,11 @@ div.topic {
   // Over-ride large default padding
   ul.simple {
     padding-left: 1rem;
+    
+    ul {
+      // So that sub-lists will have a bit less padding
+      padding-left: 2em;
+    }
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -184,15 +184,31 @@ div.admonition,
   }
 }
 
-// Similar content blocks that are not technically admonitions.
-.topic {
+/*
+ * Similar content blocks that are not technically admonitions.
+ */
+
+// Topics (also used for `contents` directive)
+div.topic {
   background-color: var(--pst-color-surface);
   border-color: var(--pst-color-border);
+  border-radius: 0.2rem;
+  padding: 1rem 1.25rem;
+
+  .topic-title {
+    margin: 0 0 0.5rem 0;
+  }
+
+  // Over-ride large default padding
+  ul.simple {
+    padding-left: 1rem;
+  }
 }
 
 aside.sidebar {
   background-color: var(--pst-color-on-surface);
   border-color: var(--pst-color-border);
+  border-radius: 0.2rem;
 }
 
 .seealso dd {

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -202,7 +202,7 @@ div.topic {
   // Over-ride large default padding
   ul.simple {
     padding-left: 1rem;
-    
+
     ul {
       // So that sub-lists will have a bit less padding
       padding-left: 2em;

--- a/src/pydata_sphinx_theme/assets/styles/content/_toctree.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_toctree.scss
@@ -31,3 +31,12 @@
     font-size: 1.3em;
   }
 }
+
+// In-page contents via the contents directive
+div.topic.contents {
+  // Style similarly to toctree
+  ul.simple {
+    list-style: none;
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
In the Jupyter docs I noticed that the in-page `{contents}` directive was producing some slightly off output. So this PR updates the contents directive to be styled more consistently with our other directives.

Here's what the in-page contents looks like now:

<img width="528" alt="chrome_ygPYoT6afq" src="https://user-images.githubusercontent.com/1839645/177296063-10b83184-9c55-44a1-8f1e-b270ab24acf9.png">

