### PR TITLE
FIX: change dark highlight for a11y

### DIFF
--- a/docs/user_guide/styling.rst
+++ b/docs/user_guide/styling.rst
@@ -191,7 +191,7 @@ As the Sphinx theme supports multiple modes, the code highlighting colors can be
    html_theme_options = {
       ...
       "pygment_light_style": "tango",
-      "pygment_dark_style": "dracula"
+      "pygment_dark_style": "monokai"
    }
 
 .. danger::

--- a/docs/user_guide/styling.rst
+++ b/docs/user_guide/styling.rst
@@ -191,7 +191,7 @@ As the Sphinx theme supports multiple modes, the code highlighting colors can be
    html_theme_options = {
       ...
       "pygment_light_style": "tango",
-      "pygment_dark_style": "native"
+      "pygment_dark_style": "dracula"
    }
 
 .. danger::

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -835,13 +835,13 @@ def _overwrite_pygments_css(app, exception=None):
     So yes, at build time we overwrite the pygment.css file so that it embeds
     2 versions:
     - the light theme prefixed with "[data-theme="light"]" using tango
-    - the dark theme prefixed with "[data-theme="dark"]" using native
+    - the dark theme prefixed with "[data-theme="dark"]" using dracula
 
     When the theme is switched, Pygments will be using one of the preset css
     style.
     """
     default_light_theme = "tango"
-    default_dark_theme = "native"
+    default_dark_theme = "dracula"
 
     if exception is not None:
         return

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -835,13 +835,13 @@ def _overwrite_pygments_css(app, exception=None):
     So yes, at build time we overwrite the pygment.css file so that it embeds
     2 versions:
     - the light theme prefixed with "[data-theme="light"]" using tango
-    - the dark theme prefixed with "[data-theme="dark"]" using dracula
+    - the dark theme prefixed with "[data-theme="dark"]" using monokai
 
     When the theme is switched, Pygments will be using one of the preset css
     style.
     """
     default_light_theme = "tango"
-    default_dark_theme = "dracula"
+    default_dark_theme = "monokai"
 
     if exception is not None:
         return

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -37,7 +37,7 @@ footer_items = copyright.html, sphinx-version.html
 page_sidebar_items = page-toc.html, searchbox.html, edit-this-page.html, sourcelink.html
 switcher =
 pygment_light_style = tango
-pygment_dark_style = native
+pygment_dark_style = dracula
 logo =
 announcement =
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -37,7 +37,7 @@ footer_items = copyright.html, sphinx-version.html
 page_sidebar_items = page-toc.html, searchbox.html, edit-this-page.html, sourcelink.html
 switcher =
 pygment_light_style = tango
-pygment_dark_style = dracula
+pygment_dark_style = monokai
 logo =
 announcement =
 


### PR DESCRIPTION
Fix #649 

I spent some time on different forums and issues about color blindness (I am a geographer so it's also important to me when I'm producing maps) It seems that native is not the best choice effectively. Note that none of the existing Pygment highlighters are fully compatible with any vision deficiency. 

ref: 
- https://www.reddit.com/r/AskProgramming/comments/ffi9eh/are_there_any_text_editor_colorschemes/
- https://stackoverflow.com/questions/68571964/colorblind-and-colors-which-elements-of-the-vs2019-text-editor-relate-to-the-c
- https://vscodethemes.com/?text=one+dark+pro&language=python
- https://pygments.org/styles/

Thus I installed the [colorblindly](https://chrome.google.com/webstore/detail/colorblindly/floniaahmccleoclneebhhmnjgdfijgg) extension for chrome and started playing with [Pygments](https://pygments.org/demo/). It seems to me that the molokai is giving us the best results for Protanopia (read-blind) and Deuteranopia (green-blind) which are the most comons form of color blindness.

Here are demo in both Python an JSON:

|       | normal      | green-b     | red-b       |
|-------|-------------|-------------|-------------|
| pyton | ![python_n] | ![python_g] | ![python_r] |
| json  | ![json_n]   | ![json_g]   | ![json_r]   |

[json_n]: https://user-images.githubusercontent.com/12596392/194342928-405e6959-23b3-4f64-a368-bac476bfb7bb.png
[json_g]: https://user-images.githubusercontent.com/12596392/194343029-669e4090-13c5-4ca3-b6d3-b8db7172a6de.png
[json_r]: https://user-images.githubusercontent.com/12596392/194343140-41f3a453-0bd7-4ade-8dbe-f1fbdb024595.png
[python_n]: https://user-images.githubusercontent.com/12596392/194343311-0cd42fb9-9ec1-41b2-b38e-e6b9feef62a7.png
[python_g]: https://user-images.githubusercontent.com/12596392/194343393-21bc13b5-3a0d-4b0a-b044-53611fd25fe5.png
[python_r]: https://user-images.githubusercontent.com/12596392/194343460-fe0b2620-5093-4e39-b106-24fd206e37be.png

Let me know what you think