### PR TITLE
fix color of the search input

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -18,7 +18,7 @@
     border-radius: $admonition-border-radius;
     border: 1px solid var(--pst-color-border);
     padding-left: 2.5rem;
-    color: var(--pst-color-border);
+    color: var(--pst-color-text-base);
 
     // Inner-text of the search bar
     &::placeholder {


### PR DESCRIPTION
the placeholder stays in border color but the content is now display as base-text color whatever the blurring status. Fix #873 