### PR TITLE
Test on different versions of sphinx

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,53 +24,53 @@ jobs:
           cache-dependency-path: "pyproject.toml"
       - uses: pre-commit/action@v3.0.0
 
-  tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
-        include:
-          - os: macos-latest
-            python-version: "3.9"
-          - os: windows-latest
-            python-version: "3.9"
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install -e .[coverage]
-
-      - name: Build docs to store
-        run: sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
-
-      - name: Check that there are no unexpected Sphinx warnings
-        if: matrix.python-version == '3.9'
-        shell: python
-        run: |
-          from pathlib import Path
-          text = Path("./warnings.txt").read_text().strip()
-          print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
-          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["frame.py", "_static", "parse.py"])]
-          for ii in unexpected:
-            print(f"Unexpected warning: \n{unexpected}\n\n")
-          assert len(unexpected) == 0
-
-      - name: Run the tests
-        run: pytest --color=yes --cov pydata_sphinx_theme --cov-branch --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
-
-      - name: Upload coverage
-        if: ${{ always() }}
-        run: codecov
+#  tests:
+#    runs-on: ${{ matrix.os }}
+#    strategy:
+#      matrix:
+#        os: [ubuntu-latest]
+#        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+#        include:
+#          - os: macos-latest
+#            python-version: "3.9"
+#          - os: windows-latest
+#            python-version: "3.9"
+#
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: Set up Python ${{ matrix.python-version }}
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#          cache: "pip"
+#          cache-dependency-path: "pyproject.toml"
+#
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install --upgrade pip wheel setuptools
+#          python -m pip install -e .[coverage]
+#
+#      - name: Build docs to store
+#        run: sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
+#
+#      - name: Check that there are no unexpected Sphinx warnings
+#        if: matrix.python-version == '3.9'
+#        shell: python
+#        run: |
+#          from pathlib import Path
+#          text = Path("./warnings.txt").read_text().strip()
+#          print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
+#          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["frame.py", "_static", "parse.py"])]
+#          for ii in unexpected:
+#            print(f"Unexpected warning: \n{unexpected}\n\n")
+#          assert len(unexpected) == 0
+#
+#      - name: Run the tests
+#        run: pytest --color=yes --cov pydata_sphinx_theme --cov-branch --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
+#
+#      - name: Upload coverage
+#        if: ${{ always() }}
+#        run: codecov
 
   sphinx-versions:
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         sphinx-version:
-          ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.3", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         sphinx-version:
-          ["sphinx==4.3", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.4", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,53 +24,53 @@ jobs:
           cache-dependency-path: "pyproject.toml"
       - uses: pre-commit/action@v3.0.0
 
-#  tests:
-#    runs-on: ${{ matrix.os }}
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest]
-#        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
-#        include:
-#          - os: macos-latest
-#            python-version: "3.9"
-#          - os: windows-latest
-#            python-version: "3.9"
-#
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: Set up Python ${{ matrix.python-version }}
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: ${{ matrix.python-version }}
-#          cache: "pip"
-#          cache-dependency-path: "pyproject.toml"
-#
-#      - name: Install dependencies
-#        run: |
-#          python -m pip install --upgrade pip wheel setuptools
-#          python -m pip install -e .[coverage]
-#
-#      - name: Build docs to store
-#        run: sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
-#
-#      - name: Check that there are no unexpected Sphinx warnings
-#        if: matrix.python-version == '3.9'
-#        shell: python
-#        run: |
-#          from pathlib import Path
-#          text = Path("./warnings.txt").read_text().strip()
-#          print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
-#          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["frame.py", "_static", "parse.py"])]
-#          for ii in unexpected:
-#            print(f"Unexpected warning: \n{unexpected}\n\n")
-#          assert len(unexpected) == 0
-#
-#      - name: Run the tests
-#        run: pytest --color=yes --cov pydata_sphinx_theme --cov-branch --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
-#
-#      - name: Upload coverage
-#        if: ${{ always() }}
-#        run: codecov
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        include:
+          - os: macos-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.9"
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install -e .[coverage]
+
+      - name: Build docs to store
+        run: sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
+
+      - name: Check that there are no unexpected Sphinx warnings
+        if: matrix.python-version == '3.9'
+        shell: python
+        run: |
+          from pathlib import Path
+          text = Path("./warnings.txt").read_text().strip()
+          print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
+          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["frame.py", "_static", "parse.py"])]
+          for ii in unexpected:
+            print(f"Unexpected warning: \n{unexpected}\n\n")
+          assert len(unexpected) == 0
+
+      - name: Run the tests
+        run: pytest --color=yes --cov pydata_sphinx_theme --cov-branch --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
+
+      - name: Upload coverage
+        if: ${{ always() }}
+        run: codecov
 
   sphinx-versions:
     runs-on: ubuntu-latest
@@ -78,7 +78,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         sphinx-version:
-          ["sphinx==4.4", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,45 @@ jobs:
         if: ${{ always() }}
         run: codecov
 
+  sphinx-versions:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+        sphinx-version:
+          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install -e .[coverage]
+          python -m pip install ${{ matrix.sphinx-version }}
+          python -m pip list
+      - name: Build docs to store
+        run: sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
+      - name: Check that there are no unexpected Sphinx warnings
+        shell: python
+        run: |
+          from pathlib import Path
+          text = Path("./warnings.txt").read_text().strip()
+          print("\n=== Sphinx Warnings ===\n\n" + text)  # Print just for reference so we can look at the logs
+          unexpected = [ii for ii in text.split("\n") if all(i not in ii for i in ["frame.py", "_static", "parse.py"])]
+          for ii in unexpected:
+            print(f"Unexpected warning: \n{unexpected}\n\n")
+          assert len(unexpected) == 0
+      - name: Run the tests
+        run: pytest --color=yes --cov pydata_sphinx_theme --cov-branch --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
+      - name: Upload coverage
+        if: ${{ always() }}
+        run: codecov
+
   # Run local Lighthouse audit against built site
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         sphinx-version:
-          ["sphinx==4.0.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
+          ["sphinx==4.2", "sphinx==4.5", "sphinx==5.0", "sphinx>=5.0"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -853,6 +853,18 @@ def _overwrite_pygments_css(app, exception=None):
 # ------------------------------------------------------------------------------
 
 
+def _traverse_or_findall(node, condition, **kwargs):
+    """Triage node.traverse (docutils <0.18.1) vs node.findall.
+    TODO: This check can be removed when the minimum supported docutils version
+    for numpydoc is docutils>=0.18.1
+    """
+    return (
+        node.findall(condition, **kwargs)
+        if hasattr(node, "findall")
+        else node.traverse(condition, **kwargs)
+    )
+
+
 class ShortenLinkTransform(SphinxPostTransform):
     """
     Shorten link when they are coming from github or gitlab and add an extra class to the tag
@@ -874,7 +886,8 @@ class ShortenLinkTransform(SphinxPostTransform):
 
     def run(self, **kwargs):
         matcher = NodeMatcher(nodes.reference)
-        for node in self.document.findall(matcher):
+        # Can just use "findall" once docutils min version >=0.18.1
+        for node in  _traverse_or_findall(self.document, matcher):
             uri = node.attributes.get("refuri")
             text = next(iter(node.children), None)
             # only act if the uri and text are the same


### PR DESCRIPTION
With sphinx==4.0.2, we get this error:
```
Running Sphinx v4.0.2
loading translations [en]... done

Sphinx version error:


Sphinx<4.0.2 is incompatible with Jinja2>=3.1.
If you wish to continue using sphinx<4.0.2 you need to pin Jinja2<3.1.
Error: Process completed with exit code 2.
```

With sphinx==4.2, we get this error:
```
Exception occurred:
  File "/home/runner/work/pydata-sphinx-theme/pydata-sphinx-theme/src/pydata_sphinx_theme/__init__.py", line 877, in run
    for node in self.document.findall(matcher):
AttributeError: 'document' object has no attribute 'findall'
The full traceback has been saved in /tmp/sphinx-err-k1k4rhuc.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
Error: Process completed with exit code 2.
```