### PR TITLE
DOCS: Fixed file path of logos

### DIFF
--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -16,7 +16,7 @@ To use a local image file, put an image in a folder that is in `html_static_path
 .. code:: python
 
    html_static_path = ["_static"]
-   html_logo = "_static/logo.png"
+   html_logo = "logo.png"
 
 To use an external link to an image, make sure the ``html_logo`` begins with ``http``.
 For example:


### PR DESCRIPTION
Compare: https://github.com/pydata/pydata-sphinx-theme/issues/967.
`_static` was incorrectly prefixed to the `html_logo` variable.