### PR TITLE
Support notoc metadata

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-secondary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-secondary.html
@@ -1,5 +1,7 @@
+{% if meta is defined and not (meta is not none and 'notoc' in meta) %}
 {% for toc_item in theme_page_sidebar_items %}
 <div class="toc-item">
   {% include toc_item %}
 </div>
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
With https://github.com/numpy/numpydoc/pull/434 this closes #955.

@jorisvandenbossche are you still using this previously undocumented feature for pandas? Should we document it (it seems useful)?