### PR TITLE
Overlay darken for search popup

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -81,7 +81,7 @@
   margin-top: 0.5rem;
   width: 90%;
   max-width: 800px;
-  box-shadow: 0 0 1rem 1rem var(--pst-color-shadow); // A bit stronger/wider
+  box-shadow: 0 0 1rem 0.2rem var(--pst-color-shadow);
 
   form.bd-search {
     flex-grow: 1;
@@ -108,6 +108,8 @@
   ~ .search-button__overlay {
     display: flex;
     position: fixed;
+    background-color: black;
+    opacity: 0.5;
     width: 100%;
     height: 100%;
     top: 0px;

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -74,14 +74,13 @@
   // Center in middle of screen just underneath header
   position: fixed;
   z-index: $zindex-fixed;
-  top: 6rem;
+  top: 30%;
   left: 50%;
   transform: translate(-50%, -50%);
   right: 1rem;
   margin-top: 0.5rem;
   width: 90%;
   max-width: 800px;
-  box-shadow: 0 0 1rem 0.2rem var(--pst-color-shadow);
 
   form.bd-search {
     flex-grow: 1;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-toggle.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-toggle.scss
@@ -16,9 +16,9 @@ input.sidebar-toggle {
 // Background overlays
 label.overlay {
   background-color: black;
+  opacity: 0.5;
   height: 0;
   width: 0;
-  opacity: 0.5;
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
This adds the same overlay styles to our search overlay that we use for our toggle overlays.

closes https://github.com/pydata/pydata-sphinx-theme/issues/794