### PR TITLE
style dataframe included in a widget

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
@@ -9,7 +9,7 @@
 /*******************************************************************************
  * nbsphinx
  */
-html div.rendered_html 
+html div.rendered_html
 // NBsphinx ipywidgets output selector
 html .jp-RenderedHTMLCommon {
   table {

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
@@ -9,8 +9,9 @@
 /*******************************************************************************
  * nbsphinx
  */
-html .jp-RenderedHTMLCommon,
-html div.rendered_html {
+html div.rendered_html 
+// NBsphinx ipywidgets output selector
+html .jp-RenderedHTMLCommon {
   table {
     table-layout: auto;
   }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
@@ -9,7 +9,7 @@
 /*******************************************************************************
  * nbsphinx
  */
-
+html .jp-RenderedHTMLCommon,
 html div.rendered_html {
   table {
     table-layout: auto;


### PR DESCRIPTION
add the `jp-RenderedHTMLCommon` special case from nbsphinx custom styling to get the "auto" layout when table are embeded in a widget as well. 

Fix #1063 

an example from the initial issue (https://github.com/ClementPinard/pydata-nbsphinx-pandas-bug-example) built with this PR: 

<img width="842" alt="Capture d’écran 2022-12-19 à 23 35 37" src="https://user-images.githubusercontent.com/12596392/208540446-ead7f5b5-0276-4201-99e2-de38faefc249.png">


