### PR TITLE
Check for /-/ in GitLab url (closes #1073)

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1007,7 +1007,9 @@ class ShortenLinkTransform(SphinxPostTransform):
 
         elif self.platform == "gitlab":
             # cp. https://docs.gitlab.com/ee/user/markdown.html#gitlab-specific-references
-            if "/-/" in path and any(map(uri.path.__contains__, ["issues", "merge_requests"])):
+            if "/-/" in path and any(
+                map(uri.path.__contains__, ["issues", "merge_requests"])
+            ):
                 group_and_subgroups, parts, *_ = path.split("/-/")
                 parts = parts.split("/")
                 url_type, element_number, *_ = parts

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1007,7 +1007,7 @@ class ShortenLinkTransform(SphinxPostTransform):
 
         elif self.platform == "gitlab":
             # cp. https://docs.gitlab.com/ee/user/markdown.html#gitlab-specific-references
-            if any(map(uri.path.__contains__, ["issues", "merge_requests"])):
+            if "/-/" in path and any(map(uri.path.__contains__, ["issues", "merge_requests"])):
                 group_and_subgroups, parts, *_ = path.split("/-/")
                 parts = parts.split("/")
                 url_type, element_number, *_ = parts

--- a/tests/sites/base/page1.rst
+++ b/tests/sites/base/page1.rst
@@ -23,6 +23,7 @@ Page 1
     https://gitlab.com/gitlab-org
     https://gitlab.com/gitlab-org/gitlab
     https://gitlab.com/gitlab-org/gitlab/-/issues/375583
+    https://gitlab.com/gitlab-org/gitlab/issues/375583
     https://gitlab.com/gitlab-org/gitlab/-/merge_requests/84669
     https://gitlab.com/gitlab-org/gitlab/-/pipelines/511894707
     https://gitlab.com/gitlab-com/gl-infra/production/-/issues/6788

--- a/tests/test_build/gitlab_links.html
+++ b/tests/test_build/gitlab_links.html
@@ -12,6 +12,9 @@
   <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/-/issues/375583">
    gitlab-org/gitlab#375583
   </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/issues/375583">
+   gitlab-org/gitlab/issues/375583
+  </a>
   <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/-/merge_requests/84669">
    gitlab-org/gitlab!84669
   </a>


### PR DESCRIPTION
Make sure the /-/ string exists in path before splitting the path to avoid exception

Exception occurred:
  File "c:\dev\gitlab\aero-software\internal\docs\venv\lib\site-packages\pydata_sphinx_theme\__init__.py", line 998, in parse_url
    group_and_subgroups, parts, *_ = path.split("/-/")
ValueError: not enough values to unpack (expected at least 2, got 1)

closes #1073