### PR TITLE
Prerelease CI: Update name, schedule and Python version

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,19 +1,19 @@
-name: cron-integration
+name: Scheduled pre-release tests
 
 on:
   schedule:
     # Run this workflow once a week
-    # ref: https://crontab.guru/#0_0_*_*_0
-    - cron: "0 0 * * 0"
+    # ref: https://crontab.guru/#0_5_*_*_1,4
+    - cron: "0 5 * * 1,4"
   workflow_dispatch:
 
 jobs:
   prerelease:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
           sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
 
       - name: Check that there are no unexpected Sphinx warnings
-        if: matrix.python-version == 3.9
+        if: matrix.python-version == "3.10"
         run: python tests/check_warnings.py
 
       - name: Run the tests

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -2,7 +2,7 @@ name: Scheduled pre-release tests
 
 on:
   schedule:
-    # Run this workflow once a week
+    # Run this workflow twice a week
     # ref: https://crontab.guru/#0_5_*_*_1,4
     - cron: "0 5 * * 1,4"
   workflow_dispatch:


### PR DESCRIPTION
A bit of maintenance on the prerelease GitHub Actions workflow:
 - Rename the workflow to better reflect it's purpose
 - Run twice a week (instead of once) on Monday and Thursday early in the morning.
 - Set `fail-fast` to `false`, so that all jobs finish and don't get cancelled if one fails.
- Run the warnings check test on Python 3.10

I was also wondering, it looks like a `warnings.txt` file is generated on each run. Should we upload or save that somewhere, or is that already the case?