### PR TITLE
set the content at the top of the page

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -12,7 +12,7 @@
     justify-content: center;
     height: 100%;
     .bd-article-container {
-      justify-content: space-between;
+      justify-content: start;
       display: flex;
       flex-direction: column;
       // Max-width is slightly more than the W3 since our docs often have images.


### PR DESCRIPTION
Fix #908 
In the current implementation we were using the "space-between"  justification for `.bd-article-container` as there is now a `.bd-header-article` bar as first item, the `.bd-article` is systematically pushed at the bottom of the page.

By using start we ensure that the content is always on top. 