### PR TITLE
Fix header spacing

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -5,8 +5,11 @@
   padding: 0.5rem 0;
   max-width: 100vw;
 
-  .container-xl {
+  .bd-header__inner {
     height: 100%;
+    gap: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 
   #navbar-end,
@@ -36,13 +39,7 @@
     overflow-y: auto;
     @include scrollbar-style;
 
-    // On smaller screens, add margin to the navbar start + toggle button
-    #navbar-start {
-      margin-left: 1rem;
-    }
-
     button.navbar-toggler {
-      margin-right: 1rem;
       border-color: var(--pst-color-text-muted);
       color: var(--pst-color-text-muted);
     }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -12,6 +12,12 @@
     padding-right: 1rem;
   }
 
+  #navbar-collapsible {
+    // Remove padding because we inherit padding from the parent container
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   #navbar-end,
   #navbar-center,
   #navbar-start {


### PR DESCRIPTION
This fixes some minor spacing issues in the header, so that if the menu items are aligned left they have a `gap`. Also fixes the way that we gave left/right padding to the header so it behaves consistently on mobile / widescreen