### PR TITLE
make code-block focusable

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -923,7 +923,7 @@ def _overwrite_pygments_css(app, exception=None):
 
 
 # ------------------------------------------------------------------------------
-# customize rendering of the links
+# customize rendering of tag elements
 # ------------------------------------------------------------------------------
 
 

--- a/src/pydata_sphinx_theme/bootstrap_html_translator.py
+++ b/src/pydata_sphinx_theme/bootstrap_html_translator.py
@@ -103,7 +103,7 @@ class BootstrapHTML5Translator(HTML5Translator):
             node,
             "div",
             suffix="",
-            CLASS="highlight-%s notranslate" % lang,
+            CLASS=f"highlight-{lang} notranslate",
             tabindex="0",
         )
         self.body.append(starttag + highlighted + "</div>\n")


### PR DESCRIPTION
Fix #1100 

That was way more complicated than expected. 

3 possible choices are available: 
- use pure JS to add the tabindex attributes at run time 
- parse the page and search for "pre" elements
- override the `visit_literal_block` method

By looking more carefully at it I realized that not all the "pre" elements are actually generated by docutils (the one included in highlighted code for example are never parsed) so I decided to overwrite the `visit_literal_block` to get both the `div` including the code elements and the `pre` from non highlighted elements.

before: 
https://pydata-sphinx-theme.readthedocs.io/en/stable/examples/kitchen-sink/blocks.html#code-block

after:
https://pydata-sphinx-theme--1104.org.readthedocs.build/en/1104/examples/kitchen-sink/blocks.html#literal-blocks