### PR TITLE
FIX: improve display of Hide search button

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -67,6 +67,7 @@ div#searchbox {
         color: unset; // make sure it uses the same color as the text
         font-family: "Font Awesome 6 Free";
         padding-right: 0.5rem;
+        margin-right: 0;
       }
     }
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -62,9 +62,9 @@ div#searchbox {
     a {
       // add icon via CSS because the link is created by javascript
       // match padding to .toc-item > i above
-      // f010 is magnifying glass minus
       &:before {
         content: var(--pst-icon-search-minus);
+        color: unset; // make sure it uses the same color as the text
         font-family: "Font Awesome 6 Free";
         padding-right: 0.5rem;
       }


### PR DESCRIPTION
byproduct of investigating #982 

since we merged (#957), some styling is applyed to icons set before a link. The only other one in the theme is the "hide search result" button as it's generated from JS. 

I did 2 small adaptation to make sure it appears in the link colors and without extra margin