### PR TITLE
fix: improve display of table in the nbsphinx context

### DIFF
--- a/docs/examples/pydata.md
+++ b/docs/examples/pydata.md
@@ -25,8 +25,8 @@ import numpy as np
 import pandas as pd
 
 rng = np.random.default_rng()
-data = rng.standard_normal((100, 3))
-df = pd.DataFrame(data, columns=['a', 'b', 'c'])
+data = rng.standard_normal((100, 26))
+df = pd.DataFrame(data, columns=list(string.ascii_lowercase))
 df
 ```
 

--- a/docs/examples/pydata.md
+++ b/docs/examples/pydata.md
@@ -21,6 +21,8 @@ Below are examples of each that we use as a benchmark for reference.
 ## Pandas
 
 ```{code-cell}
+import string
+
 import numpy as np
 import pandas as pd
 

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_pydata.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_pydata.scss
@@ -6,3 +6,12 @@
 .xr-wrap[hidden] {
   display: block !important;
 }
+
+/**
+ * special case for table rendered via nbsphinx
+ */
+.rendered_html {
+  table {
+    table-layout: auto;
+  }
+}


### PR DESCRIPTION
Fix #933 

I force the table-layout to auto when the table is nested in a `.html_render` class
I updated the width of the pandas exampe to check to display

@taylorm0192, @JoerivanEngelen, @jesnie could you confirm that it solves the issue from you side as well ? I cheked the example you gave and the classes embedding the table were quite different than ours. 