### PR TITLE
FIX: improve display of "side" docstring title

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_api.scss
@@ -118,4 +118,5 @@ dt.field-odd,
 dt.field-even {
   margin-top: 0.2rem;
   margin-bottom: 0.1rem;
+  background-color: var(--pst-color-surface);
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_api.scss
@@ -109,14 +109,22 @@ span.highlighted {
 * Styling for autosummary titles like "parameters" and "returns"
 */
 
-dl.field-list {
-  display: grid;
-  grid-template-columns: unset;
-}
+// the API selector
+// from https://github.com/pradyunsg/furo/blob/main/src/furo/assets/styles/content/_api.sass#L6)
+dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) {
+  dd {
+    margin-left: 2rem;
+  }
 
-dt.field-odd,
-dt.field-even {
-  margin-top: 0.2rem;
-  margin-bottom: 0.1rem;
-  background-color: var(--pst-color-surface);
+  dl.field-list {
+    display: grid;
+    grid-template-columns: unset;
+  }
+
+  dt.field-odd,
+  dt.field-even {
+    margin-top: 0.2rem;
+    margin-bottom: 0.1rem;
+    background-color: var(--pst-color-surface);
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_api.scss
@@ -1,8 +1,8 @@
 // Style API docs from sphinx' autodoc / autosummary
 
-/**
- * Styling for field lists
- */
+/*******************************************************************************
+* Styling for field lists
+*/
 
 /* grey highlighting of 'parameter' and 'returns' field */
 table.field-list {
@@ -35,7 +35,7 @@ table.field-list {
   }
 }
 
-/**
+/*******************************************************************************
 * Styling for autosummary tables
 */
 
@@ -103,4 +103,19 @@ span.highlighted {
   border-bottom: 1px solid var(--pst-color-border);
   position: relative;
   background-color: var(--pst-color-target);
+}
+
+/*******************************************************************************
+* Styling for autosummary titles like "parameters" and "returns"
+*/
+
+dl.field-list {
+  display: grid;
+  grid-template-columns: unset;
+}
+
+dt.field-odd,
+dt.field-even {
+  margin-top: 0.2rem;
+  margin-bottom: 0.1rem;
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_lists.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_lists.scss
@@ -5,13 +5,6 @@ dd {
   margin-left: 30px;
 }
 
-// Prevent field lists from stretching too much on narrow screens
-// ref: https://css-tricks.com/preventing-a-grid-blowout/
-dl.field-list {
-  display: grid;
-  grid-template-columns: fit-content(30%) minmax(0, 1fr);
-}
-
 ol li > p:first-child,
 ul li > p:first-child {
   margin-bottom: 0.25rem;


### PR DESCRIPTION
Fix #464 

There was already an attempt to solve this issue here: https://github.com/pydata/pydata-sphinx-theme/blob/5d52d4e1319a661c359caf8dddfc65f1de1a465a/src/pydata_sphinx_theme/assets/styles/content/_lists.scss#L12

We were still loosing a lot of real estate on small screen and for long title there were no space remaining for the content.

In this PR I propose to remove the grid beavior and set the `dt` tags on top of the `dl`. It's repsonsive to dark theme and avoid changing the display on small screens:

before: 
<img width="704" alt="Capture d’écran 2022-10-06 à 13 53 21" src="https://user-images.githubusercontent.com/12596392/194305887-93637937-db49-4768-b573-be94f6ba4849.png">


after:
<img width="709" alt="Capture d’écran 2022-10-06 à 13 53 45" src="https://user-images.githubusercontent.com/12596392/194305978-fa7cbc6e-6e24-40d0-aa99-28ae209ed3b7.png">

visible in: https://pydata-sphinx-theme--981.org.readthedocs.build/en/981/examples/api.html#numpy.linalg.eig

let me know what you think