### PR TITLE
MAINT: Add a py-spy profiler to nox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ node_modules/
 
 # files from the gallery screenshots
 docs/_static/gallery
+
+# Our site profile tests
+profile.svg


### PR DESCRIPTION
This adds a py-spy profiler to our nox profiles so we can quickly generate profiles. It does so by copying the test site to a temporary folder and adding a bunch of extra files so that we can watch what a slow build (w/ lots of files) looks like.