### PR TITLE
ENH: Use bootstrap tooltip to display icons title

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -360,4 +360,4 @@ $(addModeListener);
 $(scrollToActive);
 $(addTOCInteractivity);
 $(setupSearchButtons);
-$('[data-toggle="tooltip"]').tooltip();
+$('[data-toggle="tooltip"]').tooltip({ delay: { show: 500, hide: 100 } });

--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -360,3 +360,4 @@ $(addModeListener);
 $(scrollToActive);
 $(addTOCInteractivity);
 $(setupSearchButtons);
+$('[data-toggle="tooltip"]').tooltip();

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -1,7 +1,7 @@
 {%- macro icon_link_nav_item(url, icon, name, type, attributes='') -%}
   {%- if url | length > 2 %}
         <li class="nav-item">
-          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link", "rel": "noopener", "target": "_blank" } %}
+          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link", "rel": "noopener", "target": "_blank", "data-toggle": "tooltip"} %}
           {%- if attributes %}{% for key, val in attributes.items() %}
             {% set _ = attributesDefault.update(attributes) %}
           {% endfor %}{% endif -%}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -1,7 +1,7 @@
 {%- macro icon_link_nav_item(url, icon, name, type, attributes='') -%}
   {%- if url | length > 2 %}
         <li class="nav-item">
-          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link", "rel": "noopener", "target": "_blank", "data-toggle": "tooltip"} %}
+          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link", "rel": "noopener", "target": "_blank", "data-toggle": "tooltip", "data-delay": "500"} %}
           {%- if attributes %}{% for key, val in attributes.items() %}
             {% set _ = attributesDefault.update(attributes) %}
           {% endfor %}{% endif -%}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -1,7 +1,7 @@
 {%- macro icon_link_nav_item(url, icon, name, type, attributes='') -%}
   {%- if url | length > 2 %}
         <li class="nav-item">
-          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link", "rel": "noopener", "target": "_blank", "data-toggle": "tooltip", "data-delay": "500"} %}
+          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link", "rel": "noopener", "target": "_blank", "data-toggle": "tooltip"} %}
           {%- if attributes %}{% for key, val in attributes.items() %}
             {% set _ = attributesDefault.update(attributes) %}
           {% endfor %}{% endif -%}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
@@ -1,4 +1,4 @@
 {# A button that, when clicked, will trigger a search popup overlay #}
-<button class="btn btn-sm navbar-btn search-button search-button__button" title="{{ _('Search') }}" data-toggle="tooltip" data-delay="500">
+<button class="btn btn-sm navbar-btn search-button search-button__button" title="{{ _('Search') }}" data-toggle="tooltip">
   <i class="fas fa-search"></i>
 </button>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
@@ -1,4 +1,4 @@
 {# A button that, when clicked, will trigger a search popup overlay #}
-<button class="btn btn-sm navbar-btn search-button search-button__button" title="{{ _('Search') }}">
+<button class="btn btn-sm navbar-btn search-button search-button__button" title="{{ _('Search') }}" data-toggle="tooltip">
   <i class="fas fa-search"></i>
 </button>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
@@ -1,4 +1,4 @@
 {# A button that, when clicked, will trigger a search popup overlay #}
-<button class="btn btn-sm navbar-btn search-button search-button__button" title="{{ _('Search') }}" data-toggle="tooltip">
+<button class="btn btn-sm navbar-btn search-button search-button__button" title="{{ _('Search') }}" data-toggle="tooltip" data-delay="500">
   <i class="fas fa-search"></i>
 </button>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('dark/light') }}" data-toggle="tooltip">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('light/dark') }}" data-toggle="tooltip">
     <a class="theme-switch" data-mode="light"><i class="fas fa-sun"></i></a>
     <a class="theme-switch" data-mode="dark"><i class="far fa-moon"></i></a>
     <a class="theme-switch" data-mode="auto"><i class="fas fa-adjust"></i></a>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('switch mode') }}" data-toggle="tooltip">
     <a class="theme-switch" data-mode="light"><i class="fas fa-sun"></i></a>
     <a class="theme-switch" data-mode="dark"><i class="far fa-moon"></i></a>
     <a class="theme-switch" data-mode="auto"><i class="fas fa-adjust"></i></a>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('switch mode') }}" data-delay="500" data-toggle="tooltip">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('switch mode') }}" data-toggle="tooltip">
     <a class="theme-switch" data-mode="light"><i class="fas fa-sun"></i></a>
     <a class="theme-switch" data-mode="dark"><i class="far fa-moon"></i></a>
     <a class="theme-switch" data-mode="auto"><i class="fas fa-adjust"></i></a>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('switch mode') }}" data-toggle="tooltip">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('switch mode') }}" data-delay="500" data-toggle="tooltip">
     <a class="theme-switch" data-mode="light"><i class="fas fa-sun"></i></a>
     <a class="theme-switch" data-mode="dark"><i class="far fa-moon"></i></a>
     <a class="theme-switch" data-mode="auto"><i class="fas fa-adjust"></i></a>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('switch mode') }}" data-toggle="tooltip">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="{{ _('dark/light') }}" data-toggle="tooltip">
     <a class="theme-switch" data-mode="light"><i class="fas fa-sun"></i></a>
     <a class="theme-switch" data-mode="dark"><i class="far fa-moon"></i></a>
     <a class="theme-switch" data-mode="auto"><i class="fas fa-adjust"></i></a>

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -39,7 +39,7 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="overridden classes" foo="bar" data-toggle="tooltip" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="overridden classes" fdata-toggle="tooltip" oo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -39,7 +39,7 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="overridden classes" fdata-toggle="tooltip" oo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="overridden classes" data-toggle="tooltip" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -1,6 +1,6 @@
 <ul aria-label="Icon Links" class="navbar-nav" id="navbar-icon-links">
  <li class="nav-item">
-  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="nav-link" data-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>
@@ -11,7 +11,7 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
+  <a class="nav-link" data-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
    <span>
     <i class="FADEFAULTCLASS">
     </i>
@@ -22,24 +22,24 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
+  <a class="nav-link" data-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
    <img alt="LOCAL FILE" class="icon-link-image" src="emptylogo.png"/>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
+  <a class="nav-link" data-toggle="tooltip" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
    <span>
     Incorrectly configured icon link. Type must be `fontawesome`, `url` or `local`.
    </span>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
+  <a class="nav-link" data-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
    <img alt="URL" class="icon-link-image" src="https://site5.org/image.svg"/>
   </a>
  </li>
  <li class="nav-item">
-  <a class="overridden classes" data-delay="500" data-toggle="tooltip" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="overridden classes" data-toggle="tooltip" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -1,6 +1,6 @@
 <ul aria-label="Icon Links" class="navbar-nav" id="navbar-icon-links">
  <li class="nav-item">
-  <a class="nav-link" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="nav-link" data-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>
@@ -11,7 +11,7 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
+  <a class="nav-link" data-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
    <span>
     <i class="FADEFAULTCLASS">
     </i>
@@ -22,24 +22,24 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
+  <a class="nav-link" data-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
    <img alt="LOCAL FILE" class="icon-link-image" src="emptylogo.png"/>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
+  <a class="nav-link" data-toggle="tooltip" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
    <span>
     Incorrectly configured icon link. Type must be `fontawesome`, `url` or `local`.
    </span>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" href="https://site5.org" rel="noopener" target="_blank" title="URL">
+  <a class="nav-link" data-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
    <img alt="URL" class="icon-link-image" src="https://site5.org/image.svg"/>
   </a>
  </li>
  <li class="nav-item">
-  <a class="overridden classes" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="overridden classes" foo="bar" data-toggle="tooltip" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -1,6 +1,6 @@
 <ul aria-label="Icon Links" class="navbar-nav" id="navbar-icon-links">
  <li class="nav-item">
-  <a class="nav-link" data-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>
@@ -11,7 +11,7 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
+  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
    <span>
     <i class="FADEFAULTCLASS">
     </i>
@@ -22,24 +22,24 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
+  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
    <img alt="LOCAL FILE" class="icon-link-image" src="emptylogo.png"/>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-toggle="tooltip" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
+  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
    <span>
     Incorrectly configured icon link. Type must be `fontawesome`, `url` or `local`.
    </span>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
+  <a class="nav-link" data-delay="500" data-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
    <img alt="URL" class="icon-link-image" src="https://site5.org/image.svg"/>
   </a>
  </li>
  <li class="nav-item">
-  <a class="overridden classes" data-toggle="tooltip" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="overridden classes" data-delay="500" data-toggle="tooltip" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i class="FACLASS">
     </i>

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="switch mode">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="light/dark">
  <a class="theme-switch" data-mode="light">
   <i class="fas fa-sun">
   </i>

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="switch mode">
  <a class="theme-switch" data-mode="light">
   <i class="fas fa-sun">
   </i>

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-delay="500" data-toggle="tooltip" title="light/dark">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="light/dark">
  <a class="theme-switch" data-mode="light">
   <i class="fas fa-sun">
   </i>

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,4 +1,4 @@
-<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="light/dark">
+<span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-delay="500" data-toggle="tooltip" title="light/dark">
  <a class="theme-switch" data-mode="light">
   <i class="fas fa-sun">
   </i>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -28,7 +28,7 @@
   </div>
   <div class="sidebar-header-items__end">
    <div class="navbar-end-item">
-    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="switch mode">
+    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="light/dark">
      <a class="theme-switch" data-mode="light">
       <i class="fas fa-sun">
       </i>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -28,7 +28,7 @@
   </div>
   <div class="sidebar-header-items__end">
    <div class="navbar-end-item">
-    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-delay="500" data-toggle="tooltip" title="light/dark">
+    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="light/dark">
      <a class="theme-switch" data-mode="light">
       <i class="fas fa-sun">
       </i>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -28,7 +28,7 @@
   </div>
   <div class="sidebar-header-items__end">
    <div class="navbar-end-item">
-    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="light/dark">
+    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-delay="500" data-toggle="tooltip" title="light/dark">
      <a class="theme-switch" data-mode="light">
       <i class="fas fa-sun">
       </i>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -28,7 +28,7 @@
   </div>
   <div class="sidebar-header-items__end">
    <div class="navbar-end-item">
-    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle">
+    <span class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" data-toggle="tooltip" title="switch mode">
      <a class="theme-switch" data-mode="light">
       <i class="fas fa-sun">
       </i>


### PR DESCRIPTION
Fix #920 

From a design point of view that's a bad practice to use icons without title as it leave the user interprete what the icon is for. Even if we use stadards of the web it's better to be on the safe side. 

Titles where already set for the generated icons but missing for the search and theme switcher. 

I also changed their design simply by activating the bootstrap tooltip instead if relying on browser display. 

 
<img width="1209" alt="Capture d’écran 2022-09-11 à 14 34 43" src="https://user-images.githubusercontent.com/12596392/189528007-d7d3250a-efe3-4f4a-88f8-826b9538cf96.png">

<img width="1211" alt="Capture d’écran 2022-09-11 à 14 34 51" src="https://user-images.githubusercontent.com/12596392/189528046-76697a03-d9de-482e-831d-6afc46e4351d.png">


<img width="1210" alt="Capture d’écran 2022-09-11 à 14 35 00" src="https://user-images.githubusercontent.com/12596392/189528072-4918162f-f873-416b-9ee9-817cf2ac30f8.png">
