### PR TITLE
use hasdoc() for logo link

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -1,9 +1,9 @@
 {% if not theme_logo.get("link") %}
   {% set href = pathto(root_doc) %}
-{% elif theme_logo.get("link").startswith("http") %}
-  {% set href = theme_logo.get("link") %} {# external url #}
-{% else %}
+{% elif hasdoc(theme_logo.get("link")) %}
   {% set href = pathto(theme_logo.get("link")) %} {# internal page #}
+{% else %}
+  {% set href = theme_logo.get("link") %} {# external url #}
 {% endif %}
 
 <a class="navbar-brand logo" href="{{ href }}">


### PR DESCRIPTION
closes #912 

@datapythonista can you test with this branch? Locally I tested:

- `link="https://google.com"` (works)
- `link="user_guide/install"` (works; resolves to http://127.0.0.1:39645/user_guide/install.html)
- `link="/"` (resolves to http://127.0.0.1:39645/, AKA `localhost:port`)
- `link="/foo"` (resolves to http://127.0.0.1:39645/foo)

...but I don't have an easy way to test your setup (sphinx root is not `/` but rather `/docs/`, and you want logo to link to `/`).