### PR TITLE
Use Bootstrap styling for our dropdown button

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -3,8 +3,6 @@
  */
 
 #navbar-icon-links {
-  gap: 1rem;
-
   i {
     &.fa,
     &.fab,
@@ -35,13 +33,19 @@
     border-radius: 0.2rem;
   }
 
+  li:first-child a {
+    padding-left: 0;
+  }
+
   // inline the element in the navbar as long as they fit and use display block when collapsing
   // One breakpoint less than $breakpoint-header. See variables/_layout.scss for more info.
   @include media-breakpoint-down(md) {
     flex-direction: row;
 
+    // Use Bootstrap padding for these nav links to get the spacing right
     a {
-      margin-right: 0.1em;
+      padding-left: 0.5rem;
+      padding-right: 0.5rem;
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -66,16 +66,11 @@
     display: flex;
 
     @include media-breakpoint-up($breakpoint-header) {
-      // Add a gap on wider screens, on narrow screens we are vertical + already have padding
-      gap: 1rem;
       // Center align on wide screens so the dropdown button is centered properly
       align-items: center;
     }
 
     li a.nav-link {
-      // Unset bootstrap padding so we can use a gutter
-      padding-left: 0;
-      padding-right: 0;
       color: var(--pst-color-text-muted);
 
       &:hover {
@@ -97,7 +92,6 @@
       // On mobile, the dropdown behaves like any other link, no hiding
       button {
         display: none;
-        color: var(--pst-color-text-muted);
       }
 
       .dropdown-menu {
@@ -112,11 +106,10 @@
 
       // On wide screens, the dropdown becomes a pop-up menu
       @include media-breakpoint-up($breakpoint-header) {
-        height: 2.2rem; // Slight hack to make this aligned with navbar links
-
         button {
-          display: flex;
-          align-items: center;
+          display: unset;
+          color: var(--pst-color-text-muted);
+          border: none;
         }
 
         .dropdown-menu {


### PR DESCRIPTION
This reverts some of the custom styling we had added to the navbar dropdown, and instead just relies on Bootstrap's styling and spacing in the navbar links. I think that it is probably better to use the standard styling from Bootstrap anyway, and I believe this also closes https://github.com/pydata/pydata-sphinx-theme/issues/806