### PR TITLE
FIX: use parent when self is use in a toctree

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -247,9 +247,14 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
         meth = "findall" if hasattr(root, "findall") else "traverse"
         for toc in getattr(root, meth)(toctree_node):
             for title, page in toc.attributes["entries"]:
+                # if the page is self use the coorect link
+                page = toc.attributes["parent"] if page == "self" else page
+
                 # If this is the active ancestor page, add a class so we highlight it
                 current = " current active" if page == active_header_page else ""
                 title = title if title else app.env.titles[page].astext()
+
+                # create the html output
                 links_html.append(
                     f"""
                 <li class="nav-item{current}">

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -247,7 +247,7 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
         meth = "findall" if hasattr(root, "findall") else "traverse"
         for toc in getattr(root, meth)(toctree_node):
             for title, page in toc.attributes["entries"]:
-                # if the page is self use the coorect link
+                # if the page is using "self" use the correct link
                 page = toc.attributes["parent"] if page == "self" else page
 
                 # If this is the active ancestor page, add a class so we highlight it


### PR DESCRIPTION
Fix #926 

When self is used in a header navbar toctree, whe search for the parent of the toctree (so that the link is the same for every page) and we use it as a page key instead of the set `self` to search for the path.
