### PR TITLE
ENH: Use toctree titles in the header navbar

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -238,16 +238,17 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
 
         # Find the root document because it lists our top-level toctree pages
         root = app.env.tocs[app.config.root_doc]
+
         # Iterate through each toctree node in the root document
         # Grab the toctree pages and find the relative link + title.
         links_html = []
         # Can just use "findall" once docutils min version >=0.18.1
         meth = "findall" if hasattr(root, "findall") else "traverse"
         for toc in getattr(root, meth)(toctree_node):
-            for _, page in toc.attributes["entries"]:
+            for title, page in toc.attributes["entries"]:
                 # If this is the active ancestor page, add a class so we highlight it
                 current = " current active" if page == active_header_page else ""
-                title = app.env.titles[page].astext()
+                title = title if title else app.env.titles[page].astext()
                 links_html.append(
                     f"""
                 <li class="nav-item{current}">


### PR DESCRIPTION
Fix #911 

when building the header navbar titles we were simply using the page title. This title can be overwritten in the toctree directive. In this PR I simply give priority to the overwitten title and use it if set. 

Work as expected on my documentation : 

before:

![](https://user-images.githubusercontent.com/12596392/188171410-540c1614-ba66-404b-a5c8-36bfe4029fd7.png)

after: 

<img width="1206" alt="Capture d’écran 2022-09-06 à 11 36 19" src="https://user-images.githubusercontent.com/12596392/188601383-9dcfa018-b9d4-4afb-9726-233a21140dc6.png">


