### PR TITLE
add option to customise the alt text of the logo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,6 +129,7 @@ html_theme_options = {
     "logo": {
         "text": "PyData Theme",
         "image_dark": "logo-dark.svg",
+        "alt_text": "PyData Theme",
     },
     "use_edit_page_button": True,
     "show_toc_level": 1,

--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -77,7 +77,7 @@ To reference an external website, make sure your link starts with ``http``:
 Customize logo alternative text
 -------------------------------
 
-You may set a custom ``alt text`` to use with your logo.
+You may set a custom ``alt text`` to use with your logo to replace the default ("logo image").
 This can make the logo more accessible to those using screen readers or other assistive tech.
 To do so, use ``html_teme_options["logo"]["alt_text"]`` as in the following example:
 

--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -74,6 +74,22 @@ To reference an external website, make sure your link starts with ``http``:
        }
    }
 
+Customize logo alternative text
+-------------------------------
+
+The logo is by default using "Logo image" as an alternative text of the image. To set
+a specific alt text for this to be accessible to those using screen readers and another
+assistive tech, use the ``html_teme_options["logo"]["alt_text"]`` and provide a new name
+as in the following example:
+
+.. code-block:: python
+
+   html_theme_options = {
+       "logo": {
+           "alt_text": "foo",
+       }
+   }
+
 Add a logo title
 ----------------
 

--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -83,6 +83,7 @@ assistive tech, use the ``html_teme_options["logo"]["alt_text"]`` and provide a 
 as in the following example:
 
 .. code-block:: python
+   :caption: conf.py
 
    html_theme_options = {
        "logo": {

--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -78,7 +78,7 @@ Customize logo alternative text
 -------------------------------
 
 The logo is by default using "Logo image" as an alternative text of the image. To set
-a specific alt text for this to be accessible to those using screen readers and another
+a specific alt text for this to be accessible to those using screen readers or other
 assistive tech, use the ``html_teme_options["logo"]["alt_text"]`` and provide a new name
 as in the following example:
 

--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -77,10 +77,9 @@ To reference an external website, make sure your link starts with ``http``:
 Customize logo alternative text
 -------------------------------
 
-The logo is by default using "Logo image" as an alternative text of the image. To set
-a specific alt text for this to be accessible to those using screen readers or other
-assistive tech, use the ``html_teme_options["logo"]["alt_text"]`` and provide a new name
-as in the following example:
+You may set a custom ``alt text`` to use with your logo.
+This can make the logo more accessible to those using screen readers or other assistive tech.
+To do so, use ``html_teme_options["logo"]["alt_text"]`` as in the following example:
 
 .. code-block:: python
    :caption: conf.py

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -1,22 +1,24 @@
 {% if not theme_logo.get("link") %}
   {% set href = pathto(root_doc) %}
 {% elif theme_logo.get("link").startswith("http") %}
-  {# Logo link is to external URL #}
-  {% set href = theme_logo.get("link") %}
+  {% set href = theme_logo.get("link") %} {# external url #}
 {% else %}
-  {# Logo link is to internal page #}
-  {% set href = pathto(theme_logo.get("link")) %}
+  {% set href = pathto(theme_logo.get("link")) %} {# internal page #}
 {% endif %}
 
 <a class="navbar-brand logo" href="{{ href }}">
+
+  {# get all the brand information from html_theme_option #}
   {% set is_logo = logo or theme_logo.get("image_light") or theme_logo.get("image_dark") %}
   {% set image_light = theme_logo.get("image_light") or logo %}
   {% set image_dark = theme_logo.get("image_dark") or logo %}
   {% set image_light = image_light if image_light.startswith("http") else pathto('_static/' + image_light, 1) %}
   {% set image_dark = image_dark if image_dark.startswith("http") else pathto('_static/' + image_dark, 1) %}
+  {% set alt = theme_logo.get("alt_text", "Logo image") %}
+
   {% if is_logo %}
-    <img src="{{ image_light }}" class="logo__image only-light" alt="Logo image">
-    <img src="{{ image_dark }}" class="logo__image only-dark" alt="Logo image">
+    <img src="{{ image_light }}" class="logo__image only-light" alt="{{ alt }}">
+    <img src="{{ image_dark }}" class="logo__image only-dark" alt="{{ alt }}">
   {% endif %}
   {% if not is_logo or theme_logo.get("text") %}
     <p class="title logo__title">{{ theme_logo.get("text") or docstitle }}</p>


### PR DESCRIPTION
Fix #829 

Use an extra "alt_text" parameter to change the `alt` of the logo. fallback to "Logo image" if not set. 
I also updated the documentation for branding and use a custom text in the lib doc as an example