### PR TITLE
Reduce the left padding for ul and ol lists

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_lists.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_lists.scss
@@ -5,8 +5,10 @@ dd {
   margin-left: 30px;
 }
 
-ol li > p:first-child,
-ul li > p:first-child {
-  margin-bottom: 0.25rem;
-  margin-top: 0.25rem;
+ol, ul {
+  padding-inline-start: 2rem;
+  li > p:first-child {
+    margin-bottom: 0.25rem;
+    margin-top: 0.25rem;
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_lists.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_lists.scss
@@ -5,7 +5,8 @@ dd {
   margin-left: 30px;
 }
 
-ol, ul {
+ol,
+ul {
   padding-inline-start: 2rem;
   li > p:first-child {
     margin-bottom: 0.25rem;


### PR DESCRIPTION
This is a minor style change - I noticed that our left padding for `ul`/`ol` lists was more aggressive than I've seen most websites use. This was unset in our style and was just following the default. I've set it here to `2rem` which cuts the padding by about half, and should save some horizontal space.