### PR TITLE
ENH/MAINT: avoid overwriting the HtmlTranslator

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1010,7 +1010,10 @@ class HeaderTransform(SphinxPostTransform):
         matcher = NodeMatcher(nodes.title)
         # TODO: just use "findall" once docutils min version >=0.18.1
         for node in _traverse_or_findall(self.document, matcher):
-            pass
+            if isinstance(node.parent, addnodes.compact_paragraph) and node.parent.get(
+                "toctree"
+            ):
+                pass
 
 
 # -----------------------------------------------------------------------------
@@ -1024,14 +1027,7 @@ def setup(app):
 
     app.add_post_transform(ShortenLinkTransform)
     app.add_post_transform(BSTableTransform)
-    app.add_post_transform(HeaderTransform)
-
-    # app.set_translator("html", BootstrapHTML5Translator)
-    # Read the Docs uses ``readthedocs`` as the name of the build, and also
-    # uses a special "dirhtml" builder so we need to replace these both with
-    # our custom HTML builder
-    # app.set_translator("readthedocs", BootstrapHTML5Translator, override=True)
-    # app.set_translator("readthedocsdirhtml", BootstrapHTML5Translator, override=True)
+    # app.add_post_transform(HeaderTransform)
 
     app.connect("env-updated", update_config)
     app.connect("html-page-context", setup_edit_url)

--- a/src/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/src/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -1,11 +1,7 @@
 """A custom Sphinx HTML Translator for Bootstrap layout
 """
-from packaging.version import Version
-
-import sphinx
 from sphinx.writers.html5 import HTML5Translator
 from sphinx.util import logging
-from sphinx.ext.autosummary import autosummary_table
 
 logger = logging.getLogger(__name__)
 
@@ -17,48 +13,8 @@ class BootstrapHTML5Translator(HTML5Translator):
     directly styled with Bootstrap, and fulfill acessibility best practices.
     """
 
-    def __init__(self, *args, **kwds):
-        super().__init__(*args, **kwds)
-        self.settings.table_style = "table"
-
     def starttag(self, *args, **kwargs):
         """ensure an aria-level is set for any heading role"""
         if kwargs.get("ROLE") == "heading" and "ARIA-LEVEL" not in kwargs:
             kwargs["ARIA-LEVEL"] = "2"
         return super().starttag(*args, **kwargs)
-
-    def visit_table(self, node):
-        """
-        copy of sphinx source to *not* add 'docutils' and 'align-default' classes
-        but add 'table' class
-        """
-
-        # init the attributes
-        atts = {}
-
-        # generate_targets_for_table is deprecated in 4.0
-        if Version(sphinx.__version__) < Version("4.0"):
-            self.generate_targets_for_table(node)
-
-        if Version(sphinx.__version__) < Version("4.3"):
-            self._table_row_index = 0
-        else:
-            self._table_row_indices.append(0)
-
-        # get the classes
-        classes = [cls.strip(" \t\n") for cls in self.settings.table_style.split(",")]
-
-        # we're looking at the 'real_table', which is wrapped by an autosummary
-        if isinstance(node.parent, autosummary_table):
-            classes += ["autosummary"]
-
-        # add the width if set in a style attribute
-        if "width" in node:
-            atts["style"] = f'width: {node["width"]}'
-
-        # add specific class if align is set
-        if "align" in node:
-            classes.append(f'table-{node["align"]}')
-
-        tag = self.starttag(node, "table", CLASS=" ".join(classes), **atts)
-        self.body.append(tag)


### PR DESCRIPTION
Fix #143, Fix #94

In this PR I tried to get rid of the custom `BootstrapHTML5Translator`. To remain compatible with what was built previously I simply edit the table nodes using a Sphinx `post_transform`. 

here: 
https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/bootstrap_html_translator.py#L24

We add an `aria-level` on a specific component of the output. In fact, what is done is a rough overwriting of this:
https://github.com/sphinx-doc/sphinx/blob/fa6d42597f2c1259ccdd9166763657bd9c2a316e/sphinx/writers/html5.py#L370
I don't manage to make it work with a `post_transform` so I think the solution is a directive overwrite. Before I loose some hair on this one, can someone explain why it's relevant for the theme ?

PS: this work is a WIP but I wanted to see the distant build to try to understand why there is this `aria-level` addition.
PPS: of course I will drop the second python file entirely when this will work