### PR TITLE
drop prettify to avoid extra space in inline block

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -530,10 +530,10 @@ def add_toctree_functions(app, pagename, templatename, context, doctree):
             if not title.select(".toc-h2"):
                 out = ""
             else:
-                out = title.find("ul").prettify()
+                out = title.find("ul")
         # Else treat the h1 headers as sections
         else:
-            out = soup.prettify()
+            out = soup
 
         # Return the toctree object
         if kind == "html":


### PR DESCRIPTION
Fix #1076 

It cost me 10 points of reputation on [SO](https://stackoverflow.com/questions/75032367/inline-code-is-filling-the-space-to-the-right/75039540#75039540) (as usual when you are not a CSS/html expert) but someone leads me to the right direction. 

The issue was again the call to `prettify()` method as in the primary sidebar. 

In short the `prettify()` paradigm is to put each tag on a single line which makes it more readable and easier to debug BUT this is also creating extra spaces for inline blocks (span, pre, code, a etc...) each time you do a line break. 

By removing the call to `prettify()` alltogether it solved the problem.