### PR TITLE
ENH: place the RDT flyout in the sidebar

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/index.js
+++ b/src/pydata_sphinx_theme/assets/scripts/index.js
@@ -351,6 +351,33 @@ if (themeSwitchBtns) {
 }
 
 /*******************************************************************************
+ * MutationObserver to move the ReadTheDocs button
+ */
+
+function initRTDObserver() {
+  const mutatedCallback = (mutationList, observer) => {
+    mutationList.forEach((mutation) => {
+      // Check whether the mutation is for RTD, which will have a specific structure
+      if (mutation.addedNodes.length === 0) {
+        return;
+      }
+      if (mutation.addedNodes[0].data === undefined) {
+        return;
+      }
+      if (mutation.addedNodes[0].data.search("Inserted RTD Footer") != -1) {
+        mutation.addedNodes.forEach((node) => {
+          document.getElementById("rtd-footer-container").append(node);
+        });
+      }
+    });
+  };
+
+  const observer = new MutationObserver(mutatedCallback);
+  const config = { childList: true };
+  observer.observe(document.body, config);
+}
+
+/*******************************************************************************
  * Finalize
  */
 
@@ -361,3 +388,4 @@ $(scrollToActive);
 $(addTOCInteractivity);
 $(setupSearchButtons);
 $('[data-toggle="tooltip"]').tooltip({ delay: { show: 500, hide: 100 } });
+$(initRTDObserver);

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -1,12 +1,13 @@
 .bd-sidebar-primary div#rtd-footer-container {
   position: sticky;
   bottom: -1rem;
-  margin: -1rem 0 -1rem -1rem; // ignore sidebar padding
+  margin: -1rem; // ignore sidebar padding
 
   .rst-versions.rst-badge {
     position: unset;
     font-size: 0.9em;
     font-family: var(--pst-font-family-base);
+    max-width: unset;
 
     .rst-current-version {
       display: flex;

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -1,6 +1,7 @@
 .bd-sidebar-primary div#rtd-footer-container {
   position: sticky;
   bottom: 0;
+  margin: -1rem -1rem; // ignore sidebar padding
 
   .rst-versions.rst-badge {
     position: unset;
@@ -13,8 +14,19 @@
     gap: 0.2rem;
     height: 2.5rem;
     transition: background-color 0.2s ease-out;
-    background-color: #fff;
-    color: #5a5a5a;
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
+    background-color: var(--pst-color-background);
+    color: var(--pst-color-text-muted);
+    border-top: 1px solid var(--pst-color-border);
+  }
+
+  .rst-current-version {
+    font-family: var(--pst-font-family-base-system);
+
+    .fa.fa-book {
+      color: var(--pst-color-text-muted);
+    }
+    .fa.fa-carret-down {
+      color: var(--pst-color-text-muted);
+    }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -1,0 +1,20 @@
+.bd-sidebar-primary div#rtd-footer-container {
+  position: sticky;
+  bottom: 0;
+
+  .rst-versions.rst-badge {
+    position: unset;
+    font-size: 0.9em;
+  }
+
+  .rst-versions.rst-badge .rst-current-version {
+    display: flex;
+    align-items: center;
+    gap: 0.2rem;
+    height: 2.5rem;
+    transition: background-color 0.2s ease-out;
+    background-color: #fff;
+    color: #5a5a5a;
+    border-top: 1px solid rgba(0, 0, 0, 0.1);
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -1,7 +1,7 @@
 .bd-sidebar-primary div#rtd-footer-container {
   position: sticky;
   bottom: -1rem;
-  margin: -1rem -1rem; // ignore sidebar padding
+  margin: -1rem 0 -1rem -1rem; // ignore sidebar padding
 
   .rst-versions.rst-badge {
     position: unset;
@@ -27,6 +27,7 @@
       margin-right: auto;
 
       &::after {
+        color: var(--pst-color-text-base);
         content: "Read The Docs";
         font-family: var(--pst-font-family-base-system);
         font-weight: var(--pst-font-weight-heading);

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -6,9 +6,6 @@
   .rst-versions.rst-badge {
     position: unset;
     font-size: 0.9em;
-  }
-
-  .rst-versions.rst-badge .rst-current-version {
     display: flex;
     align-items: center;
     gap: 0.2rem;
@@ -16,11 +13,12 @@
     transition: background-color 0.2s ease-out;
     background-color: var(--pst-color-background);
     color: var(--pst-color-text-muted);
-    border-top: 1px solid var(--pst-color-border);
   }
 
   .rst-current-version {
     font-family: var(--pst-font-family-base-system);
+    border-top: 1px solid var(--pst-color-border);
+    border-bottom: 1px solid var(--pst-color-border);
 
     .fa.fa-book {
       color: var(--pst-color-text-muted);
@@ -35,6 +33,31 @@
     }
     .fa.fa-caret-down {
       color: var(--pst-color-text-muted);
+    }
+  }
+
+  rst-other-version {
+    background-color: var(--pst-color-background);
+    color: var(--pst-color-text-base);
+
+    dl {
+      dd a {
+        color: var(--pst-color-text-muted);
+      }
+    }
+
+    hr {
+      background-color: var(--pst-color-border);
+    }
+
+    small span a {
+      color: var(--pst-color-link);
+    }
+
+    input {
+      padding-left: 0.5rem;
+      border: 1px solid var(--pst-color-border);
+      background-color: var(--pst-color-background);
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -50,7 +50,7 @@
       background-color: var(--pst-color-border);
     }
 
-    small span a {
+    small a {
       color: var(--pst-color-link);
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -6,19 +6,19 @@
   .rst-versions.rst-badge {
     position: unset;
     font-size: 0.9em;
-    display: flex;
-    align-items: center;
-    gap: 0.2rem;
-    height: 2.5rem;
-    transition: background-color 0.2s ease-out;
-    background-color: var(--pst-color-background);
-    color: var(--pst-color-text-muted);
-  }
 
-  .rst-current-version {
-    font-family: var(--pst-font-family-base-system);
-    border-top: 1px solid var(--pst-color-border);
-    border-bottom: 1px solid var(--pst-color-border);
+    .rst-current-version {
+      display: flex;
+      align-items: center;
+      gap: 0.2rem;
+      height: 2.5rem;
+      transition: background-color 0.2s ease-out;
+      background-color: var(--pst-color-background);
+      color: var(--pst-color-text-muted);
+      font-family: var(--pst-font-family-base-system);
+      border-top: 1px solid var(--pst-color-border);
+      border-bottom: 1px solid var(--pst-color-border);
+    }
 
     .fa.fa-book {
       color: var(--pst-color-text-muted);
@@ -36,7 +36,7 @@
     }
   }
 
-  rst-other-version {
+  .rst-other-version {
     background-color: var(--pst-color-background);
     color: var(--pst-color-text-base);
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -36,7 +36,7 @@
     }
   }
 
-  .rst-other-version {
+  .rst-other-versions {
     background-color: var(--pst-color-background);
     color: var(--pst-color-text-base);
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -1,6 +1,6 @@
 .bd-sidebar-primary div#rtd-footer-container {
   position: sticky;
-  bottom: 0;
+  bottom: -1rem;
   margin: -1rem -1rem; // ignore sidebar padding
 
   .rst-versions.rst-badge {
@@ -24,8 +24,15 @@
 
     .fa.fa-book {
       color: var(--pst-color-text-muted);
+      margin-right: auto;
+
+      &::after {
+        content: "Read The Docs";
+        font-family: var(--pst-font-family-base-system);
+        font-weight: var(--pst-font-weight-heading);
+      }
     }
-    .fa.fa-carret-down {
+    .fa.fa-caret-down {
       color: var(--pst-color-text-muted);
     }
   }

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -1,7 +1,7 @@
 .bd-sidebar-primary div#rtd-footer-container {
   position: sticky;
   bottom: -1rem;
-  margin: -1rem -1rem -1rem -1rem; // ignore sidebar padding
+  margin: -1rem 0 -1rem -1rem; // ignore sidebar padding
 
   .rst-versions.rst-badge {
     position: unset;

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -6,6 +6,7 @@
   .rst-versions.rst-badge {
     position: unset;
     font-size: 0.9em;
+    font-family: var(--pst-font-family-base);
 
     .rst-current-version {
       display: flex;
@@ -15,9 +16,7 @@
       transition: background-color 0.2s ease-out;
       background-color: var(--pst-color-background);
       color: var(--pst-color-success);
-      font-family: var(--pst-font-family-base-system);
       border-top: 1px solid var(--pst-color-border);
-      border-bottom: 1px solid var(--pst-color-border);
     }
 
     .fa.fa-book {
@@ -27,12 +26,18 @@
       &::after {
         color: var(--pst-color-text-base);
         content: "Read The Docs";
-        font-family: var(--pst-font-family-base-system);
+        font-family: var(--pst-font-family-base);
         font-weight: var(--pst-font-weight-heading);
       }
     }
     .fa.fa-caret-down {
       color: var(--pst-color-text-muted);
+    }
+  }
+
+  .rst-versions.rst-badge.shift-up {
+    .rst-current-version {
+      border-bottom: 1px solid var(--pst-color-border);
     }
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -1,7 +1,7 @@
 .bd-sidebar-primary div#rtd-footer-container {
   position: sticky;
   bottom: -1rem;
-  margin: -1rem 0 -1rem -1rem; // ignore sidebar padding
+  margin: -1rem -1rem -1rem -1rem; // ignore sidebar padding
 
   .rst-versions.rst-badge {
     position: unset;
@@ -14,7 +14,7 @@
       height: 2.5rem;
       transition: background-color 0.2s ease-out;
       background-color: var(--pst-color-background);
-      color: var(--pst-color-text-muted);
+      color: var(--pst-color-success);
       font-family: var(--pst-font-family-base-system);
       border-top: 1px solid var(--pst-color-border);
       border-bottom: 1px solid var(--pst-color-border);
@@ -37,7 +37,7 @@
   }
 
   .rst-other-versions {
-    background-color: var(--pst-color-background);
+    background-color: var(--pst-color-surface);
     color: var(--pst-color-text-base);
 
     dl {
@@ -57,7 +57,7 @@
     input {
       padding-left: 0.5rem;
       border: 1px solid var(--pst-color-border);
-      background-color: var(--pst-color-background);
+      background-color: var(--pst-color-surface);
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/index.scss
+++ b/src/pydata_sphinx_theme/assets/styles/index.scss
@@ -55,6 +55,7 @@ $grid-breakpoints: (
 @import "./components/toc-inpage";
 @import "./components/versionmodified";
 @import "./components/indices";
+@import "./components/readthedocs-switcher";
 
 // Content blocks in standard Sphinx
 @import "./content/admonitions";

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -42,4 +42,7 @@
     </div>
     {%- endfor %}
   </div>
+
+  {# add the rtd flyout in the sidebar #}
+  <div id="rtd-footer-container"></div>
 {% endblock %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -34,7 +34,7 @@
   </div>
   {% endif %}
 
-  {# Items that will snap to the bottom of the screen#}
+  {# Items that will snap to the bottom of the screen #}
   <div class="sidebar-end-items sidebar-primary__section">
     {%- for sidebartemplate in theme_primary_sidebar_end %}
     <div class="sidebar-end-items__item">
@@ -43,6 +43,6 @@
     {%- endfor %}
   </div>
 
-  {# add the rtd flyout in the sidebar #}
+  {# add the rtd flyout in the sidebar if existing #}
   <div id="rtd-footer-container"></div>
 {% endblock %}

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -79,4 +79,6 @@
   <div class="sidebar-end-items__item">
   </div>
  </div>
+ <div id="rtd-footer-container">
+ </div>
 </div>


### PR DESCRIPTION
Fix #194 

in #705 @choldgraf was advocating in favor of moving the RTD's flyout in the header. I tried a lot and there really is no real estate available for it. we already added an option to limit the number of links displayed at the same time, the only place I could think about would be to replace the version switcher which could lead to lots of different issues. 

In this PR I fall back on the initial idea to use the primary sidebar and embed the flyout in it at the bottom (we are advertising a "clean 3-column template" so let's use it!). This can also be considered a first step before moving it elsewhere.

- the flyout is caught by JS as in sphinx-book (https://github.com/executablebooks/sphinx-book-theme/blob/af6277a7276112ee915d901984193c49e56d5a76/src/sphinx_book_theme/assets/scripts/index.js#L189-L213)
- the flyout is styled to stick to the primary sidebar
- the content is styled using our variables so it's now reactive to theming

|             | dark                    | light                   |
|--------|-----------------|----------------|
| fold       | ![dark-fold]       | ![light-fold]       |
| expand | ![dark-expand] | ![light-expand]  |

[dark-fold]: https://user-images.githubusercontent.com/12596392/194948430-53cab72a-a58f-4f79-8e4c-44fa43deefe0.png
[dark-expand]: https://user-images.githubusercontent.com/12596392/194948443-8c2e3ed4-8663-48c3-929b-8bd37d0ffe32.png
[light-fold]: https://user-images.githubusercontent.com/12596392/194948449-9c024777-c7da-4737-8314-e1e053b85df1.png
[light-expand]: https://user-images.githubusercontent.com/12596392/194948452-def0c4a5-9a8f-41f2-9561-3a50a6619366.png
