### PR TITLE
FIX: table width of nbsphinx dataframes

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_pydata.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_pydata.scss
@@ -10,7 +10,7 @@
 /**
  * special case for table rendered via nbsphinx
  */
-.rendered_html {
+html div.rendered_html {
   table {
     table-layout: auto;
   }


### PR DESCRIPTION
Fix #1017 

I though initially that the problem was solved by #954, but it wasn't. nbsphinx is not a very nice neighbour as it's injecting its css within the `article` tag instead of the header. giving it a super high priority over custom and/or our theme css. 

Instead of setting an `!important` statement I simply copy/pasted the complete selector + `html` making it more specific and thus giving it the priority. 

We cannot test it in our theme documentation as we are using mystNB but @seanlaw confirmed it worked from his side.