### PR TITLE
FIX: avoid API double select

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_api.scss
@@ -114,6 +114,11 @@ span.highlighted {
 dl[class]:not(.option-list):not(.field-list):not(.footnote):not(.glossary):not(.simple) {
   dd {
     margin-left: 2rem;
+
+    // Fix until this will be solved to Sphinx https://github.com/sphinx-doc/sphinx/issues/10815
+    & > dl.simple > dt {
+      display: flex;
+    }
   }
 
   dl.field-list {


### PR DESCRIPTION
Fix #388 

Suprisingly 1 extra CSS rule was sufficient (my recent discovery on inline-blocks led me to this test and lucky for us it works like a charm. 
I think it should be ported to sphinx attention but until then it does the job on our side.

exemplified in our doc here: https://pydata-sphinx-theme--1015.org.readthedocs.build/en/1015/examples/api.html#exceptions

<img width="639" alt="Capture d’écran 2022-10-13 à 10 25 54" src="https://user-images.githubusercontent.com/12596392/195543762-fdc4a402-891b-4bc8-9661-22f6905cd014.png">
