### PR TITLE
fix: use correct path for documentation logo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,6 @@ myst_enable_extensions = ["colon_fence", "linkify", "substitution"]
 # a list of builtin themes.
 #
 html_theme = "pydata_sphinx_theme"
-html_logo = "logo.svg"
 html_favicon = "_static/logo.svg"
 html_sourcelink_suffix = ""
 
@@ -124,6 +123,7 @@ html_theme_options = {
     ],
     "logo": {
         "text": "PyData Theme",
+        "image_light": "logo.svg",
         "image_dark": "logo-dark.svg",
         "alt_text": "PyData Theme",
     },


### PR DESCRIPTION
FIx #1130 