### PR TITLE
FIX: link shortening for gitlab

### DIFF
--- a/docs/user_guide/theme-elements.md
+++ b/docs/user_guide/theme-elements.md
@@ -146,6 +146,20 @@ Some sidebar content.
 
 ## Link shortening for git repository services
 
-Many projects have links back to their issues / PRs hosted on platforms like **GitHub** or **GitLab**. Instead of displaying these as raw links, this theme does some lightweight formatting for these platforms specifically. Here is an example from the issue requesting this feature: [https://github.com/pydata/pydata-sphinx-theme/issues/841](https://github.com/pydata/pydata-sphinx-theme/issues/841).
+Many projects have links back to their issues / PRs hosted on platforms like **GitHub** or **GitLab**. Instead of displaying these as raw links, this theme does some lightweight formatting for these platforms specifically. Here is some examples from github and gitlab:
+
+**GitHub**
+
+- "https://github.com" -> [https://github.com](https://github.com)
+- "https://github.com/pydata" -> [https://github.com/pydata](https://github.com/pydata)
+- "https://github.com/pydata/pydata-sphinx-theme" -> [https://github.com/pydata/pydata-sphinx-theme](https://github.com/pydata/pydata-sphinx-theme)
+- "https://github.com/pydata/pydata-sphinx-theme/pull/1012" -> [https://github.com/pydata/pydata-sphinx-theme/pull/1012](https://github.com/pydata/pydata-sphinx-theme/pull/1012)
+
+**GitLab**
+
+- "https://gitlab.com" -> [https://gitlab.com](https://gitlab.com)
+- "https://gitlab.com/gitlab-org" -> [https://gitlab.com/gitlab-org](https://gitlab.com/gitlab-org)
+- "https://gitlab.com/gitlab-org/gitlab" -> [https://gitlab.com/gitlab-org/gitlab](https://gitlab.com/gitlab-org/gitlab)
+- "https://gitlab.com/gitlab-org/gitlab/-/issues/375583" -> [https://gitlab.com/gitlab-org/gitlab/-/issues/375583](https://gitlab.com/gitlab-org/gitlab/-/issues/375583)
 
 Links provided with a text body won't be changed.

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -929,28 +929,29 @@ class ShortenLinkTransform(SphinxPostTransform):
 
         # split the url content
         # be careful the first one is a "/"
-        s = path.split("/")
+        parts = path.split("/")
 
         # check the platform name and read the information accordingly
+        # as "<organisation>/<repository>#<element number>"
         if self.platform == "github":
             text = "github"
-            if len(s) > 1:
-                text = s[1]
-            if len(s) > 2:
-                text += f"/{s[2]}"
-            if len(s) > 3:
-                if s[3] in ["issues", "pull", "discussions"]:
-                    text += f"#{s[-1]}"
+            if len(parts) > 1:
+                text = parts[1]  # organisation
+            if len(parts) > 2:
+                text += f"/{parts[2]}"  # repository
+            if len(parts) > 3:
+                if parts[3] in ["issues", "pull", "discussions"]:
+                    text += f"#{parts[-1]}"  # element number
 
         elif self.platform == "gitlab":
             text = "gitlab"
-            if len(s) > 1:
-                text = s[1]
-            if len(s) > 2:
-                text += f"/{s[2]}"
-            if len(s) > 4:
-                if s[4] in ["issues", "merge_requests"]:
-                    text += f"#{s[-1]}"
+            if len(parts) > 1:
+                text = parts[1]  # organisation
+            if len(parts) > 2:
+                text += f"/{parts[2]}"  # repository
+            if len(parts) > 4:
+                if parts[4] in ["issues", "merge_requests"]:
+                    text += f"#{parts[-1]}"  # element number
 
         return text
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -948,7 +948,7 @@ class ShortenLinkTransform(SphinxPostTransform):
                 text = s[1]
             if len(s) > 2:
                 text += f"/{s[2]}"
-            if len(s) > 3:
+            if len(s) > 4:
                 if s[4] in ["issues", "merge_requests"]:
                     text += f"#{s[-1]}"
 

--- a/tests/sites/base/page1.rst
+++ b/tests/sites/base/page1.rst
@@ -1,6 +1,24 @@
 Page 1
 ======
 
-- here's a normal link: https://pydata-sphinx-theme.readthedocs.io/en/latest/
-- Here's a github link: https://github.com/2i2c-org/infrastructure/issues/1329
-- Here's a gitlab link: https://gitlab.com/gitlab-org/gitlab/-/issues/375583
+**normal link**
+
+- https://pydata-sphinx-theme.readthedocs.io/en/latest/
+
+**GitHub**
+
+.. container:: github-container
+
+    https://github.com
+    https://github.com/pydata
+    https://github.com/pydata/pydata-sphinx-theme
+    https://github.com/pydata/pydata-sphinx-theme/pull/1012
+
+**GitLab**
+
+.. container:: gitlab-container
+
+    https://gitlab.com
+    https://gitlab.com/gitlab-org
+    https://gitlab.com/gitlab-org/gitlab
+    https://gitlab.com/gitlab-org/gitlab/-/issues/375583

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -656,11 +656,11 @@ def test_shorten_link(sphinx_build_factory, file_regression):
 
     sphinx_build = sphinx_build_factory("base").build()
 
-    github = sphinx_build.html_tree("page1.html").select(".github")[0]
-    file_regression.check(github.prettify(), basename="github_link", extension=".html")
+    github = sphinx_build.html_tree("page1.html").select(".github-container")[0]
+    file_regression.check(github.prettify(), basename="github_links", extension=".html")
 
-    gitlab = sphinx_build.html_tree("page1.html").select(".gitlab")[0]
-    file_regression.check(gitlab.prettify(), basename="gitlab_link", extension=".html")
+    gitlab = sphinx_build.html_tree("page1.html").select(".gitlab-container")[0]
+    file_regression.check(gitlab.prettify(), basename="gitlab_links", extension=".html")
 
 
 def test_math_header_item(sphinx_build_factory, file_regression):

--- a/tests/test_build/github_link.html
+++ b/tests/test_build/github_link.html
@@ -1,3 +1,0 @@
-<a class="github reference external" href="https://github.com/2i2c-org/infrastructure/issues/1329">
- 2i2c-org/infrastructure#1329
-</a>

--- a/tests/test_build/github_links.html
+++ b/tests/test_build/github_links.html
@@ -1,0 +1,16 @@
+<div class="github-container docutils container">
+ <p>
+  <a class="github reference external" href="https://github.com">
+   github
+  </a>
+  <a class="github reference external" href="https://github.com/pydata">
+   pydata
+  </a>
+  <a class="github reference external" href="https://github.com/pydata/pydata-sphinx-theme">
+   pydata/pydata-sphinx-theme
+  </a>
+  <a class="github reference external" href="https://github.com/pydata/pydata-sphinx-theme/pull/1012">
+   pydata/pydata-sphinx-theme#1012
+  </a>
+ </p>
+</div>

--- a/tests/test_build/gitlab_link.html
+++ b/tests/test_build/gitlab_link.html
@@ -1,3 +1,0 @@
-<a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/-/issues/375583">
- gitlab-org/gitlab#375583
-</a>

--- a/tests/test_build/gitlab_links.html
+++ b/tests/test_build/gitlab_links.html
@@ -1,0 +1,16 @@
+<div class="gitlab-container docutils container">
+ <p>
+  <a class="gitlab reference external" href="https://gitlab.com">
+   gitlab
+  </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org">
+   gitlab-org
+  </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab">
+   gitlab-org/gitlab
+  </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/-/issues/375583">
+   gitlab-org/gitlab#375583
+  </a>
+ </p>
+</div>


### PR DESCRIPTION
the links in GitLab are using an extra "-" for issues in the url. 

Fix #1011 