### PR TITLE
add css helper for images optimized for both dark and light theme

### DIFF
--- a/docs/user_guide/light-dark.rst
+++ b/docs/user_guide/light-dark.rst
@@ -110,18 +110,20 @@ the image without speicfying the helper class:
 .. code-block:: rst
 
     .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+        :class: p-2
 
 .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+    :class: p-2
 
 and the same image with it:
 
 .. code-block:: rst
 
     .. image:: https://source.unsplash.com/200x200/daily?cute+cat
-        :class: dark-light
+        :class: dark-light p-2
 
 .. image:: https://source.unsplash.com/200x200/daily?cute+cat
-    :class: dark-light
+    :class: dark-light p-2
 
 Define custom JavaScript to react to theme changes
 --------------------------------------------------

--- a/docs/user_guide/light-dark.rst
+++ b/docs/user_guide/light-dark.rst
@@ -71,7 +71,7 @@ For example to define a different background color for both the light and dark t
 
 A complete list of the colors used in this theme can be found in the :doc:`CSS style section <styling>`.
 
-Theme-dependent images and content 
+Theme-dependent images and content
 ----------------------------------
 
 It is possible to use different content for light and dark mode, so that the content only shows up when a particular theme is active.

--- a/docs/user_guide/light-dark.rst
+++ b/docs/user_guide/light-dark.rst
@@ -71,8 +71,8 @@ For example to define a different background color for both the light and dark t
 
 A complete list of the colors used in this theme can be found in the :doc:`CSS style section <styling>`.
 
-Use theme-dependent content
----------------------------
+Theme-dependent images and content 
+----------------------------------
 
 It is possible to use different content for light and dark mode, so that the content only shows up when a particular theme is active.
 This is useful if your content depends on the theme's style, such as a PNG image with a light or a dark background.
@@ -100,12 +100,14 @@ Change the theme and a new image should be displayed.
 .. image:: https://source.unsplash.com/200x200/daily?cute+dog
     :class: only-light
 
-Use non theme-dependent  content
---------------------------------
+Images and content that work in both themes
+-------------------------------------------
 
-by design Pydata-sphinx-theme will add a white background to any image that is not specifying the :code:`only-dark` class when displayed in the dark theme. If your image is suitable for both light and dark theme, please use the following **CSS helper class** :code:`dark-light` to make your image theme agnostic.
+For images without the :code:`only-dark` class, when the **dark theme** is activated, a white background will automatically be added to ensure the image contents are visible.
+If your image is suitable for both light and dark theme, add the CSS class :code:`dark-light` to make your image theme-agnostic.
 
-the image without speicfying the helper class:
+For example, here's an image without adding this helper class.
+Change to the dark theme and a grey background will be present.
 
 .. code-block:: rst
 
@@ -115,7 +117,7 @@ the image without speicfying the helper class:
 .. image:: https://source.unsplash.com/200x200/daily?cute+cat
     :class: p-2
 
-and the same image with it:
+Here's the same image with this class added:
 
 .. code-block:: rst
 

--- a/docs/user_guide/light-dark.rst
+++ b/docs/user_guide/light-dark.rst
@@ -100,6 +100,29 @@ Change the theme and a new image should be displayed.
 .. image:: https://source.unsplash.com/200x200/daily?cute+dog
     :class: only-light
 
+Use non theme-dependent  content
+--------------------------------
+
+by design Pydata-sphinx-theme will add a white background to any image that is not specifying the :code:`only-dark` class when displayed in the dark theme. If your image is suitable for both light and dark theme, please use the following **CSS helper class** :code:`dark-light` to make your image theme agnostic.
+
+the image without speicfying the helper class:
+
+.. code-block:: rst
+
+    .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+
+.. image:: https://source.unsplash.com/200x200/daily?cute+cat
+
+and the same image with it:
+
+.. code-block:: rst
+
+    .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+        :class: dark-light
+
+.. image:: https://source.unsplash.com/200x200/daily?cute+cat
+    :class: dark-light
+
 Define custom JavaScript to react to theme changes
 --------------------------------------------------
 

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -108,10 +108,10 @@ $pst-semantic-colors: (
         filter: brightness(0.8) contrast(1.2);
       }
       /* Give images a light background in dark mode in case they have
-      *  transparency and black text (unless they have class .only-dark, in
+      *  transparency and black text (unless they have class .only-dark or .dark-light, in
       *  which case assume they're already optimized for dark mode).
       */
-      .bd-content img:not(.only-dark) {
+      .bd-content img:not(.only-dark):not(.dark-light) {
         background: rgb(255, 255, 255);
         border-radius: 0.25rem;
       }


### PR DESCRIPTION
Fix #879 

When switching from dark to light theme, image management can become complex. In the current implementation of pydata-sphinx-theme the images that have 0 specifications are added a white background when displayed in dark theme. On the other hand the user can specify a CSS helper class and duplicate its asset to make them look nice in both theme (`.only-dark`, `.only-light`).

As discussed in #879, the most common situation is to have images non optimised for dark background but in some cases, the images can work on both. In this PR I'm adding the `.dark-light` class to setup these image and prevent the addition of the white background. 