### PR TITLE
Fix typos, use logging.warning

### DIFF
--- a/docs/contribute/manual.md
+++ b/docs/contribute/manual.md
@@ -2,7 +2,7 @@
 
 # Set up a manual development environment
 
-If you prefer not to use automation tools like `nox`, or want to have more control over the specific version of packages that you'd like like installed, you may also manually set up a development environment locally.
+If you prefer not to use automation tools like `nox`, or want to have more control over the specific version of packages that you'd like installed, you may also manually set up a development environment locally.
 
 To do so, follow the instructions on this page.
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -25,7 +25,7 @@ def update_config(app, env):
 
     # DEPRECATE >= v0.10
     if theme_options.get("search_bar_position") == "navbar":
-        logger.warn(
+        logger.warning(
             "Deprecated config `search_bar_position` used."
             "Use `search-field.html` in `navbar_end` template list instead."
         )
@@ -43,7 +43,7 @@ def update_config(app, env):
 
     # Raise a warning for a deprecated theme switcher config
     if "url_template" in theme_options.get("switcher", {}):
-        logger.warn(
+        logger.warning(
             "html_theme_options['switcher']['url_template'] is no longer supported."
             " Set version URLs in JSON directly."
         )
@@ -95,7 +95,7 @@ def prepare_html_config(app, pagename, templatename, context, doctree):
 
     # DEPRECATE: >= 0.11
     if context.get("theme_logo_link"):
-        logger.warn(
+        logger.warning(
             "DEPRECATION: Config `logo_link` will be deprecated in v0.11. "
             "Use the `logo.link` configuration dictionary instead."
         )
@@ -688,14 +688,14 @@ def _overwrite_pygments_css(app, exception=None):
     pygments_styles = list(get_all_styles())
     light_theme = theme_options.get("pygment_light_style", default_light_theme)
     if light_theme not in pygments_styles:
-        logger.warn(
+        logger.warning(
             f"{light_theme}, is not part of the available pygments style,"
             f' defaulting to "{default_light_theme}".'
         )
         light_theme = default_light_theme
     dark_theme = theme_options.get("pygment_dark_style", default_dark_theme)
     if dark_theme not in pygments_styles:
-        logger.warn(
+        logger.warning(
             f"{dark_theme}, is not part of the available pygments style,"
             f' defaulting to "{default_dark_theme}".'
         )

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -38,7 +38,7 @@
 }
 
 /**
- * Fade the scrollbar until the element is hovered, so it is less attention-grabbind
+ * Fade the scrollbar until the element is hovered, so it is less attention-grabbing
  */
 @mixin scrollbar-on-hover() {
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -35,7 +35,7 @@
     border-radius: 0.2rem;
   }
 
-  // inline the element in the navbar as long as they fit and use display block when colapsing
+  // inline the element in the navbar as long as they fit and use display block when collapsing
   @include media-breakpoint-down(md) {
     flex-direction: row;
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_footnotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_footnotes.scss
@@ -8,7 +8,7 @@ dt.label > span.brackets:not(:only-child):after {
   content: "]";
 }
 
-// Make footnote as a supercript
+// Make footnote as a superscript
 a.footnote-reference {
   vertical-align: super;
   font-size: small;

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -22,7 +22,7 @@ blockquote {
 
   @include background-from-color-variable(--pst-color-border);
 
-  //hack to make the text in the bloquote selectable
+  //hack to make the text in the blockquote selectable
   &:before {
     z-index: -1;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -9,7 +9,7 @@
   // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
   max-width: 60em;
   overflow-x: auto; // Prevent wide content from pushing off the secondary sidebar
-  // Give a bit more verticle spacing on wide screens
+  // Give a bit more vertical spacing on wide screens
   padding: 3rem 1.5rem 2rem 3rem;
   @include media-breakpoint-down(md) {
     padding: 3rem 1rem 1rem 1rem;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -139,7 +139,7 @@
   padding: 0 15px;
 }
 
-// inline the element in the navbar as long as they fit and use display block when colapsing
+// inline the element in the navbar as long as they fit and use display block when collapsing
 @include media-breakpoint-up(md) {
   .navbar-center-item {
     display: inline-block;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -142,7 +142,7 @@ nav.bd-links {
   }
 }
 
-// Navigatation items on the left
+// Navigation items on the left
 .bd-sidenav {
   display: none;
 }


### PR DESCRIPTION
Hi,

Two commits here, but happy to squash if necessary. Found a typo in the docs for new contributors (double "like" in <https://pydata-sphinx-theme.readthedocs.io/en/stable/contribute/manual.html>).

So I ran the PyCharm linter, and added the other typos found in code comments.

The other commit is for `logging.warn`, which was deprecated in [3.3](https://bugs.python.org/issue13235) and is to be removed some day :+1: 

![image](https://user-images.githubusercontent.com/304786/177641333-08e70a81-1dbe-4f82-aa15-4887f7836095.png)

Thanks!
-Bruno