### PR TITLE
FIX: Center search keyboard buttons

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -48,6 +48,7 @@
 
   // Shows off the keyboard shortcuts for the button
   .search-button__kbd-shortcut {
+    display: flex;
     position: absolute;
     right: 2em;
     color: var(--pst-color-border);


### PR DESCRIPTION
A very minor fix - I noticed that the "keyboard suggestion" buttons in the search field were just slightly not centered vertically:

(look at the buttons on the right)

<img width="349" alt="chrome_NmGirTPGFA" src="https://user-images.githubusercontent.com/1839645/211153869-7ad1eae3-06dd-4e23-b417-4f1972ef962f.png">

This adds `display:flex` so that they take up their available vertical space and are centered vertically:

<img width="434" alt="chrome_UTCmJ2Vjxy" src="https://user-images.githubusercontent.com/1839645/211153884-e36db05d-306d-453a-a106-868ddf4d0a3e.png">
