### PR TITLE
Add download link icon to download links

### DIFF
--- a/docs/user_guide/styling.rst
+++ b/docs/user_guide/styling.rst
@@ -3,7 +3,6 @@ Theme variables and CSS
 =======================
 
 .. _pydata-css-variables: https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/assets/styles/variables/
-.. _pydata-css-colors: https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
 .. _css-variable-help: https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties
 
 This section covers a few ways that you can control the look and feel of your theme via your own CSS and theme variables.
@@ -174,17 +173,13 @@ The following image should help you understand these overlays:
       </div>
     </div>
 
-
-For a complete list of the theme colors that you may override, see the
-`color variables defaults CSS file <pydata-css-colors_>`_.
-
 .. it would be nice to have this `.. literalinclude::` here to actually show
    the file, but there's a pygments bug that fails to lex SCSS variables
    (specifically the `$` symbol that prepends SCSS variables, see
    https://github.com/pygments/pygments/issues/2130). So for now it's
-   commented out.
-   .. literalinclude:: ../../src/pydata_sphinx_theme/assets/styles/variables/_color.scss
-     :language: scss
+   just a raw download link.
+
+For a complete list of the theme colors that you may override, see the :download:`PyData theme CSS colors stylesheet <../../src/pydata_sphinx_theme/assets/styles/variables/_color.scss>`.
 
 Configure pygments theme
 ========================

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -19,6 +19,7 @@ a.reference.download.external:before {
   content: "\f019";
   font-family: "Font Awesome 5 Free";
   font-size: 0.9em;
+  font-weight: 600;
   padding-right: 0.5em;
   color: var(--pst-color-text-muted);
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -15,7 +15,7 @@ span.guilabel {
   @include background-from-color-variable(--pst-color-info);
 }
 
-a.reference.download.external:before {
+a.reference.download:before {
   content: "\f019";
   font-family: "Font Awesome 5 Free";
   font-size: 0.8em;

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -14,3 +14,11 @@ span.guilabel {
 
   @include background-from-color-variable(--pst-color-info);
 }
+
+a.reference.download.external:before {
+  content: "\f019";
+  font-family: "Font Awesome 5 Free";
+  font-size: 0.9em;
+  padding-right: 0.5em;
+  color: var(--pst-color-text-muted);
+}

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -18,8 +18,8 @@ span.guilabel {
 a.reference.download.external:before {
   content: "\f019";
   font-family: "Font Awesome 5 Free";
-  font-size: 0.9em;
+  font-size: 0.8em;
   font-weight: 600;
-  padding-right: 0.5em;
+  padding: 0 0.25em;
   color: var(--pst-color-text-muted);
 }


### PR DESCRIPTION
This adds a little icon to make it clear when a link will *download* something because it has been created by the `:download:` role.

As one example here's the long link from the examples page:

![image](https://user-images.githubusercontent.com/1839645/181459539-bb75b8a4-8865-46a6-9000-91a136482edb.png)

- Originally reported in: https://github.com/executablebooks/sphinx-book-theme/issues/594 