### PR TITLE
STYLE: style admonitions

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -60,14 +60,14 @@ div.admonition,
   }
 
   &.attention {
-    border-color: var(--pst-color-warning);
+    border-color: var(--pst-color-secondary);
     > .admonition-title {
       &:before {
-        background-color: var(--pst-color-warning);
+        background-color: var(--pst-color-secondary);
       }
 
       &:after {
-        color: var(--pst-color-warning);
+        color: var(--pst-color-secondary);
         content: var(--pst-icon-admonition-attention);
       }
     }
@@ -158,14 +158,14 @@ div.admonition,
   }
 
   &.important {
-    border-color: var(--pst-color-success);
+    border-color: var(--pst-color-secondary);
     > .admonition-title {
       &:before {
-        background-color: var(--pst-color-success);
+        background-color: var(--pst-color-secondary);
       }
 
       &:after {
-        color: var(--pst-color-success);
+        color: var(--pst-color-secondary);
         content: var(--pst-icon-admonition-important);
       }
     }
@@ -186,14 +186,14 @@ div.admonition,
   }
 
   &.seealso {
-    border-color: var(--pst-color-info);
+    border-color: var(--pst-color-success);
     > .admonition-title {
       &:before {
-        background-color: var(--pst-color-info);
+        background-color: var(--pst-color-success);
       }
 
       &:after {
-        color: var(--pst-color-info);
+        color: var(--pst-color-success);
         content: var(--pst-icon-admonition-seealso);
       }
     }

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -199,6 +199,20 @@ div.admonition,
     }
   }
 
+  &.admonition-todo {
+    border-color: var(--pst-color-border);
+    > .admonition-title {
+      &:before {
+        background-color: var(--pst-color-border);
+      }
+
+      &:after {
+        color: var(--pst-color-border);
+        content: var(--pst-icon-admonition-todo);
+      }
+    }
+  }
+
   /**
    * Special-case for a `sidebar` class that makes the admonition float to
    * the right like the {sidebar} directive.

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -186,14 +186,14 @@ div.admonition,
   }
 
   &.seealso {
-    border-color: var(--pst-color-success);
+    border-color: var(--pst-color-info);
     > .admonition-title {
       &:before {
-        background-color: var(--pst-color-success);
+        background-color: var(--pst-color-info);
       }
 
       &:after {
-        color: var(--pst-color-success);
+        color: var(--pst-color-info);
         content: var(--pst-icon-admonition-seealso);
       }
     }

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -60,14 +60,14 @@ div.admonition,
   }
 
   &.attention {
-    border-color: var(--pst-color-secondary);
+    border-color: var(--pst-color-attention);
     > .admonition-title {
       &:before {
-        background-color: var(--pst-color-secondary);
+        background-color: var(--pst-color-attention);
       }
 
       &:after {
-        color: var(--pst-color-secondary);
+        color: var(--pst-color-attention);
         content: var(--pst-icon-admonition-attention);
       }
     }
@@ -158,14 +158,14 @@ div.admonition,
   }
 
   &.important {
-    border-color: var(--pst-color-secondary);
+    border-color: var(--pst-color-attention);
     > .admonition-title {
       &:before {
-        background-color: var(--pst-color-secondary);
+        background-color: var(--pst-color-attention);
       }
 
       &:after {
-        color: var(--pst-color-secondary);
+        color: var(--pst-color-attention);
         content: var(--pst-icon-admonition-important);
       }
     }
@@ -230,6 +230,10 @@ div.admonition,
     // TODO: these semantic-color-names border-color rules might no longer be
     //       needed when we drop support for Sphinx 4 / docutils 0.17
     &.attention,
+    &.important {
+      border-color: var(--pst-color-attention);
+    }
+
     &.caution,
     &.warning {
       border-color: var(--pst-color-warning);
@@ -242,11 +246,12 @@ div.admonition,
 
     &.hint,
     &.tip,
-    &.important {
+    &.seealso {
       border-color: var(--pst-color-success);
     }
 
-    &.note {
+    &.note,
+    &.todo {
       border-color: var(--pst-color-info);
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/variables/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_admonitions.scss
@@ -14,4 +14,5 @@ html {
   --pst-icon-admonition-tip: var(--pst-icon-lightbulb);
   --pst-icon-admonition-important: var(--pst-icon-exclamation-circle);
   --pst-icon-admonition-seealso: var(--pst-icon-share);
+  --pst-icon-admonition-todo: var(--pst-icon-pencil);
 }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_admonitions.scss
@@ -3,7 +3,7 @@ html {
   * Admonitions
   **/
 
-  --pst-icon-admonition-default: var(--pst-icon-text);
+  --pst-icon-admonition-default: var(--pst-icon-bell);
   --pst-icon-admonition-note: var(--pst-icon-info-circle);
   --pst-icon-admonition-attention: var(--pst-icon-exclamation-circle);
   --pst-icon-admonition-caution: var(--pst-icon-exclamation-triangle);

--- a/src/pydata_sphinx_theme/assets/styles/variables/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_admonitions.scss
@@ -3,7 +3,7 @@ html {
   * Admonitions
   **/
 
-  --pst-icon-admonition-default: var(--pst-icon-info-circle);
+  --pst-icon-admonition-default: var(--pst-icon-text);
   --pst-icon-admonition-note: var(--pst-icon-info-circle);
   --pst-icon-admonition-attention: var(--pst-icon-exclamation-circle);
   --pst-icon-admonition-caution: var(--pst-icon-exclamation-triangle);

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -6,7 +6,10 @@
 */
 $pst-semantic-colors: (
   "primary": rgb(69, 157, 185),
-  "secondary": rgb(238, 144, 64),
+  "secondary": (
+    "light": rgb(255, 193, 7),
+    "dark": rgb(220, 169, 15),
+  ),
   "info": rgb(69, 157, 185),
   "warning": rgb(238, 144, 64),
   "success": (
@@ -18,16 +21,16 @@ $pst-semantic-colors: (
     "dark": rgb(203, 70, 83),
   ),
   "text-base": (
-    // Black + 50
     "light": rgb(50, 50, 50),
-    // White - 50
+    // Black + 50
     "dark": rgb(206, 206, 206),
+    // White - 50
   ),
   "text-muted": (
-    // Twice as far from 0 as base
     "light": rgb(100, 100, 100),
-    // Twice as far from 256 as base
+    // Twice as far from 0 as base
     "dark": rgb(166, 166, 166),
+    // Twice as far from 256 as base
   ),
   "shadow": (
     "light": rgb(216, 216, 216),
@@ -93,7 +96,7 @@ $pst-semantic-colors: (
     }
     // assign the "duplicate" colors (ones that just reference other variables)
     --pst-color-link: var(--pst-color-primary);
-    --pst-color-link-hover: var(--pst-color-secondary);
+    --pst-color-link-hover: var(--pst-color-warning);
     // adapt to light/dark-specific content
     @if $mode == "light" {
       .only-dark {

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -6,15 +6,16 @@
 */
 $pst-semantic-colors: (
   "primary": rgb(69, 157, 185),
-  "secondary": (
-    "light": rgb(255, 193, 7),
-    "dark": rgb(220, 169, 15),
-  ),
+  "secondary": rgb(238, 144, 64),
   "info": rgb(69, 157, 185),
   "warning": rgb(238, 144, 64),
   "success": (
     "light": rgb(40, 167, 69),
     "dark": rgb(72, 135, 87),
+  ),
+  "attention": (
+    "light": rgb(255, 193, 7),
+    "dark": rgb(220, 169, 15),
   ),
   "danger": (
     "light": rgb(220, 53, 69),

--- a/src/pydata_sphinx_theme/assets/styles/variables/_icons.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_icons.scss
@@ -21,4 +21,5 @@ html {
   --pst-icon-github: "\f09b"; // fa-brands fa-github
   --pst-icon-gitlab: "\f296"; // fa-brands fa-gitlab
   --pst-icon-share: "\f064"; // fa-solid fa-share
+  --pst-icon-text: "\f039"; // fa-solid fa-text-justify
 }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_icons.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_icons.scss
@@ -22,4 +22,5 @@ html {
   --pst-icon-gitlab: "\f296"; // fa-brands fa-gitlab
   --pst-icon-share: "\f064"; // fa-solid fa-share
   --pst-icon-text: "\f039"; // fa-solid fa-text-justify
+  --pst-icon-pencil: "\f303"; // fa-solid fa-pencil
 }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_icons.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_icons.scss
@@ -21,6 +21,6 @@ html {
   --pst-icon-github: "\f09b"; // fa-brands fa-github
   --pst-icon-gitlab: "\f296"; // fa-brands fa-gitlab
   --pst-icon-share: "\f064"; // fa-solid fa-share
-  --pst-icon-text: "\f039"; // fa-solid fa-text-justify
+  --pst-icon-bell: "\f0f3"; // fa-solid fa-bell
   --pst-icon-pencil: "\f303"; // fa-solid fa-pencil
 }


### PR DESCRIPTION
related to #1040

The idea here is to align the styling of our admionitions on what's used in other themes so that user don't get lost when switching to ours. In short the RTD theme is driving everything as it's the one by default when you publish on their site so I think we can consider their coloring as default. some themes are stricly respecting it (picolo, insipid, alabaster, material). Furo stands out as every admonition have a color variation on RTD theme (important green is not the same as hint green).

Thus what I changed in this PR: 
- use text justify for custom admonitions (inspired by Furo)
- use grey color and pencil icon for `todo` admonitions
- fallback to blue for `seealso`

everything can be checked on this page: 