### PR TITLE
BUG: Fix links not clickable in versionmodified directives

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -62,5 +62,10 @@
     top: 0;
     background-color: var(#{$color-variable});
     opacity: $opacity;
+
+    // So that hovering over the text within background is still possible.
+    // Otherwise the background overlays the text and you cannot click or select easily.
+    // ref: https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events
+    pointer-events: none;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -27,6 +27,7 @@ div.versionadded {
 
   p:before {
     background-color: var(--pst-color-success);
+    pointer-events: none;
   }
 }
 
@@ -35,6 +36,7 @@ div.versionchanged {
 
   p:before {
     background-color: var(--pst-color-warning);
+    pointer-events: none;
   }
 }
 
@@ -43,6 +45,7 @@ div.deprecated {
 
   p:before {
     background-color: var(--pst-color-danger);
+    pointer-events: none;
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -27,7 +27,6 @@ div.versionadded {
 
   p:before {
     background-color: var(--pst-color-success);
-    pointer-events: none;
   }
 }
 
@@ -36,7 +35,6 @@ div.versionchanged {
 
   p:before {
     background-color: var(--pst-color-warning);
-    pointer-events: none;
   }
 }
 
@@ -45,7 +43,6 @@ div.deprecated {
 
   p:before {
     background-color: var(--pst-color-danger);
-    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
Reference https://github.com/scipy/scipy/issues/16846 4th point.

https://pydata-sphinx-theme.readthedocs.io/en/stable/demo/theme-elements.html#version-changes uses the pseudo `content` CSS property to add the background colour for different version modified directives (`versionadded`, `versionchanged`, `deprecated`), unfortunately it seems like it is on top of the text content (higher in z-index). This leads to text not being clickable; more specifically, all links in the text are blocked and don't work. This is quite a problem because usually when deprecating a method, you would want to link the alternate method from the docs in the message.

See [here](https://output.circle-artifacts.com/output/job/901b791a-6e25-42f1-b38d-d5fd2bf76a5e/artifacts/0/html/reference/generated/scipy.misc.face.html#scipy.misc.face) as an example of the links not working.

This PR fixes the issue. I'm not a CSS expert, and there are many ways to fix the problem. Let me know if you have a better idea or if this change could break something else (i hope not). 

cc @tupui @rgommers