### PR TITLE
Fix nbsphinx spacing and logo link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,6 +121,7 @@ html_theme_options = {
     "logo": {
         "text": "PyData Theme",
         "image_dark": "logo-dark.svg",
+        "link": "https://pydata.org",
     },
     "use_edit_page_button": True,
     "show_toc_level": 1,

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -9,8 +9,8 @@ All configuration options are passed with the ``html_theme_options`` variable
 in your ``conf.py`` file. This is a dictionary with ``key: val`` pairs that
 you can configure in various ways. This page describes the options available to you.
 
-Configure project logo and title
-================================
+Customize logo and title
+========================
 
 By default the theme will use the value of ``project`` on the left side of the header navbar.
 This can be replaced by a Logo image, and optionally a custom ``html_title`` as well.
@@ -51,13 +51,26 @@ Customize logo link
 -------------------
 
 The logo links to ``root_doc`` (usually the first page of your documentation) by default.
-If you'd like it to link to another page or use an external link instead, use the following configuration:
+You can instead link to a local document or an external website.
+To do so, use the ``html_theme_options["logo"]["link"]`` option and provide a new link.
+
+For example, to reference another local page:
 
 .. code-block:: python
 
    html_theme_options = {
        "logo": {
-           "link": "<other page or external link>",
+           "link": "some/other-page",
+       }
+   }
+
+To reference an external website, make sure your link starts with ``http``:
+
+.. code-block:: python
+
+   html_theme_options = {
+       "logo": {
+           "link": "https://pydata.org",
        }
    }
 

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -18,12 +18,20 @@ This can be replaced by a Logo image, and optionally a custom ``html_title`` as 
 Single logo for light and dark mode
 -----------------------------------
 
-Put an image in a folder that is in `html_static_path`, and use the following configuration:
+To use a local image file, put an image in a folder that is in `html_static_path`, and use the following configuration:
 
 .. code:: python
 
    html_static_path = ["_static"]
    html_logo = "_static/logo.png"
+
+To use an external link to an image, make sure the ``html_logo`` begins with ``http``.
+For example:
+
+.. code:: python
+
+   html_static_path = ["_static"]
+   html_logo = "https://pydata.org/wp-content/uploads/2019/06/pydata-logo-final.png"
 
 Different logos for light and dark mode
 ---------------------------------------

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_execution.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_execution.scss
@@ -53,3 +53,10 @@ html[data-theme="dark"] .bd-content {
     }
   }
 }
+
+// NBSphinx
+// If a cell immediately precedes text (with no output cell) then add padding
+// so that we have the same spacing as paragraphs after paragraphs.
+div.nblast + p {
+  margin-top: 1rem;
+}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -12,9 +12,17 @@
   {% set is_logo = logo or theme_logo.get("image_light") or theme_logo.get("image_dark") %}
   {% set image_light = theme_logo.get("image_light") or logo %}
   {% set image_dark = theme_logo.get("image_dark") or logo %}
+
+  {#- Prepare the logo image link based on whether it is local or remote -#}
+  {% if not image_light.startswith("http") %}
+    {% set image_light = pathto('_static/' + image_light, 1) %}
+  {% endif %}
+  {% if not image_dark.startswith("http") %}
+    {% set image_dark = pathto('_static/' + image_dark, 1) %}
+  {% endif %}
   {% if is_logo %}
-    <img src="{{ pathto('_static/' + image_light, 1) }}" class="logo__image only-light" alt="Logo image">
-    <img src="{{ pathto('_static/' + image_dark, 1) }}" class="logo__image only-dark" alt="Logo image">
+    <img src="{{ image_light }}" class="logo__image only-light" alt="Logo image">
+    <img src="{{ image_dark }}" class="logo__image only-dark" alt="Logo image">
   {% endif %}
   {% if not is_logo or theme_logo.get("text") %}
     <p class="title logo__title">{{ theme_logo.get("text") or docstitle }}</p>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -193,6 +193,23 @@ def test_logo_external_link(sphinx_build_factory):
     assert f'href="{test_url}"' in index_str
 
 
+def test_logo_external_image(sphinx_build_factory):
+    """Test that the logo link is correct for external URLs."""
+    # Test with a specified external logo image source
+    test_url = "https://pydata.org/wp-content/uploads/2019/06/pydata-logo-final.png"
+    confoverrides = {
+        "html_theme_options": {
+            "logo": {
+                "image_dark": test_url,
+            }
+        },
+    }
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
+    index_html = sphinx_build.html_tree("index.html")
+    index_str = str(index_html.select(".navbar-brand")[0])
+    assert f'src="{test_url}"' in index_str
+
+
 def test_favicons(sphinx_build_factory):
     """Test that arbitrary favicons are included."""
     html_theme_options_favicons = {


### PR DESCRIPTION
This does two quick fixes for issues we have in 0.10:

- Adds the ability for the logo image URL to be an external link. closes #758 
- Adds a CSS rule for nbsphinx to make the vertical padding better w/ output cells. closes #323 