### PR TITLE
FIX: expand the bd-article-container

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -18,6 +18,7 @@
       // Max-width is slightly more than the W3 since our docs often have images.
       // We shoot for about 100 characters per line instead of 80.
       // ref: https://www.w3.org/WAI/tutorials/page-structure/styling/#line-length
+      width: 100%;
       max-width: 60em;
       overflow-x: auto; // Prevent wide content from pushing off the secondary sidebar
       padding: 1rem;


### PR DESCRIPTION
Fix #904, Fix #140 

I simply expanded the width to the max possible width: 60em 

before: 

<img width="1622" alt="Capture d’écran 2022-09-29 à 19 41 32" src="https://user-images.githubusercontent.com/12596392/193105892-4f290767-4420-439a-aeff-f27eaf3cc63f.png">

after:

<img width="1502" alt="Capture d’écran 2022-09-29 à 19 49 07" src="https://user-images.githubusercontent.com/12596392/193106004-183b503b-9fb0-4c8e-9020-7fe2d486c75b.png">

it remains at the correct width (60em) on wide screens: 

<img width="2245" alt="Capture d’écran 2022-09-29 à 19 49 16" src="https://user-images.githubusercontent.com/12596392/193106135-de068f15-62b0-40b3-ab93-968aa38e934c.png">

