### PR TITLE
FIX: display external links in toctree

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,10 +93,6 @@ if not version_match or version_match.isdigit():
 html_theme_options = {
     "external_links": [
         {
-            "url": "https://github.com/pydata/pydata-sphinx-theme/releases",
-            "name": "Changelog",
-        },
-        {
             "url": "https://pydata.org",
             "name": "PyData",
         },

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,3 +63,9 @@ Several example pages to demonstrate the functionality of this theme when used a
 
 examples/index
 ```
+
+```{toctree}
+:hidden:
+
+Changelog <https://github.com/pydata/pydata-sphinx-theme/releases>
+```

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -331,14 +331,23 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
                         else:
                             title += node.astext()
 
+                # set up the status of the link and the path
+                # if the path is relative then we use the context for the path
+                # resolution and the internal class.
+                # If it's an absolute one then we use the external class and
+                # the complete url.
+                is_absolute = bool(urlparse(page).netloc)
+                link_status = "external" if is_absolute else "internal"
+                link_href = page if is_absolute else context["pathto"](page)
+
                 # create the html output
                 links_html.append(
                     f"""
-                <li class="nav-item{current}">
-                  <a class="nav-link" href="{context["pathto"](page)}">
-                    {title}
-                  </a>
-                </li>
+                    <li class="nav-item{current}">
+                      <a class="nav-link nav-{link_status}" href="{link_href}">
+                        {title}
+                      </a>
+                    </li>
                 """
                 )
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -355,9 +355,12 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
         for external_link in context["theme_external_links"]:
             links_html.append(
                 f"""
-            <li class="nav-item">
-                <a class="nav-link nav-external" href="{ external_link["url"] }">{ external_link["name"] }<i class="fa-solid fa-up-right-from-square"></i></a>
-            </li>"""  # noqa
+                <li class="nav-item">
+                  <a class="nav-link nav-external" href="{ external_link["url"] }">
+                    { external_link["name"] }
+                  </a>
+                </li>
+                """
             )
 
         # The first links will always be visible

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -125,8 +125,18 @@
   border-left: 2px solid var(--pst-color-primary);
 }
 
-.nav-link:hover {
-  border-style: none;
+.nav-link {
+  :hover {
+    border-style: none;
+  }
+
+  &.nav-external:after {
+    font-family: "Font Awesome 6 Free";
+    font-weight: 900;
+    content: var(--pst-icon-external-link);
+    font-size: 0.75em;
+    margin-left: 0.3em;
+  }
 }
 
 #navbar-main-elements li.nav-item i {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -126,7 +126,7 @@
 }
 
 .nav-link {
-  :hover {
+  &:hover {
     border-style: none;
   }
 

--- a/tests/sites/base/index.rst
+++ b/tests/sites/base/index.rst
@@ -8,6 +8,7 @@ Index ``with code`` in title
    page1
    page2
    section1/index
+   google <https://google.com>
 
 A header
 --------

--- a/tests/sites/deprecated/index.rst
+++ b/tests/sites/deprecated/index.rst
@@ -8,6 +8,7 @@ Index ``with code`` in title
    page1
    page2
    section1/index
+   google <https://google.com>
 
 A header
 --------

--- a/tests/test_build/math_header_item.html
+++ b/tests/test_build/math_header_item.html
@@ -1,5 +1,5 @@
 <li class="nav-item current active">
- <a class="nav-link" href="#">
+ <a class="nav-link nav-internal" href="#">
   Page
   <span class="math notranslate nohighlight">
    \(\beta\)

--- a/tests/test_build/navbar_ix.html
+++ b/tests/test_build/navbar_ix.html
@@ -6,12 +6,12 @@
    </p>
    <ul class="navbar-nav" id="navbar-main-elements">
     <li class="nav-item">
-     <a class="nav-link" href="page1.html">
+     <a class="nav-link nav-internal" href="page1.html">
       Page 1
      </a>
     </li>
     <li class="nav-item">
-     <a class="nav-link" href="page2.html">
+     <a class="nav-link nav-internal" href="page2.html">
       Page
       <span class="math notranslate nohighlight">
        \(\beta\)
@@ -19,7 +19,7 @@
      </a>
     </li>
     <li class="nav-item">
-     <a class="nav-link" href="section1/index.html">
+     <a class="nav-link nav-internal" href="section1/index.html">
       Section 1 index
      </a>
     </li>

--- a/tests/test_build/navbar_ix.html
+++ b/tests/test_build/navbar_ix.html
@@ -23,6 +23,11 @@
       Section 1 index
      </a>
     </li>
+    <li class="nav-item">
+     <a class="nav-link nav-external" href="https://google.com">
+      google
+     </a>
+    </li>
    </ul>
   </nav>
  </div>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -8,12 +8,12 @@
      </p>
      <ul class="navbar-nav" id="navbar-main-elements">
       <li class="nav-item">
-       <a class="nav-link" href="../page1.html">
+       <a class="nav-link nav-internal" href="../page1.html">
         Page 1
        </a>
       </li>
       <li class="nav-item">
-       <a class="nav-link" href="../page2.html">
+       <a class="nav-link nav-internal" href="../page2.html">
         Page
         <span class="math notranslate nohighlight">
          \(\beta\)
@@ -21,7 +21,7 @@
        </a>
       </li>
       <li class="nav-item current active">
-       <a class="nav-link" href="#">
+       <a class="nav-link nav-internal" href="#">
         Section 1 index
        </a>
       </li>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -25,6 +25,11 @@
         Section 1 index
        </a>
       </li>
+      <li class="nav-item">
+       <a class="nav-link nav-external" href="https://google.com">
+        google
+       </a>
+      </li>
      </ul>
     </nav>
    </div>

--- a/tests/test_build/test_navbar_no_in_page_headers.html
+++ b/tests/test_build/test_navbar_no_in_page_headers.html
@@ -1,11 +1,11 @@
 <ul class="navbar-nav" id="navbar-main-elements">
  <li class="nav-item">
-  <a class="nav-link" href="page1.html">
+  <a class="nav-link nav-internal" href="page1.html">
    Page 1
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" href="page2.html">
+  <a class="nav-link nav-internal" href="page2.html">
    Page 2
   </a>
  </li>


### PR DESCRIPTION
Fix #913 
Superced #1054 

@chrisjsewell, I itterated from your suggestion and used `urlib` to decide wether or not `page` is an absolute url. 
I'm adding a class to the elements as well: 
`nav-internal` and `nav-external` to follow what is done with the elements added from the conf.py file https://github.com/pydata/pydata-sphinx-theme/blob/7119c245c2ea3c52349310256128ef11aedd623f/src/pydata_sphinx_theme/__init__.py#L345

Let me know what you think