### PR TITLE
FIX: use the github repo of flake8 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:
       - id: flake8


### PR DESCRIPTION
It's causing errors in the most recent builds (https://github.com/pydata/pydata-sphinx-theme/actions/runs/3524547220/jobs/5910100842)