### PR TITLE
NEW: Adding a section for footer-content like in sphinx-basic-ng

### DIFF
--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -79,38 +79,63 @@ You can click on section titles to learn more about them and some basic layout c
         Links between pages in the active section.
 
     .. grid-item::
-        :padding: 2
-        :outline:
-        :columns: 6
-        :class: content
+        :columns: 8
 
-        .. button-ref:: layout-article-header
-            :color: primary
+        .. grid::
+            :margin: 0
+            :gutter: 0
+
+            .. grid-item::
+                :class: content
+                :padding: 2
+                :columns: 8
+                :outline:
+
+                .. button-ref:: layout-article-header
+                    :color: primary
+                    :outline:
+
+                    Article Header
+
+                **Article Content**
+
+                .. button-ref:: layout-article-footer
+                    :color: primary
+                    :outline:
+
+                    Article Footer
+
+            .. grid-item::
+                :padding: 2
+                :columns: 4
+                :outline:
+                :class: sidebar-secondary
+
+                .. button-ref:: layout-sidebar-secondary
+                    :color: primary
+                    :outline:
+
+                    Secondary Sidebar
+
+                Within-page header links
+
+        .. grid::
+            :margin: 0
+            :gutter: 0
             :outline:
 
-            Article Header
+            .. grid-item::
+                :padding: 2
+                :columns: 12
+                :class: footer-content
 
-        **Article Content**
+                .. button-ref:: layout-footer-content
+                    :color: primary
+                    :outline:
 
-        .. button-ref:: layout-article-footer
-            :color: primary
-            :outline:
+                    Footer content
 
-            Article Footer
 
-    .. grid-item::
-        :padding: 2
-        :outline:
-        :columns: 2
-        :class: sidebar-secondary
-
-        .. button-ref:: layout-sidebar-secondary
-            :color: primary
-            :outline:
-
-            Secondary Sidebar
-
-        Within-page header links
 
     .. grid-item::
         :padding: 2

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -352,14 +352,16 @@ use this pattern:
 Footer Content
 ==============
 
-What is the exact use of it?
+The footer content is a narrow bar spanning the article’s content and secondary sidebar.
+It does not contain anything immediately viewable to the reader, but is kept as a placeholder in case theme developers wish to re-use it in the future.
+
 
 .. _layout-sidebar-secondary:
 
 Secondary Sidebar (right)
 =========================
 
-The in-page sidebar is just to the right of a page's main content, and is
+The in-page sidebar is just to the right of a page's article content, and is
 configured in ``conf.py`` with ``html_theme_options['page_sidebar_items']``.
 
 By default, it has the following templates:
@@ -396,7 +398,7 @@ at the bottom. You can hide these buttons with the following configuration:
 Footer
 ======
 
-The footer is just below a page's main content, and is configured in ``conf.py``
+The footer is just below a page’s main content, and is configured in ``conf.py``
 with ``html_theme_options['footer_items']``.
 
 By default, it has the following templates:

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -347,7 +347,7 @@ use this pattern:
      "**": []
    }
 
-.. _layout-footer-ontent:
+.. _layout-footer-content:
 
 Footer Content
 ==============

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -347,6 +347,13 @@ use this pattern:
      "**": []
    }
 
+.. _layout-footer-ontent:
+
+Footer Content
+==============
+
+What is the exact use of it?
+
 .. _layout-sidebar-secondary:
 
 Secondary Sidebar (right)

--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -5,6 +5,7 @@
   flex-grow: 1;
   flex-direction: column;
   display: flex;
+  min-width: 0;
 
   .bd-content {
     display: flex;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -8,7 +8,8 @@
 
   .bd-content {
     display: flex;
-
+    justify-content: center;
+    height: 100%;
     // Max-width is slightly more than the W3 since our docs often have images.
     // We shoot for about 100 characters per line instead of 80.
     // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
@@ -16,6 +17,8 @@
       justify-content: space-between;
       display: flex;
       flex-direction: column;
+      max-width: 60rem;
+      padding: 1rem;
       .bd-article {
         // Give a bit more verticle spacing on wide screens
         @include media-breakpoint-up($breakpoint-sidebar-secondary) {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -10,14 +10,15 @@
     display: flex;
     justify-content: center;
     height: 100%;
-    // Max-width is slightly more than the W3 since our docs often have images.
-    // We shoot for about 100 characters per line instead of 80.
-    // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
     .bd-article-container {
       justify-content: space-between;
       display: flex;
       flex-direction: column;
-      max-width: 60rem;
+      // Max-width is slightly more than the W3 since our docs often have images.
+      // We shoot for about 100 characters per line instead of 80.
+      // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
+      max-width: 60em;
+      overflow-x: auto; // Prevent wide content from pushing off the secondary sidebar
       padding: 1rem;
       .bd-article {
         // Give a bit more verticle spacing on wide screens

--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -1,22 +1,28 @@
 /**
  * Main content area
  */
-.bd-content {
-  display: flex;
+.bd-main {
+  flex-grow: 1;
   flex-direction: column;
+  display: flex;
 
-  // Max-width is slightly more than the W3 since our docs often have images.
-  // We shoot for about 100 characters per line instead of 80.
-  // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
-  max-width: 60em;
-  overflow-x: auto; // Prevent wide content from pushing off the secondary sidebar
-  padding: 1rem;
+  .bd-content {
+    display: flex;
 
-  .bd-article {
-    // Give a bit more verticle spacing on wide screens
-    @include media-breakpoint-up($breakpoint-sidebar-secondary) {
-      padding-top: 2rem;
-      padding-left: 2rem;
+    // Max-width is slightly more than the W3 since our docs often have images.
+    // We shoot for about 100 characters per line instead of 80.
+    // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
+    .bd-article-container {
+      justify-content: space-between;
+      display: flex;
+      flex-direction: column;
+      .bd-article {
+        // Give a bit more verticle spacing on wide screens
+        @include media-breakpoint-up($breakpoint-sidebar-secondary) {
+          padding-top: 2rem;
+          padding-left: 2rem;
+        }
+      }
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_container.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_container.scss
@@ -11,6 +11,6 @@
 .bd-page-width {
   width: 100%;
   @include media-breakpoint-up(lg) {
-    width: $breakpoint-page-width;
+    max-width: $breakpoint-page-width;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_container.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_container.scss
@@ -1,10 +1,16 @@
 .bd-container {
   flex-grow: 1;
   display: flex;
-  flex-direction: column;
+  justify-content: center;
 
   .bd-container__inner {
-    flex-grow: 1;
-    justify-content: center;
+    display: flex;
+  }
+}
+
+.bd-page-width {
+  width: 100%;
+  @include media-breakpoint-up(lg) {
+    width: $breakpoint-page-width;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -17,8 +17,10 @@
   width: 100%;
   padding: 0.5rem 0;
   max-width: 100vw;
-
+  justify-content: center;
   .bd-header__inner {
+    display: flex;
+    align-items: center;
     height: 100%;
     padding-left: 1rem;
     padding-right: 1rem;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -4,10 +4,7 @@
  */
 
 .bd-sidebar-primary {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-
+  flex-shrink: 0;
   max-height: calc(100vh - var(--pst-header-height));
   position: sticky;
   top: var(--pst-header-height);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -4,7 +4,9 @@
  */
 
 .bd-sidebar-primary {
-  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   max-height: calc(100vh - var(--pst-header-height));
   position: sticky;
   top: var(--pst-header-height);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -17,7 +17,7 @@
   }
 
   padding: 2rem 1rem 1rem 1rem;
-  width: 17rem;
+  width: var(--pst-sidebar-secondary);
 
   // Color and border
   background-color: var(--pst-color-background);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -5,6 +5,7 @@
 .bd-sidebar-secondary {
   display: flex;
   order: 2;
+  flex-shrink: 0;
   flex-direction: column;
   position: sticky;
   top: var(--pst-header-height);
@@ -16,7 +17,7 @@
   }
 
   padding: 2rem 1rem 1rem 1rem;
-  @include make-col(2);
+  width: 17rem;
 
   // Color and border
   background-color: var(--pst-color-background);

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -19,6 +19,7 @@
 */
 $breakpoint-sidebar-primary: lg; // When we collapse the primary sidebar
 $breakpoint-sidebar-secondary: xl; // When we collapse the secondary sidebar
+$breakpoint-page-width: 88rem; // value taken from sphinx-basic-ng
 
 /*******************************************************************************
 * Define the animation behaviour

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -7,6 +7,7 @@
   // Article header is 66% of Header
   --pst-header-height: 3rem;
   --pst-header-article-height: calc(var(--pst-header-height) * 2 / 3);
+  --pst-sidebar-secondary: 17rem;
 }
 
 /*******************************************************************************

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -20,7 +20,7 @@
 */
 $breakpoint-sidebar-primary: lg; // When we collapse the primary sidebar
 $breakpoint-sidebar-secondary: xl; // When we collapse the secondary sidebar
-$breakpoint-page-width: 88rem; // value taken from sphinx-basic-ng
+$breakpoint-page-width: 88rem; // following sphinx-basic-ng design pattern, which we are ultimately going to inherit
 
 /*******************************************************************************
 * Define the animation behaviour

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -20,7 +20,7 @@
 */
 $breakpoint-sidebar-primary: lg; // When we collapse the primary sidebar
 $breakpoint-sidebar-secondary: xl; // When we collapse the secondary sidebar
-$breakpoint-page-width: 88rem; // following sphinx-basic-ng design pattern, which we are ultimately going to inherit
+$breakpoint-page-width: 88rem; // taken from sphinx-basic-ng, which we are ultimately going to inherit
 
 /*******************************************************************************
 * Define the animation behaviour

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -78,45 +78,45 @@
   </nav>
   {% endblock %}
 
-  <div class="bd-container container-xl">
-    <div class="bd-container__inner row">
+  <div class="bd-container">
+    <div class="bd-container__inner bd-page-width">
       {# Primary sidebar #}
       <div class="bd-sidebar-primary bd-sidebar{% if not sidebars %} hide-on-wide{% endif %}">
         {% include "sections/sidebar-primary.html" %}
       </div>
-
-      {# Secondary sidebar #}
-      {% block docs_toc %}
-      {% if not remove_sidebar_secondary %}
-        <div class="bd-sidebar-secondary bd-toc">
-          {% include "sections/sidebar-secondary.html" %}
-        </div>
-      {% endif %}
-      {% endblock %}
-
-      {# Main content area #}
-      {% block docs_main %}
-      <div class="bd-content col">
-          {# Article header #}
-          <div class="bd-header-article">
-              {% include "sections/header-article.html" %}
+      <main class="bd-main">
+        {# Main content area #}
+        {% block docs_main %}
+        <div class="bd-content">
+          <div class="bd-article-container">
+            {# Article header #}
+            <div class="bd-header-article">
+                {% include "sections/header-article.html" %}
+            </div>
+            {# Article content #}
+            {% block docs_body %}
+            <article class="bd-article" role="main">
+              {% block body %} {% endblock %}
+            </article>
+            {% endblock %}
+            {# Article Footer #}
+            {% if theme_show_prev_next %}
+            <footer class="bd-footer-article">
+                {% include "sections/footer-article.html" %}
+            </footer>
+            {% endif %}
           </div>
-
-          {# Article content #}
-          {% block docs_body %}
-          <article class="bd-article" role="main">
-            {% block body %} {% endblock %}
-          </article>
-          {% endblock %}
-
-          {# Article Footer #}
-          {% if theme_show_prev_next %}
-          <footer class="bd-footer-article">
-              {% include "sections/footer-article.html" %}
-          </footer>
+          {# Secondary sidebar #}
+          {% block docs_toc %}
+          {% if not remove_sidebar_secondary %}
+            <div class="bd-sidebar-secondary bd-toc">
+              {% include "sections/sidebar-secondary.html" %}
+            </div>
           {% endif %}
-      </div>
-      {% endblock %}
+          {% endblock %}
+        </div>
+        {% endblock %}
+      </main>
     </div>
   </div>
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -115,6 +115,11 @@
           {% endif %}
           {% endblock %}
         </div>
+        <footer class="bd-footer-content">
+          <div class="bd-footer-content__inner">
+            {% include "sections/footer-content.html" %}
+          </div>
+        </footer>
         {% endblock %}
       </main>
     </div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer-content.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer-content.html
@@ -1,0 +1,1 @@
+{#- Intentionally empty in case others want to add something -#}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -1,4 +1,4 @@
-<div class="bd-header__inner container-xl">
+<div class="bd-header__inner bd-page-width">
   <label class="sidebar-toggle primary-toggle" for="__primary">
       <span class="fas fa-bars"></span>
   </label>


### PR DESCRIPTION
Added footer-content.html, following the sphinx-basic-ng design. 


For this and to mimic sphinx-basic-ng design (which we are ultimately planning to inherit) https://github.com/pydata/pydata-sphinx-theme/pull/840, have reordered and created a few tags for body content. Copied over the container CSS for these elements as well from sphinx-basic-ng, including the page width to be 88rem (which looked nicer to me, but can revert it.).
![slack-imgs](https://user-images.githubusercontent.com/6542997/183648147-dac480b1-4f76-4f19-9733-d0dca267d9b2.png)

The specific tags created/reordered here are:
- `bd-container__inner` now has a new `main` tag and primary sidebar as its only children. secondary sidebar has been moved from this position.
- new `main` tag is introduced to accommodate footer-content section. The visual position of which is shown in the pic above. 
- `main` tag has `bd-content` and the new footer-section as its children tags.
- `bd-content` now has `bd-article-container` and the secondary sidebar as its children. Note that the secondary sidebar was earlier on the same level as primary sidebar, but has moved here to adhere to the skeleton of sphinx-basic-ng. 
- `bd-article-container ` has an article header, article content, and article footer in it. 

Inspecting the HTML, in the preview of this PR will help understand the hierarchy better.

The need for this section was highlighted in a PR in sphinx-book-theme: https://github.com/executablebooks/sphinx-book-theme/pull/597