### PR TITLE
Rename and add deprecation warnings to for section names

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,11 +128,11 @@ html_theme_options = {
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
     # "show_nav_level": 2,
     # "search_bar_position": "navbar",  # TODO: Deprecated - remove in future version
-    # "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
+    "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "navbar_start": ["navbar-logo", "version-switcher"],
     # "navbar_center": ["navbar-nav", "navbar-version"],  # Just for testing, we should use defaults in our docs
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],  # Just for testing, we should use defaults in our docs
-    # "left_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
+    # "primary_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
     # "footer_items": ["copyright", "sphinx-version", ""]
     "switcher": {
         "json_url": json_url,

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -47,7 +47,7 @@ The CSS and JS for this theme are built for the browser from `src/pydata_sphinx_
   - captures the techniques for transforming the JS and CSS source files in
     `src/pydata_sphinx_theme/assets/*` into the production assets in `src/theme/pydata_sphinx_theme/static/`
 
-**For more information** about developing this theme, see the sections below and in the left sidebar.
+**For more information** about developing this theme, see the sections below and in the sidebar to the left.
 
 ```{toctree}
 :maxdepth: 2

--- a/docs/demo/no-sidebar.md
+++ b/docs/demo/no-sidebar.md
@@ -8,4 +8,4 @@ html_sidebars = {
 }
 ```
 
-The left sidebar should be entirely gone, and the main content should expand slightly to make up the extra space.
+The primary sidebar should be entirely gone, and the main content should expand slightly to make up the extra space.

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -721,7 +721,7 @@ version switcher in a sidebar. For example, you could define
     {%- include 'version-switcher.html' -%}
     {{ super() }}
 
-to insert a version switcher at the top of the left sidebar, while still
+to insert a version switcher at the top of the primary sidebar, while still
 keeping the default navigation below it. See :doc:`sections` for more
 information.
 
@@ -782,7 +782,7 @@ Add an Edit this Page button
 
 You can add a button to each page that will allow users to edit the page text
 directly and submit a pull request to update the documentation. To include this
-button in the right sidebar of each page, add the following configuration to
+button in the secondary sidebar of each page, add the following configuration to
 your ``conf.py`` file in 'html_theme_options':
 
 .. code:: python
@@ -937,7 +937,7 @@ Secondary Sidebar (Table of Contents)
 
 The secondary sidebar is to the right of your documentation content.
 It is primarily for showing a within-page Table of Contents, as well as links that point to the source of the page.
-
+To remove the secondary sidebar, see [](secondary-sidebar:remove).
 
 Show more levels of the in-page TOC by default
 ----------------------------------------------
@@ -957,16 +957,11 @@ You can show deeper levels by default by using the following configuration, indi
 All headings up to and including the level specified will now be shown
 regardless of what is displayed on the page.
 
-Remove the Table of Contents
-----------------------------
-
-To remove the Table of Contents, add ``:theme_html_remove_secondary_sidebar:`` to the `file-wide metadata <https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#file-wide-metadata>`_ at the top of a page.
-This will remove the Table of Contents from that page only.
 
 Remove the sidebar from some pages
 ==================================
 
-If you'd like the left sidebar to be removed from a page, you can use the
+If you'd like the primary sidebar to be removed from a page, you can use the
 following configuration in ``conf.py``:
 
 .. code-block:: python
@@ -983,7 +978,7 @@ This works for glob-style patterns as well. For example:
      "folder/*": []
    }
 
-If you'd like to remove the left sidebar from **all** pages of your documentation,
+If you'd like to remove the primary sidebar from **all** pages of your documentation,
 use this pattern:
 
 .. code-block:: python

--- a/docs/user_guide/sections.rst
+++ b/docs/user_guide/sections.rst
@@ -1,6 +1,6 @@
-====================================
-Add/Remove items from theme sections
-====================================
+===================================
+Add/Remove theme sections and items
+===================================
 
 There are a few major theme sections that you can customize to add/remove
 components, or add your own components. Each section is configured with a
@@ -37,15 +37,15 @@ By default, the following configuration is used:
    ...
    }
 
-The left sidebar
-================
+The primary sidebar (left)
+==========================
 
-The left sidebar is just to the left of a page's main content.
+The primary sidebar is just to the left of a page's main content.
 Configuring it is a bit different from configuring the other sections, because
 configuring the sidebar is natively supported in Sphinx, via the ``html_sidebars``
 configuration variable.
 
-For the left sidebar only, you can configure templates so that they only show
+For the primary sidebar only, you can configure templates so that they only show
 up on certain pages. You do so via a configuration like so in ``conf.py``:
 
 .. code-block:: python
@@ -66,14 +66,14 @@ By default, it has the following configuration:
         "**": ["search-field", "sidebar-nav-bs", "sidebar-ethical-ads"]
     }
 
-Left sidebar end sections
-=========================
+Primary sidebar end sections
+============================
 
-There is a special ``<div>`` within the left sidebar that appears at the
+There is a special ``<div>`` within the primary sidebar that appears at the
 bottom of the page, regardless of the content that is above it.
 
 To control the HTML templates that are within this div, use
-``html_theme_options['left_sidebar_end']`` in ``conf.py``.
+``html_theme_options['primary_sidebar_end']`` in ``conf.py``.
 
 By default, it has the following templates:
 
@@ -81,16 +81,16 @@ By default, it has the following templates:
 
     html_theme_options = {
       ...
-      "left_sidebar_end": ["sidebar-ethical-ads"],
+      "primary_sidebar_end": ["sidebar-ethical-ads"],
       ...
     }
 
 
-The right in-page sidebar
-=========================
+The secondary sidebar (right)
+=============================
 
-The in-page sidebar is just to the right of a page's main content, and is
-configured in ``conf.py`` with ``html_theme_options['page_sidebar_items']``.
+The secondary sidebar contains page-related information.
+It is just to the right of a page's main content, and is configured in ``conf.py`` with ``html_theme_options['secondary_sidebar_items']``.
 
 By default, it has the following templates:
 
@@ -98,9 +98,16 @@ By default, it has the following templates:
 
     html_theme_options = {
       ...
-      "page_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
+      "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
       ...
     }
+
+(secondary-sidebar:remove)=
+Remove the secondary sidebar
+----------------------------
+
+To remove the secondary sidebar, add ``:theme_html_remove_secondary_sidebar:`` to the `file-wide metadata <https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#file-wide-metadata>`_ at the top of a page.
+This will remove the secondary sidebar from that page only.
 
 The footer
 ==========

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -30,6 +30,35 @@ def update_config(app, env):
             "Use `search-field.html` in `navbar_end` template list instead."
         )
 
+    # DEPRECATE >= v0.11
+    if theme_options.get("left_sidebar_end"):
+        theme_options["primary_sidebar_end"] = theme_options.get("left_sidebar_end")
+        logger.warning(
+            "The configuration `left_sidebar_end` is deprecated, use `primary_sidebar_end`"  # noqa
+        )
+
+    if theme_options.get("left_sidebar_end"):
+        theme_options["primary_sidebar_end"] = theme_options.get("left_sidebar_end")
+        logger.warning(
+            "The configuration `left_sidebar_end` is deprecated, use `primary_sidebar_end`."  # noqa
+        )
+
+    if theme_options.get("logo_text"):
+        logo = theme_options.get("logo", {})
+        logo["text"] = theme_options.get("logo_text")
+        theme_options["logo"] = logo
+        logger.warning(
+            "The configuration `logo_text` is deprecated, use `'logo': {'text': }`."
+        )  # noqa
+
+    if theme_options.get("page_sidebar_items"):
+        theme_options["secondary_sidebar_items"] = theme_options.get(
+            "page_sidebar_items"
+        )
+        logger.warning(
+            "The configuration `page_sidebar_items` is deprecated, use `secondary_sidebar_items`."  # noqa
+        )
+
     # Validate icon links
     if not isinstance(theme_options.get("icon_links", []), list):
         raise ExtensionError(
@@ -112,8 +141,8 @@ def update_templates(app, pagename, templatename, context, doctree):
         "theme_navbar_center",
         "theme_navbar_end",
         "theme_footer_items",
-        "theme_page_sidebar_items",
-        "theme_left_sidebar_end",
+        "theme_secondary_sidebar_items",
+        "theme_primary_sidebar_end",
         "sidebars",
     ]
     for section in template_sections:

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -17,7 +17,7 @@
     {%- endfor %}
   </div>
   <div class="sidebar-end-items">
-    {%- for leftsidebartemplate in theme_left_sidebar_end %}
+    {%- for leftsidebartemplate in theme_primary_sidebar_end %}
     {%- include leftsidebartemplate %}
     {%- endfor %}
   </div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -32,9 +32,9 @@ navbar_start = navbar-logo.html
 navbar_center = navbar-nav.html
 navbar_end = search-button.html, theme-switcher.html, navbar-icon-links.html
 header_links_before_dropdown = 5
-left_sidebar_end = sidebar-ethical-ads.html
+primary_sidebar_end = sidebar-ethical-ads.html
 footer_items = copyright.html, sphinx-version.html
-page_sidebar_items = page-toc.html, edit-this-page.html, sourcelink.html
+secondary_sidebar_items = page-toc.html, edit-this-page.html, sourcelink.html
 switcher =
 pygment_light_style = tango
 pygment_dark_style = native
@@ -43,3 +43,5 @@ announcement =
 
 # DEPRECATE after 0.11
 logo_text =
+left_sidebar_end =
+page_sidebar_items =


### PR DESCRIPTION
This adds some renaming in the docs and checks for old configuration values since we are standardizing our naming of the primary/secondary sidebars.