### PR TITLE
Disable CloudFlare Rocket loader on dark mode script

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -27,7 +27,10 @@
                                    or not theme_secondary_sidebar_items %}
 
 {%- block css %}
-  <script>
+  {# The data-cfasync attribute disables CloudFlare's Rocket loader so that #}
+  {# mode/theme are correctly set before the browser renders the page. #}
+  {# https://github.com/pydata/pydata-sphinx-theme/pull/1045 #}
+  <script data-cfasync="false">
     document.documentElement.dataset.mode = localStorage.getItem("mode") || "{{ default_mode }}";
     document.documentElement.dataset.theme = localStorage.getItem("theme") || "light";
   </script>


### PR DESCRIPTION
If it's enabled, then the initialization of the dark mode does not occur early enough, and the page will flash from light-to-dark if that was the saved theme.

See the CloudFlare documentation for details:
https://support.cloudflare.com/hc/en-us/articles/200168056-Understanding-Rocket-Loader

Fixes #959 

I've temporarily added this on https://matplotlib.org so you can see that this is working. It is not added on any other page, which you can use for comparison.