### PR TITLE
Fix for publishing prereleases

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ if not version_match or version_match.isdigit():
         version_match = "latest"
         # We want to keep the relative reference if we are in dev mode
         # but we want the whole url if we are effectively in a released version
-        json_url = "/_static/switcher.json"
+        json_url = "_static/switcher.json"
     else:
         version_match = "v" + release
 


### PR DESCRIPTION
Fix #973.

This should fix https://github.com/pydata/pydata-sphinx-theme/actions/runs/3182801089.

I tested on my laptop and it works. I am not sure if the leading slash is ever needed. The tests pass when it is removed, but I am not sure why it was there to begin with.

```
In [1]: from pathlib import Path

In [2]: srcdir = '/home/jarrod/src/pydata-sphinx-theme'

In [3]: json_url = '/_static/switcher.json'

In [4]: Path(srcdir, json_url)
Out[4]: PosixPath('/_static/switcher.json')

In [5]: json_url = '_static/switcher.json'

In [6]: Path(srcdir, json_url)
Out[6]: PosixPath('/home/jarrod/src/pydata-sphinx-theme/_static/switcher.json')
```

The error is triggered in `src/pydata_sphinx_theme/__init__.py` here:
```
        if urlparse(json_url).scheme in ["http", "https"]:
            content = requests.get(json_url).text
        else:
            content = Path(env.srcdir, json_url).read_text()
```
when `Path(env.srcdir, json_url).read_text()` sets `content` to `'/_static/switcher.json` instead of something like `/home/jarrod/src/pydata-sphinx-theme/_static/switcher.json`.