### PR TITLE
WIP - ENH  - Fix PyData brand colour contrast issues

### DIFF
--- a/docs/user_guide/accessibility.rst
+++ b/docs/user_guide/accessibility.rst
@@ -8,8 +8,8 @@
 Accessibility
 *************
 
-Creating and publishing content that does not exclude audiences with limited abilities
-of various kinds is challenging, but also important, to achieve and then maintain.
+Creating and publishing content that does not exclude disabled readers is a challenging
+yet extremely important and impactful task, to achieve and then maintain.
 
 While there is no one-size-fits-all solution to maintaining accessible content, this
 theme and documentation site use some techniques to avoid common content shortcomings.
@@ -34,11 +34,21 @@ page that lacks metadata, please open a pull request to add it!
 Colors
 ======
 
+Syntax highlighting
+-------------------
+
 Our default code highlighting styles are ``a11y-high-contrast-light`` and
 ``a11y-high-contrast-dark`` from https://github.com/Quansight-Labs/accessible-pygments.
-These styles are designed to be more accessible to users with limited visual abilities.
+These styles are designed to be more accessible by meeting `WCAG 2.1 criteria for color contrast <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`__.
 If you don't like the look of our default code highlighting styles, there are several more
 to choose from at https://github.com/Quansight-Labs/accessible-pygments.
+
+Default branding colors
+-----------------------
+
+The PyData Sphinx Theme uses a modified version of the PyData brand colors to ensure
+the theme complies with the `WCAG 2.1 criteria for color contrast <https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html>`__,
+both, in dark and light mode.
 
 
 What You Can Do
@@ -55,7 +65,7 @@ Natural Language
 ----------------
 
 If not using a more robust `internationalization approach <https://www.sphinx-doc.org/en/master/usage/advanced/intl.html>`__,
-specifying at least the baseline natural language will help assistive technology
+specifying at least the baseline natural language will help assistive technology (such as screen readers)
 identify if the content is in a language the reader understands.
 
 .. Hint::
@@ -75,7 +85,7 @@ approach to telling programs like search engines and assistive technologies wher
 different content appears on a website.
 
 If using a service like `ReadTheDocs <https://readthedocs.com>`__, these files
-will be created for you *automatically*, but for some of the other approaches below,
+will be created for you *automatically*, but for some other approaches below,
 it's handy to generate a `sitemap.xml` locally or in CI with a tool like
 `sphinx-sitemap <https://pypi.org/project/sphinx-sitemap/>`__.
 
@@ -153,3 +163,15 @@ automation, page performance, and other best practices.
 
     Specifically, `foo-software/lighthouse-check-action <https://github.com/foo-software/lighthouse-check-action>`__
     is run on selected pages from the generated documentation site.
+
+Other useful resources
+======================
+
+It is important to ensure your color choices are accessible when customizing your documentation theme.
+
+Color contrast checkers
+-----------------------
+
+- `WebAIM link contrast checker <https://webaim.org/resources/linkcontrastchecker>`__: useful to check links color contrast.
+- `Mozilla color picker tool <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Colors/Color_picker_tool>`__: to create and adjust custom colors for the web, as well to convert among various color formats.
+- `Adobe color contrast analyser <https://color.adobe.com/create/color-contrast-analyzer>`__: useful to check the contrast between two colors, and find suitable alternatives to meet WCAG 2.1 contrast criteria.

--- a/docs/user_guide/styling.rst
+++ b/docs/user_guide/styling.rst
@@ -39,7 +39,7 @@ used to quickly control behavior and display across your documentation.
 These are based on top of the basic `Bootstrap CSS variables <https://getbootstrap.com/docs/4.0/getting-started/theming/#css-variables>`_
 extended with some theme specific variables.
 
-base variables
+Base variables
 --------------
 
 In order to change a variable, follow these steps:
@@ -97,8 +97,9 @@ Here is an overview of the colors available in the theme (change theme mode to s
       span.pst-badge {border: 1px solid var(--pst-color-text-base);}
       span.pst-primary {background-color: var(--pst-color-primary);}
       span.pst-secondary {background-color: var(--pst-color-secondary);}
-      span.pst-success {background-color: var(--pst-color-success);}
       span.pst-info {background-color: var(--pst-color-info);}
+      span.pst-success {background-color: var(--pst-color-success);}
+      span.pst-attention {background-color: var(--pst-color-attention);}
       span.pst-warning {background-color: var(--pst-color-warning);}
       span.pst-danger {background-color: var(--pst-color-danger);}
       span.pst-background {background-color: var(--pst-color-background);}
@@ -111,8 +112,9 @@ Here is an overview of the colors available in the theme (change theme mode to s
     <p>
       <span class="sd-sphinx-override sd-badge pst-badge pst-primary">primary</span>
       <span class="sd-sphinx-override sd-badge pst-badge pst-secondary">secondary</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-success">success</span>
       <span class="sd-sphinx-override sd-badge pst-badge pst-info">info</span>
+      <span class="sd-sphinx-override sd-badge pst-badge pst-success">success</span>
+      <span class="sd-sphinx-override sd-badge pst-badge pst-attention">attention</span>
       <span class="sd-sphinx-override sd-badge pst-badge pst-warning">warning</span>
       <span class="sd-sphinx-override sd-badge pst-badge pst-danger">danger</span>
       <span class="sd-sphinx-override sd-badge pst-badge pst-background">background</span>
@@ -184,7 +186,8 @@ For a complete list of the theme colors that you may override, see the :download
 Configure pygments theme
 ========================
 
-As the Sphinx theme supports multiple modes, the code highlighting colors can be modified for each one of them by modifying the ``pygment_light_style`` and ``pygment_dark_style``. You can check available Pygments colors on this `page <https://pygments.org/styles/>`__.
+As the Sphinx theme supports multiple modes, the code highlighting colors can be modified for each one of them by modifying the ``pygment_light_style`` and ``pygment_dark_style``. You can check available `Pygments colors on this page <https://pygments.org/styles/>`__ as well
+as `WCAG-conformant pygments styles <https://github.com/Quansight-Labs/accessible-pygments>`__ that you can use in your documentation.
 
 .. code-block:: python
 

--- a/docs/user_guide/theme-elements.md
+++ b/docs/user_guide/theme-elements.md
@@ -184,7 +184,7 @@ For example:
   - `[https://github.com/pydata/pydata-sphinx-theme/pull/1012](https://github.com/pydata/pydata-sphinx-theme/pull/1012)`
   - [https://github.com/pydata/pydata-sphinx-theme/pull/1012](https://github.com/pydata/pydata-sphinx-theme/pull/1012)
 
-- **MyST Markdown with [MyST Linkify](https://myst-**parser.readthedocs.io/en/latest/syntax/optional.html#linkify)
+- **MyST Markdown with [MyST Linkify](https://myst-**parser.readthedocs.io/en/latest/syntax/optional.html#linkify)**
   - `https://github.com/pydata/pydata-sphinx-theme/pull/1012`
   - https://github.com/pydata/pydata-sphinx-theme/pull/1012
 

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -42,14 +42,13 @@
  * A consistent box shadow style we apply across elements.
  */
 @mixin box-shadow() {
-  box-shadow: 0 0.2rem 0.5rem var(--pst-color-shadow),
-    0 0 0.0625rem var(--pst-color-shadow) !important;
+  box-shadow: 0 0.2rem 0.5rem var(--pst-color-shadow), 0 0 0.0625rem var(--pst-color-shadow) !important;
 }
 
 /**
  * create a low opacity background behind object using our variable colors
  */
-@mixin background-from-color-variable($color-variable, $opacity: 0.1) {
+@mixin background-from-color-variable($color-variable, $opacity: 0.2) {
   // This is a hack to create a light background with controlled opacity
   // using our css color variables
   // ref: https://stackoverflow.com/a/56951626/6734243

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -48,7 +48,7 @@
 /**
  * create a low opacity background behind object using our variable colors
  */
-@mixin background-from-color-variable($color-variable, $opacity: 0.2) {
+@mixin background-from-color-variable($color-variable, $opacity: 0.1) {
   // This is a hack to create a light background with controlled opacity
   // using our css color variables
   // ref: https://stackoverflow.com/a/56951626/6734243

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -47,7 +47,7 @@ a {
 
   &.headerlink {
     color: var(--pst-color-warning);
-    opacity: 0.4;
+    opacity: 0.7;
     font-size: 0.8em;
     padding: 0 4px 0 4px;
     margin-left: 0.2em;

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -10,13 +10,13 @@ $pst-semantic-colors: (
     "light": rgb(0, 130, 146),
   ),
   "secondary": (
-    "dark": rgb(252, 165, 0),
+    "dark": rgb(235, 131, 0),
     "light": rgb(176, 98, 0),
   ),
   // semantic colours - used to indicate state or purpose
   "info": #1d7afc,
   "warning": (
-    "dark": rgb(252, 165, 0),
+    "dark": rgb(235, 131, 0),
     "light": rgb(235, 131, 0),
   ),
   "success": (
@@ -45,7 +45,7 @@ $pst-semantic-colors: (
   ),
   "shadow": (
     "light": rgb(216, 216, 216),
-    "dark": rgb(0, 0, 0),
+    "dark": rgb(6, 6, 6),
   ),
   "border": (
     "light": rgb(201, 201, 201),

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -6,18 +6,18 @@
 */
 $pst-semantic-colors: (
   "primary": (
-    "dark": rgb(102, 205, 218),
+    "dark": rgb(5, 174, 194),
     "light": rgb(0, 130, 146),
   ),
   "secondary": (
-    "dark": rgb(235, 131, 0),
-    "light": rgb(176, 98, 0),
+    "dark": rgb(217, 112, 8),
+    "light": rgb(182, 92, 2),
   ),
   // semantic colours - used to indicate state or purpose
   "info": #1d7afc,
   "warning": (
-    "dark": rgb(235, 131, 0),
-    "light": rgb(235, 131, 0),
+    "light": rgb(217, 112, 8),
+    "dark": rgb(238, 144, 64),
   ),
   "success": (
     "light": rgb(34, 160, 107),
@@ -52,8 +52,8 @@ $pst-semantic-colors: (
     "dark": rgb(192, 192, 192),
   ),
   "inline-code": (
-    "dark": rgb(255, 128, 200),
-    "light": rgb(191, 57, 137),
+    "dark": rgb(222, 135, 194),
+    "light": rgb(188, 15, 133),
   ),
   "target": (
     "light": rgb(251, 229, 78),

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -45,7 +45,7 @@ $pst-semantic-colors: (
   ),
   "shadow": (
     "light": rgb(216, 216, 216),
-    "dark": rgb(33, 33, 33),
+    "dark": rgb(0, 0, 0),
   ),
   "border": (
     "light": rgb(201, 201, 201),

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -5,13 +5,23 @@
 * NOTE: this theme defines "info == primary" and "warning == secondary"
 */
 $pst-semantic-colors: (
-  "primary": rgb(69, 157, 185),
-  "secondary": rgb(238, 144, 64),
-  "info": rgb(69, 157, 185),
-  "warning": rgb(238, 144, 64),
+  "primary": (
+    "dark": rgb(102, 205, 218),
+    "light": rgb(0, 130, 146),
+  ),
+  "secondary": (
+    "dark": rgb(252, 165, 0),
+    "light": rgb(176, 98, 0),
+  ),
+  // semantic colours - used to indicate state or purpose
+  "info": #1d7afc,
+  "warning": (
+    "dark": rgb(252, 165, 0),
+    "light": rgb(235, 131, 0),
+  ),
   "success": (
-    "light": rgb(40, 167, 69),
-    "dark": rgb(72, 135, 87),
+    "light": rgb(34, 160, 107),
+    "dark": rgb(75, 206, 151),
   ),
   "attention": (
     "light": rgb(255, 193, 7),
@@ -42,8 +52,8 @@ $pst-semantic-colors: (
     "dark": rgb(192, 192, 192),
   ),
   "inline-code": (
-    "light": rgb(232, 62, 140),
-    "dark": rgb(221, 158, 194),
+    "dark": rgb(255, 128, 200),
+    "light": rgb(191, 57, 137),
   ),
   "target": (
     "light": rgb(251, 229, 78),

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -107,7 +107,7 @@ $pst-semantic-colors: (
     }
     // assign the "duplicate" colors (ones that just reference other variables)
     --pst-color-link: var(--pst-color-primary);
-    --pst-color-link-hover: var(--pst-color-warning);
+    --pst-color-link-hover: var(--pst-color-secondary);
     // adapt to light/dark-specific content
     @if $mode == "light" {
       .only-dark {


### PR DESCRIPTION
## Done

This PR Closes #1052 

For easy comparison, I have [created a table with the corresponding colours and WCAG compliance](https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=%23FFFFFF%2C%20White%0D%0A%23f5f5f5%2C%20Surface%20(light-theme)%0D%0A%23e1e1e1%2C%20On%20surface%20(light-theme)%0D%0A%23121212%2C%0D%0A%23212121%2C%20Surface%20(dark-theme)%0D%0A%23313131%2C%20On%20surface%20(dark-theme)%0D%0A%0D%0A&foreground-colors=%2305AEC2%2C%20Primary%20(dark)%0D%0A%23008292%2C%20Primary%20(light)%0D%0A%23EB8300%2C%20Secondary-alt%20(dark)%0D%0A%23B06200%2C%20Secondary-alt%20(light)%0D%0A%23D97008%2C%20Secondary%20(dark)%0D%0A%23B65C02%2C%20Secondary%20(light)%0D%0A%23DE87C2%2C%20Inline%20code%20(dark)%0D%0A%23BC0F85%2C%20Inline%20code%20(light)%0D%0A&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18&es-color-form__show-contrast=dnp), some things to note:
- To ensure that text meets the colour contrast criteria of at least 4.5 for WCAG AA it was necessary to add `light` and `dark` variants to the primary and secondary colours (I used this instead of the alternative changes from @drammock of [separating text and non-text colours](https://github.com/drammock/pydata-sphinx-theme/commit/8df0c64561684ee216bc5846a2ddba1c97c88f04) - you mentioned wanting to keep the PyData colours for structural elements, but I believe this approach would add complexity in terms of having multiple slight variants of the colours as well as adding a more neutral theme. ) For reference see how the badges and buttons look now in the "Web components" section of the documentation in the image below, which I believe achieves what you were aiming for:
![Sphinx_Design_Components_—_PyData_Theme_0_12_1rc1_dev0_documentation](https://user-images.githubusercontent.com/23552331/208171851-4707ad6b-7762-4fe8-930b-8e1e20432610.png)

- To ensure the `.headerlink` permalinks pass the contrast criteria, I had to change the opacity to `0.7`
- I noticed that the link hover colour was [assigned from the `warning` colour](https://github.com/pydata/pydata-sphinx-theme/blob/f367a58af33be362351686f1e207ea099f8e529e/src/pydata_sphinx_theme/assets/styles/variables/_color.scss#L100), since I tweaked the PyData colours to ensure enough contrast without being too jarring I swapped the link hover to `secondary`. This also fixes the contrast issue for links in `<code>` elements.
- The trickiest (and most tedious part) was checking the admonition colours (and those of elements with opacity), so [I have another comparison table for you all](https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=%23322223%2C%20Danger%20(Opacity%200.1)%0D%0A%23fbeeee%2C%20Danger%20(light%2C%20Opacity%200.1)%0D%0A%23222a24%2C%20Success%20%20(Opacity%200.1)%0D%0A%23342e1f%2C%20Attention%20%20(Opacity%200.1)%0D%0A%23fff9ec%2C%20Attention%20%20(light%2C%20Opacity%200.1)%0D%0A%23222c30%2C%20Info%20%20(Opacity%200.1)%0D%0A%23ecf3ff%2C%20Info%20%20(light%2C%20Opacity%200.1)%0D%0A%23372b21%2C%20Warning%20%20(Opacity%200.1)%0D%0A%23fdf4ee%2C%20Warning%20%20(light%2COpacity%200.1)%0D%0A%23121212%0D%0A%23ffffff&foreground-colors=%23cb4653%2C%20Danger%20(light)%0D%0A%23dc3545%2C%20Danger%20(dark)%0D%0A%2328a745%2C%20Success%20(dark)%0D%0A%23488757%2C%20Success%20(light)%0D%0A%23ffc107%2C%20Attention%20(dark)%0D%0A%23dca90f%2C%20Attention%20(light)%0D%0A%23ee9040%2C%20Warning%20(dark)%0D%0A%23d97008%2C%20Warning%20(light)%0D%0A%231d7afc%2C%20Info%0D%0A%23cecece%2C%20Text%0D%0A%23121212%0D%0A%23ffffff&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18).
  - I had to manually get the colours from the colours with an opacity different to 1 (rows in the table)
  - The only colours I made adjustments to are the `warning` and `success` ones to ensure there is enough contrast where needed (admonition icons and buttons meet at least 3:1)
  - Almost all the admonition the icons meet the WCAG contrast requirement of 3:1 for non-text elements and the title has enough contrast against the background (the only exception is the `attention` one but I added a note below)
- Updates to the documentation to better reflect some changes and added some accessibility resources too (though it seems the `Danger` note in https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/styling.html#configure-pygments-theme needs updating , I am not entirely sure)
- Also I made some adjustment to the dark-theme shadow as I noticed @drammock had these too in his [WIP-commits](https://github.com/drammock/pydata-sphinx-theme/commit/d68bbd89caacf5335f4b5505d11726018b46c038)
  
 ## TODO
 
 Contrast issues still present:
 1. `dark-theme` - link colour on announcement banner (currently 4.33 between `#05AEC2` and `#152a4a`
 2. `light-theme` - link colour on announcement banner (currently 3.61 between `#098292` and `#d8e6fe`
 3. the buttons text (see image above) do not have enough contrast against the background in both themes (it seems [the function that handles the `text-color`](https://github.com/pydata/pydata-sphinx-theme/blob/f367a58af33be362351686f1e207ea099f8e529e/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss#L32) needs some adjustments)
![Sphinx_Design_Components_—_PyData_Theme_0_12_1rc1_dev0_documentation](https://user-images.githubusercontent.com/23552331/208173696-c994d4d9-e1bc-4254-81cc-090718211579.png)
4. Not enough colour contrast for `code` elements on the sidebar for example:
![Sphinx_Design_Components_—_PyData_Theme_0_12_1rc1_dev0_documentation](https://user-images.githubusercontent.com/23552331/208174104-91f3ff4d-2b0f-4845-a479-5c17ba9973ee.png)
5. Need to make a slight tweak to the `attention` colour for the light theme as currently, the contrast is 2.4:1 and it needs to be 3:1 for non-text elements (like admonition icons)

Perhaps 3 and 4 need to be done separately to avoid too many changes in this PR and would be best suited as part of #1079 or other PRs aimed at improving the theme as a whole.

A review in the meantime would be appreciated.

### Suggested links to look at

_added by @choldgraf_

| This PR                                                                                                                    | Dev                                                                                                                        |
| -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
| [Admonitions](https://pydata-sphinx-theme--1086.org.readthedocs.build/en/1086/examples/kitchen-sink/admonitions.html)      | [Admonitions](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/admonitions.html)      |
| [Generic items](https://pydata-sphinx-theme--1086.org.readthedocs.build/en/1086/examples/kitchen-sink/generic.html)        | [Generic items](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/generic.html)        |
| [Sphinx design components](https://pydata-sphinx-theme--1086.org.readthedocs.build/en/1086/user_guide/web-components.html) | [Sphinx design components](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/web-components.html) | 