### PR TITLE
FIX: remove double quotes in github actions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -35,7 +35,7 @@ jobs:
           sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
 
       - name: Check that there are no unexpected Sphinx warnings
-        if: matrix.python-version == "3.10"
+        if: matrix.python-version == '3.10'
         run: python tests/check_warnings.py
 
       - name: Run the tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.9"
       - name: Build package
         run: |
           python -m pip install -U pip build


### PR DESCRIPTION
The latest prerelease run failed because of an error in the yaml file: https://github.com/pydata/pydata-sphinx-theme/actions/runs/3458681079

searching on the web, I found out that even though double quotes are legit in a yaml file, they are not currently supported by github actions
- https://github.com/actions/runner/issues/866
- https://docs.github.com/en/actions/learn-github-actions/expressions#:~:text=you%20must%20use%20single%20quotes.%20escape%20literal%20single-quotes%20with%20a%20single%20quote.

specifically: 

> You must use single quotes. Escape literal single quotes with a single quote.  

```yaml
myString: ${{ 'Mona the Octocat' }}
```

In order to avoid confusion for the next contributors I decided to remove all the unnecessary double quotes. 