### PR TITLE
add matplotlib to the list of warnings

### DIFF
--- a/tests/warning_list.txt
+++ b/tests/warning_list.txt
@@ -16,6 +16,7 @@ WARNING: image file not readable: _static/gallery/feature-engine.png
 WARNING: image file not readable: _static/gallery/arviz.png
 WARNING: image file not readable: _static/gallery/sepal.png
 WARNING: image file not readable: _static/gallery/enoslib.png
+WARNING: image file not readable: _static/gallery/matplotlib.png
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.count'. Check your autosummary_generate setting.
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.index'. Check your autosummary_generate setting.
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResultBytes.count'. Check your autosummary_generate setting.


### PR DESCRIPTION
I validated #1090 even though I created this file. Gallery images are effectively not build during tests but we need to add the new missing image to the list to avoid failure of ALL downstream tests 😄