### PR TITLE
FIX: do not prettify primary sidebar html

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -395,12 +395,8 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
                     f"li.toctree-l{ii} > input.toctree-checkbox"
                 ):
                     checkbox.attrs["checked"] = None
-            out = soup.prettify()
 
-        elif kind == "raw":
-            out = soup
-
-        return out
+        return soup
 
     @lru_cache(maxsize=None)
     def generate_toc_html(kind="html"):
@@ -661,6 +657,7 @@ def soup_to_python(soup, only_pages=False):
     navs = []
     for ul in soup.find_all("ul", recursive=False):
         extract_level_recursive(ul, navs)
+
     return navs
 
 


### PR DESCRIPTION
Fix #929 

same explaination as in my comment in the issue: 

it seems that the problem is related to how we build the sidebar itself. 

the generated html is: 
```html
<ul class="current nav bd-sidenav">
 <li class="toctree-l1">
  <a class="reference internal" href="page1.html">
   <cite>
    test
   </cite>
   .test
  </a>
 </li>
 <li class="toctree-l1 current active">
  <a class="current reference internal" href="#">
   test
  </a>
 </li>
</ul>
```

for the specific `li` "test.test" this is interpreted by my browser (and apparently yours) as:
```html
<li class="toctree-l1">
  <a class="reference internal" href="page1.html">
    <cite> test </cite>
    " .test "
  </a>
</li>
```

which look like this: 

<img width="162" alt="Capture d’écran 2022-09-29 à 21 47 56" src="https://user-images.githubusercontent.com/12596392/193128067-4343dab8-7b5e-4522-9d3b-59c5ecac31bd.png">

This piece of code is generated by this function https://github.com/pydata/pydata-sphinx-theme/blob/8d32801b1d6fecfce87ed80aa52693e69e379eb1/src/pydata_sphinx_theme/__init__.py#L309. I did some testing and it seems that removing the prettify() function from beautifulsoup is solving the problem as the output becomes: 

```html
<ul class="current nav bd-sidenav">
<li class="toctree-l1"><a class="reference internal" href="page1.html"><cite>test</cite>.test</a></li>
<li class="toctree-l1 current active"><a class="current reference internal" href="#">test</a></li>
</ul>
```

which look like:

<img width="172" alt="Capture d’écran 2022-09-29 à 21 48 28" src="https://user-images.githubusercontent.com/12596392/193128212-e0b2b4f7-fa26-45bb-93f2-e7f194ace466.png">
