### PR TITLE
MAINT: Upgrade FontAwesome dependency to latest version

### DIFF
--- a/docs/community/topics.md
+++ b/docs/community/topics.md
@@ -120,7 +120,7 @@ This is configured in the `webpack.config.js` file, and imported in the respecti
 
 ### FontAwesome icons
 
-Three "styles" of the [FontAwesome 5 Free](https://fontawesome.com/icons?m=free)
+Three "styles" of the [FontAwesome 6 Free](https://fontawesome.com/icons?m=free)
 icon font are used for {ref}`icon links <icon-links>` and admonitions, and is
 the only `vendored` font.
 

--- a/docs/user_guide/fonts.rst
+++ b/docs/user_guide/fonts.rst
@@ -1,7 +1,7 @@
 Fonts and FontAwesome
 =====================
 
-The theme includes the `FontAwesome 5 Free <https://fontawesome.com/icons?m=free>`__
+The theme includes the `FontAwesome 6 Free <https://fontawesome.com/icons?m=free>`__
 icon font (the ``.fa, .far, .fas`` styles, which are used for
 :ref:`icon links <icon-links>` and admonitions).
 This is the only *vendored* font, and otherwise the theme by default relies on

--- a/docs/user_guide/header-links.rst
+++ b/docs/user_guide/header-links.rst
@@ -89,7 +89,7 @@ as well as brand-specific icons (e.g. "github").
 You can use FontAwesome icons by specifying ``"type": "fontawesome"``, and
 specifying a FontAwesome class in the ``icon`` value.
 The value of ``icon`` can be any full
-`FontAwesome 5 Free <https://fontawesome.com/icons?d=gallery&m=free>`__ icon.
+`FontAwesome 6 Free <https://fontawesome.com/icons?d=gallery&m=free>`__ icon.
 In addition to the main icon class, e.g. ``fa-cat``, the "style" class must
 also be provided e.g. `fab` for *branding*, or `fas` for *solid*.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,9 +61,9 @@
       }
     },
     "@fortawesome/fontawesome-free": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.13.0.tgz",
-      "integrity": "sha512-xKOeQEl5O47GPZYIMToj6uuA2syyFlq9EMSl2ui0uytjY9xbe8XS0pexNWmxrdcCyNGyDmLyYw5FtKsalBUeOg=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
+      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ=="
     },
     "@types/glob": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "webpack-watch-files-plugin": "^1.0.3"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "5.13.0",
+    "@fortawesome/fontawesome-free": "6.1.2",
     "bootstrap": "^4.4.1",
     "jquery": "3.5.1",
     "optimize-css-assets-webpack-plugin": "^5.0.3",


### PR DESCRIPTION
This is a PR to propose an upgrade to the latest version of FontAwesome (i.e. v6.1.2). Moving from 5.13.0 to 6.x.x provides to `pydata-sphinx-theme` users with a richer bank of icons, and also more up to date versions of brand logos (e.g. GitLab).