### PR TITLE
ENH: split doc generation to avoid sphinx-design requiring nonnewest …

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ from gallery_directive import GalleryDirective
 # -- Project information -----------------------------------------------------
 
 project = "PyData Theme"
-copyright = "2019, PyData Community"
+copyright = "2023, PyData Community"
 author = "PyData Community"
 
 import pydata_sphinx_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-doc = [
+doc_base = [
   "numpydoc",
   "myst-nb",
   "linkify-it-py",  # for link shortening
@@ -61,22 +61,25 @@ doc = [
   "numpy",
   "xarray",
   "sphinx-copybutton",
-  "sphinx-design",
   "sphinx-togglebutton",
+  "ipyleaflet",
+]
+doc = [
+  "sphinx-design",
   # Install nbsphinx in case we want to test it locally even though we can't load
   # it at the same time as MyST-NB.
   "nbsphinx",
-  "ipyleaflet",
+  "pydata-sphinx-theme[doc_base]"
 ]
 test = [
   "pytest",
-  "pydata-sphinx-theme[doc]",
+  "pydata-sphinx-theme[doc_base]",
 ]
 coverage = [
   "pytest-cov",
   "codecov",
   "colorama",
-  "pydata-sphinx-theme[test]",
+  "pydata-sphinx-theme[doc]",
 ]
 dev = [
   "pyyaml",


### PR DESCRIPTION
split doc generation to avoid sphinx-design requiring nonnewest sphinx version (#1099)

