### PR TITLE
Build wheels for testing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install (prerelease) dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel setuptools
           python -m pip install --upgrade --pre -e .[test]
 
       - name: Build docs to store

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip wheel setuptools
           python -m pip install -e .[coverage]
 
       - name: Build docs to store


### PR DESCRIPTION
This should fix this error:
```
ERROR: Could not build wheels for pydata-sphinx-theme, which is required to install pyproject.toml-based projects
```

See #934.