### PR TITLE
MAINT: Run audit on a simplified docs build

### DIFF
--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -8,7 +8,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:performance": ["error", { "minScore": 0.5 }],
+        "categories:performance": ["error", { "minScore": 0.8 }],
         "categories:accessibility": ["error", { "minScore": 0.8 }],
         "categories:best-practices": ["error", { "minScore": 0.8 }],
         "categories:seo": ["error", { "minScore": 0.7 }]

--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -1,7 +1,7 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./docs/_build/html/examples/kitchen-sink",
+      "staticDistDir": "./audit/_build/kitchen-sink/",
       "settings": {
         "skipAudits": ["canonical"]
       }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,9 +134,19 @@ jobs:
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install -e .[coverage]
 
-      - name: Build docs to store
+      # We want to run the audit on a simplified documentation build so that
+      # the audit results aren't affected by non-theme things like extensions.
+      # Here we copy over just the kitchen sink into an empty docs site with
+      # only the theme loaded so extensions don't play a role in audit scores.
+      - name: Copy kitchen sink to a tiny site and build it
         run: |
-          sphinx-build -b html docs/ docs/_build/html
+          mkdir audit/
+          mkdir audit/site
+          cp -r docs/examples/kitchen-sink audit/site/kitchen-sink
+          printf "Test\n====\n\n.. toctree::\n\n   kitchen-sink/index\n" > audit/site/index.rst
+          echo 'html_theme = "pydata_sphinx_theme"' > audit/site/conf.py
+          echo '.. toctree::\n   :glob:\n\n   *' >> audit/site/index.rst
+          sphinx-build audit/site audit/_build
 
       # The lighthouse audit runs directly on the HTML files, no serving needed
       - name: Audit with Lighthouse


### PR DESCRIPTION
This modifies our `audit` CI job so that it runs on a simplified documentation build rather than on our full documentation site.

The reason for this is because we load a lot of extensions, and this often has a significant impact on the audit, even though there's nothing actionable in this theme (for example, see: #891)

This should make our audit results more reliable, simpler, faster, and less variable since it's only tied to *this* theme and not the extensions we load with it.

- closes #891