### PR TITLE
better document how to remove secondary sidebar

### DIFF
--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -374,7 +374,7 @@ By default, it has the following templates:
       ...
     }
 
-To learn how to further customize or remove the secondary sidebar, please check :ref:`page-toc`.
+To learn how to further customize or remove the secondary sidebar, please check :doc:`page-toc`.
 
 .. _layout-article-footer:
 

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -374,6 +374,8 @@ By default, it has the following templates:
       ...
     }
 
+To learn how to further customize or remove the secondary sidebar, please check :ref:`page-toc`.
+
 .. _layout-article-footer:
 
 Article Footer


### PR DESCRIPTION
Fix #869 

My idea is that a user that want to get rid of the secondary sidebar will first check the layout and the layout page will lead to the page-toc specific page. 

happy to hear your thoughts