### PR TITLE
rename secondary_sidebar_items to page_sidebar_items in user guide

### DIFF
--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -368,7 +368,7 @@ Secondary Sidebar (right)
 =========================
 
 The in-page sidebar is just to the right of a page's article content, and is
-configured in ``conf.py`` with ``html_theme_options['secondary_sidebar_items']``.
+configured in ``conf.py`` with ``html_theme_options['page_sidebar_items']``.
 
 By default, it has the following templates:
 
@@ -376,7 +376,7 @@ By default, it has the following templates:
 
     html_theme_options = {
       ...
-      "secondary_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
+      "page_sidebar_items": ["page-toc", "edit-this-page", "sourcelink"],
       ...
     }
 


### PR DESCRIPTION
Ran into an error following the documentation for modifying `secondary_sidebar_items`:
```bash
preparing documents... WARNING: unsupported theme option 'secondary_sidebar_items' given
```
I think it should be named `page_sidebar_items`