### PR TITLE
Correct the link to the pygments styles in styling.rst

### DIFF
--- a/docs/user_guide/styling.rst
+++ b/docs/user_guide/styling.rst
@@ -184,7 +184,7 @@ For a complete list of the theme colors that you may override, see the :download
 Configure pygments theme
 ========================
 
-As the Sphinx theme supports multiple modes, the code highlighting colors can be modified for each one of them by modifying the ``pygment_light_style`` and ``pygment_dark_style``. You can check available Pygments colors on this `page <https://help.farbox.com/pygments.html>`__.
+As the Sphinx theme supports multiple modes, the code highlighting colors can be modified for each one of them by modifying the ``pygment_light_style`` and ``pygment_dark_style``. You can check available Pygments colors on this `page <https://pygments.org/styles/>`__.
 
 .. code-block:: python
 


### PR DESCRIPTION
Corrects the link to the pygments styles in styling.rst from https://help.farbox.com/pygments.html
to https://pygments.org/styles/