### PR TITLE
feat: support leaflet maps in the theme

### DIFF
--- a/docs/examples/pydata.md
+++ b/docs/examples/pydata.md
@@ -89,7 +89,7 @@ data = xr.DataArray(
 data
 ```
 
-## `jupyter-sphinx`
+## jupyter-sphinx
 
 Another common library is `jupyter-sphinx`.
 This section demonstrates a subset of functionality above to make sure it behaves as expected.
@@ -102,4 +102,16 @@ rng = np.random.default_rng()
 data = rng.standard_normal((3, 100))
 fig, ax = plt.subplots()
 ax.scatter(data[0], data[1], c=data[2], s=3)
+```
+
+## ipyleaflet
+
+`ipyleaflet` is a **Jupyter**/**Leaflet** bridge enabling interactive maps in the Jupyter notebook environment. this demonstrate how you can integrate maps in your documentation.
+
+```{jupyter-execute}
+from ipyleaflet import Map, basemaps
+
+# display a map centered on France
+m = Map(basemap=basemaps.Esri.WorldImagery,  zoom=5, center=[46.21, 2.21])
+m
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,8 @@ doc = [
   "sphinx-togglebutton",
   # Install nbsphinx in case we want to test it locally even though we can't load
   # it at the same time as MyST-NB.
-  "nbsphinx"
+  "nbsphinx",
+  "ipyleaflet",
 ]
 test = [
   "pytest",

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_leaflet.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_leaflet.scss
@@ -1,0 +1,14 @@
+/**
+ * style for the various mapping libs based on leaflet (folium, geemap, ipyleaflet)
+ * mainly ensure the good display of the maps in both themes and avoid the customization
+ * of the tiles
+ */
+
+/**
+ * avoid border override from pydata-sphinx-theme
+ * minimal selctor to get the priority
+ */
+html[data-theme="dark"] .bd-content img.leaflet-tile.leaflet-tile-loaded {
+  border-radius: 0;
+  padding: 0;
+}

--- a/src/pydata_sphinx_theme/assets/styles/pydata-sphinx-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/pydata-sphinx-theme.scss
@@ -69,6 +69,7 @@
 @import "./extensions/sphinx_panels";
 @import "./extensions/togglebutton";
 @import "./extensions/notebooks";
+@import "./extensions/leaflet";
 
 // Page-specific CSS
 @import "./pages/search";


### PR DESCRIPTION
Fix #1110 

There are several libs to bind Python and leaflet (folium, geemap, sepal-ui, ipyleaflet) and the dark theme was badly modifying there display in the dark theme. 
These libs are widely used in the GIS community so I thought it worth our time to make sure they display nicely. 

I used `ipylealflet` in the doc as it's the most commonly used and all the others are outputting the same tile class (`leaflet-tile`) so it should work the same. I created an extra file because some other surprises may rise in the future.

https://pydata-sphinx-theme--1112.org.readthedocs.build/en/1112/examples/pydata.html#ipyleaflet


<img width="1337" alt="Capture d’écran 2023-01-08 à 22 29 53" src="https://user-images.githubusercontent.com/12596392/211220051-a45589be-db8c-4949-8876-e2e5ca18503f.png">

