### PR TITLE
FIX: respect the align and width parameter of table directives

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -10,6 +10,19 @@ table {
   overflow: auto;
 
   @include scrollbar-style();
+
+  &.align-center {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  &.align-right {
+    margin-right: 0;
+  }
+
+  &.align-left {
+    margin-left: 0;
+  }
 }
 
 // customize table caption from bootstrap

--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -11,16 +11,15 @@ table {
 
   @include scrollbar-style();
 
-  &.align-center {
-    margin-left: auto;
-    margin-right: auto;
-  }
+  // default to table-center
+  margin-left: auto;
+  margin-right: auto;
 
-  &.align-right {
+  &.table-right {
     margin-right: 0;
   }
 
-  &.align-left {
+  &.table-left {
     margin-left: 0;
   }
 }

--- a/src/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/src/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -1,7 +1,6 @@
 """A custom Sphinx HTML Translator for Bootstrap layout
 """
 from packaging.version import Version
-from docutils import nodes
 
 import sphinx
 from sphinx.writers.html5 import HTML5Translator
@@ -29,9 +28,13 @@ class BootstrapHTML5Translator(HTML5Translator):
         return super().starttag(*args, **kwargs)
 
     def visit_table(self, node):
-        # type: (nodes.Element) -> None
-        # copy of sphinx source to *not* add 'docutils' and 'align-default' classes
-        # but add 'table' class
+        """
+        copy of sphinx source to *not* add 'docutils' and 'align-default' classes
+        but add 'table' class
+        """
+
+        # init the attributes
+        atts = {}
 
         # generate_targets_for_table is deprecated in 4.0
         if Version(sphinx.__version__) < Version("4.0"):
@@ -42,14 +45,19 @@ class BootstrapHTML5Translator(HTML5Translator):
         else:
             self._table_row_indices.append(0)
 
+        # get the classes
         classes = [cls.strip(" \t\n") for cls in self.settings.table_style.split(",")]
 
         # we're looking at the 'real_table', which is wrapped by an autosummary
         if isinstance(node.parent, autosummary_table):
             classes += ["autosummary"]
 
+        # add the width if set in a style attribute
+        if "width" in node:
+            atts["style"] = f'width: {node["width"]}'
+
         # classes.insert(0, "docutils")  # compat
         # if 'align' in node:
         #     classes.append('align-%s' % node['align'])
-        tag = self.starttag(node, "table", CLASS=" ".join(classes))
+        tag = self.starttag(node, "table", CLASS=" ".join(classes), **atts)
         self.body.append(tag)

--- a/src/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/src/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -56,8 +56,9 @@ class BootstrapHTML5Translator(HTML5Translator):
         if "width" in node:
             atts["style"] = f'width: {node["width"]}'
 
-        # classes.insert(0, "docutils")  # compat
-        # if 'align' in node:
-        #     classes.append('align-%s' % node['align'])
+        # add specific class if align is set
+        if "align" in node:
+            classes.append(f'align-{node["align"]}')
+
         tag = self.starttag(node, "table", CLASS=" ".join(classes), **atts)
         self.body.append(tag)

--- a/src/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/src/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -58,7 +58,7 @@ class BootstrapHTML5Translator(HTML5Translator):
 
         # add specific class if align is set
         if "align" in node:
-            classes.append(f'align-{node["align"]}')
+            classes.append(f'table-{node["align"]}')
 
         tag = self.starttag(node, "table", CLASS=" ".join(classes), **atts)
         self.body.append(tag)


### PR DESCRIPTION
Fix #524 

simply add back some rules on both css and python side.

![test — test 0 0 0 documentation](https://user-images.githubusercontent.com/12596392/193443643-09c88d08-7310-4853-9878-60e062db45f4.png)

