### PR TITLE
FIX: use target color for footnotes

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_footnotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_footnotes.scss
@@ -24,4 +24,8 @@ aside.footnote {
   span.backrefs {
     font-weight: bold;
   }
+
+  &:target {
+    background-color: var(--pst-color-target);
+  }
 }


### PR DESCRIPTION
FIx #960 

It was still set by the `base.css` file

dark theme 

<img width="633" alt="Capture d’écran 2022-09-29 à 09 16 12" src="https://user-images.githubusercontent.com/12596392/192965294-dd830715-526e-4c9f-ac22-75a4f12fba55.png">

light theme

<img width="622" alt="Capture d’écran 2022-09-29 à 09 16 24" src="https://user-images.githubusercontent.com/12596392/192965339-5d355c09-d2b8-450b-92f0-bc055e641cdb.png">
