### PR TITLE
ENH: Add light background to inline code

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_code.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_code.scss
@@ -25,3 +25,13 @@ div.literal-block-wrapper {
     }
   }
 }
+
+/**
+ * In-line code
+ */
+code.literal {
+  padding: 0.1rem 0.25rem;
+  background-color: var(--pst-color-surface);
+  border: 1px solid var(--pst-color-on-surface);
+  border-radius: 0.25rem;
+}


### PR DESCRIPTION
This adds a lightweight background to our inline code to follow a pattern that is very common in other documentation platforms, and hopefluly makes inline code standout better.

Two quick points:

- It doesn't change the code color at all, **do people think we should change the color to be the same as our text?**
- It tries to add a light border that isn't intrusive, **@drammock is it OK to you?**

Here's an example in light/dark:

![ShareX_lI80D2naEK](https://user-images.githubusercontent.com/1839645/180662546-194ee12b-3028-4d5a-8ca2-10eb21815834.gif)

closes #837