### PR TITLE
FIX: Remove unnecessary padding for article header

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_header-article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header-article.scss
@@ -2,7 +2,6 @@
   min-height: var(--pst-header-article-height);
   display: flex;
   align-items: center;
-  padding: 0 0.5rem;
 
   .bd-header-article__end {
     margin-left: auto;


### PR DESCRIPTION
This removes some horizontal padding so that the sidebar toggle buttons align with the logo / navbar toggle buttons instead of being slightly offset.