### PR TITLE
Fix usage of version dropdown to work on mobile

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -45,6 +45,11 @@
     overflow-y: visible;
     @include scrollbar-style;
 
+    // If we're expanded, then make it possible to scroll if overflow
+    &.shown {
+      overflow-y: auto;
+    }
+
     button.navbar-toggler {
       border-color: var(--pst-color-text-muted);
       color: var(--pst-color-text-muted);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -42,7 +42,7 @@
   @include media-breakpoint-down(md) {
     // Make it scrollable with a max height on mobile in cases there are many items
     max-height: 90vh;
-    overflow-y: auto;
+    overflow-y: visible;
     @include scrollbar-style;
 
     button.navbar-toggler {

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -29,3 +29,14 @@
     </div>
   </div>
 </div>
+
+<script>
+// Adds the `shown` class to the parent so that we can trigger overflow
+// behavior that depends on whether we're expanded
+$('#navbar-collapsible').on('show.bs.collapse', function () {
+  $(".bd-header").addClass("shown");
+});
+$('#navbar-collapsible').on('hide.bs.collapse', function () {
+  $(".bd-header").removeClass("shown");
+});
+</script>


### PR DESCRIPTION
This fixes a minor bug that was preventing the version dropdown from showing on mobile + uncollapsed navbar. It adds two little JavaScript hooks to the bootstrap show/hide events that add a class to the `bd-header` container, and trigger whether it should be scrollable with an overflow-y

closes https://github.com/pydata/pydata-sphinx-theme/issues/782