### PR TITLE
Add push events for tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "*"
   pull_request:
 
 env:


### PR DESCRIPTION
Our latest release didn't trigger a GitHub Action to upload it. I think that's because we're only triggering our workflow on `push: main`. I think this will fix it. Will merge it in to give it a shot.