### PR TITLE
Inline math docs and optional keywords for favicons

### DIFF
--- a/docs/demo/theme-elements.md
+++ b/docs/demo/theme-elements.md
@@ -11,8 +11,7 @@ This page is a reference for how these look.
 
 Most Sphinx sites support math, but it is particularly important for scientific computing and so we illustrate support here as well.
 
-This is a test. Here is an equation:
-{math}`X_{0:5} = (X_0, X_1, X_2, X_3, X_4)`.
+This is a test. Here is an inline equation: {math}`X_{0:5} = (X_0, X_1, X_2, X_3, X_4)` and {math}`another` and {math}`x^2 x^3 x^4` another.
 
 Here is another:
 

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -435,7 +435,6 @@ Add favicons
 
 Additionally you may add any number of browser- or device-specific favicons of any size.
 To do so, use the ``html_theme_options["favicons"]`` configuration key.
-
 The only required argument is ``href``, which can be either an absolute URL (beginning with ``http``) or a local path relative to your ``html_static_path``.
 In addition, you may specify a size with ``sizes``, specify a ``rel`` value, and specify a ``color``.
 See `this blog post on SVG favicons for more information <https://medium.com/swlh/are-you-using-svg-favicons-yet-a-guide-for-modern-browsers-836a6aace3df>`_.

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -433,7 +433,7 @@ Add favicons
 
 ``pydata_sphinx_theme`` supports the `standard sphinx favicon configuration <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_favicon>`_, using ``html_favicon``.
 
-Additionally you ma add any number of browser- or device-specific favicons of any size.
+Additionally you may add any number of browser- or device-specific favicons of any size.
 To do so, use the ``html_theme_options["favicons"]`` configuration key.
 
 The only required argument is ``href``, which can be either an absolute URL (beginning with ``http``) or a local path relative to your ``html_static_path``.

--- a/docs/user_guide/configuring.rst
+++ b/docs/user_guide/configuring.rst
@@ -428,18 +428,19 @@ For example, to change the number of displayed header links to be ``4`` instead 
      "header_links_before_dropdown": 4
    }
 
-Adding favicons
-===============
+Add favicons
+============
 
-``pydata_sphinx_theme`` supports the
-`standard sphinx favicon configuration <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_favicon>`_,
-using ``html_favicon``.
+``pydata_sphinx_theme`` supports the `standard sphinx favicon configuration <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_favicon>`_, using ``html_favicon``.
 
-Additionally, ``pydata_sphinx_theme`` allows you to add any number of
-browser- or device-specific favicons of any size. To define arbitrary favicons,
-use the ``favicons`` configuration key. The ``href`` value can be either an
-absolute URL (beginning with ``http``) or a local path relative to your
-``html_static_path``:
+Additionally you ma add any number of browser- or device-specific favicons of any size.
+To do so, use the ``html_theme_options["favicons"]`` configuration key.
+
+The only required argument is ``href``, which can be either an absolute URL (beginning with ``http``) or a local path relative to your ``html_static_path``.
+In addition, you may specify a size with ``sizes``, specify a ``rel`` value, and specify a ``color``.
+See `this blog post on SVG favicons for more information <https://medium.com/swlh/are-you-using-svg-favicons-yet-a-guide-for-modern-browsers-836a6aace3df>`_.
+
+For example, below we define three extra favicons of different sizes and ``rel`` types, and one with a specific color.
 
 .. code-block:: python
 
@@ -458,7 +459,8 @@ absolute URL (beginning with ``http``) or a local path relative to your
          {
             "rel": "apple-touch-icon",
             "sizes": "180x180",
-            "href": "apple-touch-icon-180x180.png"
+            "href": "apple-touch-icon-180x180.png",
+            "color": "#000000",
          },
       ]
    }
@@ -468,7 +470,7 @@ section, following this pattern:
 
 .. code-block:: html+jinja
 
-   <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ favicon.href }}">
+   <link rel="{{ favicon.rel }}" sizes="{{ favicon.sizes }}" href="{{ favicon.href }}" color="{{ favicon.color }}">
 
 
 .. _configure-sidebar:

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -146,7 +146,7 @@ def update_templates(app, pagename, templatename, context, doctree):
             "type": f"image/{icon_type}",
         }
         if favicon.get("color"):
-            opts["color"] = favicon.get("color", "")
+            opts["color"] = favicon["color"]
         # Sphinx will auto-resolve href if it's a local file
         app.add_css_file(favicon["href"], **opts)
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -143,8 +143,8 @@ def update_templates(app, pagename, templatename, context, doctree):
         # Sphinx will auto-resolve href if it's a local file
         app.add_css_file(
             favicon["href"],
-            rel=favicon["rel"],
-            sizes=favicon["sizes"],
+            rel=favicon.get("rel", "icon"),
+            sizes=favicon.get("sizes", "16x16"),
             **{"type": f"image/{icon_type}"},
         )
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -145,7 +145,7 @@ def update_templates(app, pagename, templatename, context, doctree):
             "sizes": favicon.get("sizes", "16x16"),
             "type": f"image/{icon_type}",
         }
-        if favicon.get("color"):
+        if "color" in favicon:
             opts["color"] = favicon["color"]
         # Sphinx will auto-resolve href if it's a local file
         app.add_css_file(favicon["href"], **opts)

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -140,13 +140,15 @@ def update_templates(app, pagename, templatename, context, doctree):
     # Add links for favicons in the topbar
     for favicon in context.get("theme_favicons", []):
         icon_type = Path(favicon["href"]).suffix.strip(".")
+        opts = {
+            "rel": favicon.get("rel", "icon"),
+            "sizes": favicon.get("sizes", "16x16"),
+            "type": f"image/{icon_type}",
+        }
+        if favicon.get("color"):
+            opts["color"] = favicon.get("color", "")
         # Sphinx will auto-resolve href if it's a local file
-        app.add_css_file(
-            favicon["href"],
-            rel=favicon.get("rel", "icon"),
-            sizes=favicon.get("sizes", "16x16"),
-            **{"type": f"image/{icon_type}"},
-        )
+        app.add_css_file(favicon["href"], **opts)
 
 
 def add_toctree_functions(app, pagename, templatename, context, doctree):


### PR DESCRIPTION
This is a quick PR to clean up two things:

- Adds some extra inline math to our math example page to confirm that it works as expected. closes #809 
- Adds default values for `rel` and `sizes` for our favicons. closes https://github.com/pydata/pydata-sphinx-theme/issues/710
- Adds some support for colors to favicons and updates the docs, so closes https://github.com/pydata/pydata-sphinx-theme/issues/426