### PR TITLE
FIX: improve numbering of the docs

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -31,8 +31,8 @@ See the sections in the primary sidebar and below to explore.
 
     no-sidebar
     persistent-search-field
-    mult_headers
     subpages/index
+    mult_headers
     Link to an external site <https://jupyterbook.org/>
 
 .. meta::


### PR DESCRIPTION
exchange position of the multi-title page
Fix #842