### PR TITLE
Support Sphinx 4.2+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install -e .[coverage]
+          python -m pip list
+
+      - name: Test Sphinx==4.2
+        if: matrix.python-version == '3.7'
+        run: |
+          python -m pip install sphinx==4.2
+          python -m pip list
 
       - name: Build docs to store
         run: sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 
 requires-python = ">=3.7"
 dependencies = [
-  "sphinx>=4.0.2",
+  "sphinx>=4.2",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "packaging",


### PR DESCRIPTION
The main branch currently fails on Sphinx <= 4.4. This adds support for Sphinx 4.2--4.3 and tests on Sphinx 4.2. It also make Sphinx 4.2 the minimum supported version of Sphinx.

numpydoc dropped support for Sphinx < 4.2 already.

4.0.2 May 2021
4.1 July 2021
4.2 Sept 2021
4.3 Nov 2021
4.4 Jan 2022 
4.5 March 2022
5.0 May 2022
5.1 July 2022
5.2 Sept 2022

See #977 for more details.