### PR TITLE
align the icons in the navbar-end

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -75,7 +75,7 @@
 }
 .search-button__wrapper.show {
   .search-button__search-container {
-    display: flex;
+    display: inline-block;
     // Center in middle of screen just underneath header
     position: fixed;
     z-index: $zindex-modal;

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -2,8 +2,6 @@
 .theme-switch-button {
   // overide bootstrap settings
   border-color: var(--pst-color-on-background);
-  // Size is a bit smaller because the background shadow is bigger
-  font-size: calc(var(--pst-font-size-icon) - 0.1rem);
   margin: 0 -0.5rem;
   padding: 0; // We pad the `a` not the container
 
@@ -21,11 +19,8 @@
   &:hover,
   &:active {
     // overide bootstrap settings
-    background-color: var(--pst-color-on-surface) !important;
+    background-color: var(--pst-color-on-background) !important;
     border-color: var(--pst-color-on-background) !important;
-    a {
-      color: var(--pst-color-text-muted);
-    }
   }
 }
 


### PR DESCRIPTION
Fix #928 

The search and theme switcher were special-cased in wide screens. 
This PR ensures that if a high number of icons are set in the navbar-end

<img width="280" alt="Capture d’écran 2022-09-27 à 12 33 30" src="https://user-images.githubusercontent.com/12596392/192503766-b54be7b2-fe63-4786-8776-53326f0b3efd.png">
