### PR TITLE
Fixing header height

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -1,6 +1,6 @@
 html {
   font-size: var(--pst-font-size-base);
-  scroll-padding-top: calc(var(--pst-header-height) + 12px);
+  scroll-padding-top: calc(var(--pst-header-height) + 1rem);
 }
 
 body {

--- a/src/pydata_sphinx_theme/assets/styles/components/header/_header-logo.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/header/_header-logo.scss
@@ -1,8 +1,9 @@
 .navbar-brand {
   position: relative;
   height: var(--pst-header-height);
+  max-height: var(--pst-header-height);
+  padding: 0.5rem 0;
   width: auto;
-  padding: 0;
   margin: 0;
   display: flex;
   align-items: center;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -13,7 +13,8 @@
   background: var(--pst-color-on-background) !important;
   box-shadow: 0 0.125rem 0.25rem 0 var(--pst-color-shadow);
 
-  min-height: var(--pst-header-height);
+  height: var(--pst-header-height);
+  max-height: var(--pst-header-height);
   width: 100%;
   padding: 0.5rem 0;
   max-width: 100vw;

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -5,7 +5,7 @@ html {
 
   // Header height will impact the top offset for many sections
   // Article header is 66% of Header
-  --pst-header-height: 3rem;
+  --pst-header-height: 4rem;
   --pst-header-article-height: calc(var(--pst-header-height) * 2 / 3);
   --pst-sidebar-secondary: 17rem;
 }


### PR DESCRIPTION
I realized that our header height was not properly being set, and this was causing `h1` and `h2` titles to be too-close to the header when clicking anchor links.

The problem was that we defined a `--pst-header-height` variable, but we did not force the header height to max-out at that variable. So the content of the header was causing it to expand in height. This made it look correct to us, but technically the header height wasn't the variable we had set. Because the anchors were set to a padding _relative to_ the header height variable, their positioning was wrong.

So this PR forces the header to have the height we want, and increases the height from `3rem` to `4rem` which mimics the behavior we are used to. 