### PR TITLE
FIX: Use logo_url instead deprecated logo in theme (#1094)

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -7,9 +7,9 @@
 {% endif %}
 <a class="navbar-brand logo" href="{{ href }}">
   {# get all the brand information from html_theme_option #}
-  {% set is_logo = logo or theme_logo.get("image_light") or theme_logo.get("image_dark") %}
-  {% set image_light = theme_logo.get("image_light") or logo %}
-  {% set image_dark = theme_logo.get("image_dark") or logo %}
+  {% set is_logo = logo_url or theme_logo.get("image_light") or theme_logo.get("image_dark") %}
+  {% set image_light = theme_logo.get("image_light") or logo_url %}
+  {% set image_dark = theme_logo.get("image_dark") or logo_url %}
   {% set image_light = image_light if image_light.startswith("http") else pathto('_static/' + image_light, 1) %}
   {% set image_dark = image_dark if image_dark.startswith("http") else pathto('_static/' + image_dark, 1) %}
   {% set alt = theme_logo.get("alt_text", "Logo image") %}


### PR DESCRIPTION
Hey, quickly fixed the issue described in #1094 - from a quick look over the code it seems that this is nowhere else used (and favicon neither, which was as well deprecated in sphinx).

resolves #1094 