### PR TITLE
FIX: Fix equation scrolling behavior

### DIFF
--- a/docs/user_guide/theme-elements.md
+++ b/docs/user_guide/theme-elements.md
@@ -11,7 +11,7 @@ Some of these are triggered with configuration or markdown syntax that is unique
 
 Most Sphinx sites support math, but it is particularly important for scientific computing and so we illustrate support here as well.
 
-Here is an inline equation: {math}`X_{0:5} = (X_0, X_1, X_2, X_3, X_4)` and {math}`another` and {math}`x^2 x^3 x^4` another.
+Here is an inline equation: {math}`X_{0:5} = (X_0, X_1, X_2, X_3, X_4)` and {math}`another` and {math}`x^2 x^3 x^4` another. And here's one to test vertical height {math}`\frac{\partial^2 f}{\partial \phi^2}`.
 
 Here is block-level equation:
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -4,24 +4,30 @@
 .math {
   align-items: center;
   display: flex;
-  flex-direction: row-reverse;
   gap: 0.5em;
   max-width: 100%;
-  overflow: auto;
-
-  @include scrollbar-style();
-
-  mjx-container {
-    flex-grow: 1;
-  }
-
-  span.eqno a.headerlink {
-    position: relative;
-    font-size: 1em;
-  }
+  // This will be over-ridden for the y-direction and divs
+  overflow: hidden;
 }
 
 // Special-case for inline math
 span.math {
   display: inline-flex;
+}
+
+div.math {
+  // So that the eqno shows up after the equation
+  flex-direction: row-reverse;
+
+  span.eqno a.headerlink {
+    position: relative;
+    font-size: 1em;
+  }
+
+  mjx-container {
+    flex-grow: 1;
+    padding-bottom: 0.2rem;
+    overflow-x: auto;
+    @include scrollbar-style();
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -1,12 +1,13 @@
 /**
  * Mathematics via MathJax.
- * 
+ *
  * This is designed for MathJax v3
  * ref: https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax
  */
- 
+
 // Applies to all math elements
-span.math, div.math {
+span.math,
+div.math {
   align-items: center;
   display: flex;
   max-width: 100%;


### PR DESCRIPTION
This makes a few CSS fixes to our equation scrolling behavior. Here's the summary:

- It makes the block-level equation scroll at the `mth-container` level, instead of the `div.math` level. This means that the equation label will always show up and _only_ the equation will scroll.
- This also fixes the "scrolled to the right" bug, and closes https://github.com/pydata/pydata-sphinx-theme/issues/857
- It also cleans up the `overflow: hidden` behavior in general, and also closes https://github.com/pydata/pydata-sphinx-theme/issues/858 (it also supercedes https://github.com/pydata/pydata-sphinx-theme/pull/871 but happy to merge that one first and incorporate here if @drammock prefers)