### PR TITLE
Move publish to new workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,6 @@
+# This will run every time a tag is created and pushed to the repository.
+# It calls our tests workflow via a `workflow_call`, and if tests pass
+# then it triggers our upload to PyPI for a new release.
 name: Publish to PyPI
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  tests:
+    uses: ./.github/workflows/tests.yml
+  publish:
+    name: publish
+    needs: [tests] # require tests to pass before deploy runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Build package
+        run: |
+          python -m pip install -U pip build
+          python -m build
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,8 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "*"
   pull_request:
+  workflow_call:
 
 env:
   COVERAGE_THRESHOLD: 60
@@ -144,25 +143,3 @@ jobs:
           temporaryPublicStorage: true
           uploadArtifacts: true
           runs: 3 # Multiple runs to reduce variance
-
-  publish:
-    name: Publish to PyPI
-    needs: [lint, tests]
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.7
-      - name: Build package
-        run: |
-          python -m pip install -U pip build
-          python -m build
-      - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_KEY }}


### PR DESCRIPTION
OK that last one didn't fix it. So this PR tries to move the publish step into its own workflow that depends on our `tests` workflow completing.