### PR TITLE
Align all the columns on the primary sidebar

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -24,7 +24,7 @@
       .bd-article {
         // Give a bit more verticle spacing on wide screens
         @include media-breakpoint-up($breakpoint-sidebar-secondary) {
-          padding-top: 1rem;
+          padding-top: 1.5rem;
           padding-left: 2rem;
         }
       }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -24,7 +24,7 @@
       .bd-article {
         // Give a bit more verticle spacing on wide screens
         @include media-breakpoint-up($breakpoint-sidebar-secondary) {
-          padding-top: 2rem;
+          padding-top: 1rem;
           padding-left: 2rem;
         }
       }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -25,7 +25,6 @@
 
   .onthispage {
     color: var(--pst-color-text-base);
-    //font-size: var(--pst-sidebar-header-font-size);
     font-weight: var(--pst-sidebar-header-font-weight);
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -25,6 +25,8 @@
 
   .onthispage {
     color: var(--pst-color-text-base);
+    //font-size: var(--pst-sidebar-header-font-size);
+    font-weight: var(--pst-sidebar-header-font-weight);
   }
 
   @include scrollbar-style();
@@ -32,7 +34,7 @@
 
 // Each TOC item is wrapped in this
 .toc-item {
-  padding: 0.3rem 0.5rem;
+  padding: 0.5rem 0.5rem;
   @include media-breakpoint-up($breakpoint-sidebar-secondary) {
     border-left: 1px solid var(--pst-color-border);
     padding-left: 1rem;


### PR DESCRIPTION
Fix #930 

I decided to align everything on the primary sidebar. The text starts at 1.5 rem in total. 
I also changed the weight of the on-this-page link.

<img width="1217" alt="Capture d’écran 2022-09-27 à 12 05 34" src="https://user-images.githubusercontent.com/12596392/192498285-9dec923c-f632-443b-b78e-e4c03f74577e.png">
