### PR TITLE
DOCS: Update grid size for gallery

### DIFF
--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -4,7 +4,6 @@ This is a gallery of documentation built on top of the `pydata-sphinx-theme`.
 If you'd like to add your documentation to this list, simply add an entry to [this gallery.yaml file](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/_static/gallery.yaml) and open a Pull Request to add it.
 
 ```{gallery-grid} ../_static/gallery.yaml
----
-grid-columns: "1 2 2 3"
+:grid-columns: "1 2 2 3"
 
 ```

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -5,6 +5,6 @@ If you'd like to add your documentation to this list, simply add an entry to [th
 
 ```{gallery-grid} ../_static/gallery.yaml
 ---
-grid-columns: "1 2 2 3" 
+grid-columns: "1 2 2 3"
 
 ```

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -4,5 +4,7 @@ This is a gallery of documentation built on top of the `pydata-sphinx-theme`.
 If you'd like to add your documentation to this list, simply add an entry to [this gallery.yaml file](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/_static/gallery.yaml) and open a Pull Request to add it.
 
 ```{gallery-grid} ../_static/gallery.yaml
+---
+grid-columns: "1 2 2 3" 
 
 ```


### PR DESCRIPTION
Update the gallery images sizes as I notified that they were uper small on my 13'' screen. 

| ![][before] | ![][after] |
|-----------|----------|

[before]: https://user-images.githubusercontent.com/12596392/187070143-1ada9620-c7ad-4267-b311-e5f2b99aeba6.png
[after]: https://user-images.githubusercontent.com/12596392/187070637-7a8d3f35-c6dc-4194-afce-c6e1ba6a7ee2.png

