### PR TITLE
Add expected pandas 1.5 warning

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,7 +43,7 @@ jobs:
 
           text = Path("./warnings.txt").read_text().strip()
           print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
-          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["kitchen-sink", "_static", "parse.py"])]
+          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["frame.py", "_static", "parse.py"])]
           print("\n=== Unexpected Warnings ===\n\n" + "\n".join(unexpected))
 
           env_file = os.getenv('GITHUB_ENV')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
           from pathlib import Path
           text = Path("./warnings.txt").read_text().strip()
           print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
-          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["kitchen-sink", "_static", "parse.py"])]
+          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["frame.py", "_static", "parse.py"])]
           for ii in unexpected:
             print(f"Unexpected warning: \n{unexpected}\n\n")
           assert len(unexpected) == 0


### PR DESCRIPTION
Close #935. I didn't see any kitchen-sink warnings, so I replaced ` kitchen-sink` with `frame.py` in  `.github/workflows/test.yml` and `.github/workflows/prerelease.yml`.