### PR TITLE
FIX: Hide vert scrollbars on inline math

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -24,4 +24,5 @@
 // Special-case for inline math
 span.math {
   display: inline-flex;
+  overflow-y: hidden;
 }


### PR DESCRIPTION
closes #858 