### PR TITLE
fix: update switcher color according to sidebar

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -29,6 +29,17 @@
   }
 }
 
+// specific border color when the button is nested in the navbar
+// as it's color is different from the header
+.bd-sidebar-primary .theme-switch-button {
+  border-color: var(--pst-color-background);
+
+  &:hover,
+  &:active {
+    border-color: var(--pst-color-background) !important;
+  }
+}
+
 html[data-mode="auto"] .theme-switch-button a[data-mode="auto"] {
   display: flex;
 }


### PR DESCRIPTION
Everything is in the title, look very carefully at the theme switcher in the dark theme when it's folded in the primary sidebar and you'll see a light grey border. 

It's because the button has been customized to work on the header navbar that is "on-background" colored when the primary sidebar is simply using "background". 

This trick ensures that we use the correct color when used in the sidebar.

For the poor soul that will review this PR, that's before: 

<img width="44" alt="Capture d’écran 2022-08-17 à 22 43 28" src="https://user-images.githubusercontent.com/12596392/185239472-c8a8e50b-219c-4b18-8898-d1ac1888a4cc.png">

that's after:

<img width="44" alt="Capture d’écran 2022-08-17 à 22 50 02" src="https://user-images.githubusercontent.com/12596392/185240510-02281403-5112-45a2-a11c-c6971db29f52.png">

