### PR TITLE
ENH: Add section title to sidebar navigation

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_navbar-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_navbar-links.scss
@@ -68,3 +68,8 @@
     }
   }
 }
+
+// Don't display the `site navigation` in the header menu
+.bd-header .navbar-nav > p.sidebar-header-items__title {
+  display: none;
+}

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -1,10 +1,10 @@
 button.version-switcher__button {
   border-color: var(--pst-color-border);
   color: var(--pst-color-text-base);
+  // Add a margin on narrow screens to avoid feeling cramped
   margin-bottom: 1em;
-
   @include media-breakpoint-up($breakpoint-sidebar-primary) {
-    margin-bottom: none;
+    margin-bottom: unset;
   }
 
   &:hover {

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -1,6 +1,11 @@
 button.version-switcher__button {
   border-color: var(--pst-color-border);
   color: var(--pst-color-text-base);
+  margin-bottom: 1em;
+
+  @include media-breakpoint-up($breakpoint-sidebar-primary) {
+    margin-bottom: none;
+  }
 
   &:hover {
     color: var(--pst-color-text-base);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -36,7 +36,7 @@
 
   .sidebar-start-items__item,
   .sidebar-end-items__item {
-    padding: 0.25rem 0;
+    padding: 0.5rem 0;
   }
 
   // Hide the sidebar header items on widescreen since they are visible in the header
@@ -202,9 +202,15 @@ nav.bd-links {
     }
   }
 
+  // Title
+  p.bd-links__title {
+    font-size: var(--pst-sidebar-header-font-size);
+    font-weight: var(--pst-sidebar-header-font-weight);
+    margin-bottom: 0.5rem;
+  }
+
   // Toctree captions
   p.caption {
-    font-size: var(--pst-sidebar-header-font-size);
     font-weight: var(--pst-sidebar-header-font-weight);
     position: relative;
     margin-top: 1.25em;

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
@@ -1,3 +1,8 @@
-<ul id="navbar-main-elements" class="navbar-nav">
-    {{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown) }}
-</ul>
+<nav class="navbar-nav">
+    <p class="sidebar-header-items__title" role="heading" aria-level="1" aria-label="{{ _('Site Navigation') }}">
+        {{ _("Site Navigation") }}
+    </p>
+    <ul id="navbar-main-elements" class="navbar-nav">
+        {{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown) }}
+    </ul>
+</nav>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
@@ -1,4 +1,7 @@
 <nav class="bd-links" id="bd-docs-nav" aria-label="{{ _('Section navigation') }}">
+  <p class="bd-links__title" role="heading" aria-level="1">
+    {{ _("Section Navigation") }}
+  </p>
   <div class="bd-toc-item navbar-nav">
     {{ sidebar_nav_html }}
   </div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -1,9 +1,6 @@
 {% block docs_sidebar %}
   {# Header items that will be displayed in the sidebar on mobile #}
   <div class="sidebar-header-items sidebar-primary__section">
-    <p class="sidebar-header-items__title" role="heading" aria-level="1" aria-label="{{ _('Navigation') }}">
-      {{ _("Site Navigation") }}
-    </p>
     {# The header center items #}
     {% if theme_navbar_center %}
       <div class="sidebar-header-items__center">

--- a/tests/test_build/navbar_ix.html
+++ b/tests/test_build/navbar_ix.html
@@ -1,21 +1,26 @@
 <div class="mr-auto" id="navbar-center">
  <div class="navbar-center-item">
-  <ul class="navbar-nav" id="navbar-main-elements">
-   <li class="nav-item">
-    <a class="nav-link" href="page1.html">
-     Page 1
-    </a>
-   </li>
-   <li class="nav-item">
-    <a class="nav-link" href="page2.html">
-     Page 2
-    </a>
-   </li>
-   <li class="nav-item">
-    <a class="nav-link" href="section1/index.html">
-     Section 1 index
-    </a>
-   </li>
-  </ul>
+  <nav class="navbar-nav">
+   <p aria-label="Site Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">
+    Site Navigation
+   </p>
+   <ul class="navbar-nav" id="navbar-main-elements">
+    <li class="nav-item">
+     <a class="nav-link" href="page1.html">
+      Page 1
+     </a>
+    </li>
+    <li class="nav-item">
+     <a class="nav-link" href="page2.html">
+      Page 2
+     </a>
+    </li>
+    <li class="nav-item">
+     <a class="nav-link" href="section1/index.html">
+      Section 1 index
+     </a>
+    </li>
+   </ul>
+  </nav>
  </div>
 </div>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -1,27 +1,29 @@
 <div class="bd-sidebar-primary bd-sidebar">
  <div class="sidebar-header-items sidebar-primary__section">
-  <p aria-label="Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">
-   Site Navigation
-  </p>
   <div class="sidebar-header-items__center">
    <div class="navbar-center-item">
-    <ul class="navbar-nav" id="navbar-main-elements">
-     <li class="nav-item">
-      <a class="nav-link" href="../page1.html">
-       Page 1
-      </a>
-     </li>
-     <li class="nav-item">
-      <a class="nav-link" href="../page2.html">
-       Page 2
-      </a>
-     </li>
-     <li class="nav-item current active">
-      <a class="nav-link" href="#">
-       Section 1 index
-      </a>
-     </li>
-    </ul>
+    <nav class="navbar-nav">
+     <p aria-label="Site Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">
+      Site Navigation
+     </p>
+     <ul class="navbar-nav" id="navbar-main-elements">
+      <li class="nav-item">
+       <a class="nav-link" href="../page1.html">
+        Page 1
+       </a>
+      </li>
+      <li class="nav-item">
+       <a class="nav-link" href="../page2.html">
+        Page 2
+       </a>
+      </li>
+      <li class="nav-item current active">
+       <a class="nav-link" href="#">
+        Section 1 index
+       </a>
+      </li>
+     </ul>
+    </nav>
    </div>
   </div>
   <div class="sidebar-header-items__end">
@@ -50,6 +52,9 @@
  <div class="sidebar-start-items sidebar-primary__section">
   <div class="sidebar-start-items__item">
    <nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
+    <p aria-level="1" class="bd-links__title" role="heading">
+     Section Navigation
+    </p>
     <div class="bd-toc-item navbar-nav">
      <ul class="nav bd-sidenav">
       <li class="toctree-l1">

--- a/tests/test_build/test_sidebars_captions.html
+++ b/tests/test_build/test_sidebars_captions.html
@@ -1,4 +1,7 @@
 <nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
+ <p aria-level="1" class="bd-links__title" role="heading">
+  Section Navigation
+ </p>
  <div class="bd-toc-item navbar-nav">
   <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">

--- a/tests/test_build/test_sidebars_nested_page.html
+++ b/tests/test_build/test_sidebars_nested_page.html
@@ -1,4 +1,7 @@
 <nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
+ <p aria-level="1" class="bd-links__title" role="heading">
+  Section Navigation
+ </p>
  <div class="bd-toc-item navbar-nav">
   <p aria-level="2" class="caption" role="heading">
    <span class="caption-text">


### PR DESCRIPTION
This cleans up some of our sidebar navigation code, so that it is structured more compactly in our theme, and so that there are similar navigation headers for both the site and section navigation. Here's a quick summary:

- It moves the `Site Navigation` title to be inside of our `site header navigation` component. This is invisible in widescreen, but is visible on narrow screens when it shows up in the sidebar.
- It adds a `Section Navigation` title to the "within section" navigation, so it's easy to distinguish the site/section navigation.
- Cleans up a little bit of the CSS spacing, closes https://github.com/pydata/pydata-sphinx-theme/issues/886

For example, note the "site navigation" and (new) "section navigation" headers:

![image](https://user-images.githubusercontent.com/1839645/187072933-e65a04f8-fd42-4dfd-811b-8e41a934c385.png)
