### PR TITLE
fix: align sidebar sliding with the buttons

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-toggle.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-toggle.scss
@@ -100,15 +100,13 @@ input {
 }
 
 .bd-sidebar-primary {
-  // One breakpoint less than $breakpoint-sidebar-primary. See variables/_layout.scss for more info.
-  @include media-breakpoint-down(md) {
+  @include media-breakpoint-down($breakpoint-sidebar-primary) {
     @include sliding-drawer("left");
   }
 }
 
 .bd-sidebar-secondary {
-  // One breakpoint less than $breakpoint-sidebar-secondary. See variables/_layout.scss for more info.
-  @include media-breakpoint-down(lg) {
+  @include media-breakpoint-down($breakpoint-sidebar-secondary) {
     @include sliding-drawer("right");
   }
 }


### PR DESCRIPTION
Fix #1082 

When I switched Bootstrap version I hunt all the occurrences of the breakpoints, I didn't realize that the sliding behaviour was hard coded. 

Problem solved:

![Enregistrement de l’écran 2023-01-21 à 17 13 10](https://user-images.githubusercontent.com/12596392/213876134-15e3517e-daf0-440d-bbd2-0b1a77aa8c78.gif)


