### PR TITLE
fix: remove primary sidebar if empty

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -12,7 +12,7 @@
     includehidden=True,
     titles_only=True)
 -%}
-{% if not sidebar_nav_html %}
+{% if sidebar_nav_html | length < 1 %}
 {% set sidebars = sidebars | reject("in", "sidebar-nav-bs.html") | list %}
 {% endif %}
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -12,12 +12,12 @@
     includehidden=True,
     titles_only=True)
 -%}
-{% if sidebar_nav_html | length < 1 %}
+{% if sidebar_nav_html | length == 0 %}
 {% set sidebars = sidebars | reject("in", "sidebar-nav-bs.html") | list %}
 {% endif %}
 
 {# Remove the page-toc from secondary sidebar if there are no links to show #}
-{% if generate_toc_html() | length < 1 %}
+{% if generate_toc_html() | length == 0 %}
 {% set theme_page_sidebar_items = theme_page_sidebar_items | reject("in", "page-toc.html") | list %}
 {% endif %}
 


### PR DESCRIPTION
Fix #976 

I think the jinja test was a bit too lazy. here I test the length of the links list. if 0 I don't display it