### PR TITLE
Test with sphinx 6

### DIFF
--- a/.github/workflows/legacy-and-latest.yml
+++ b/.github/workflows/legacy-and-latest.yml
@@ -1,0 +1,52 @@
+name: "test legacy and latest versions"
+
+# This workflow tests our oldest supported Python and Sphinx versions, as well
+# as the newest (pre)released versions, on the three major OSes. When support
+# for a given version is dropped or a new version is (pre)released, update the
+# `matrix` includes in the `strategy` section.
+
+# Note that this only runs the tests, it does not do a full build of our own
+# docs. This is necessary because at present some of our build (but not test)
+# dependencies have an upper pin on the Sphinx version. See comments in
+# pyproject.toml
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - python-version: "3.7" # legacy
+            sphinx-version: "4.2" # legacy
+          - python-version: "3.12-dev" # latest
+            sphinx-version: "6.x-dev" # latest
+
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: "pyproject.toml"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install -e .[test] sphinx==${{ matrix.sphinx-version }}
+
+      - name: Show installed versions
+        run: python -m pip list
+
+      - name: Run tests
+        run: pytest --color=yes pydata_sphinx_theme

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   COVERAGE_THRESHOLD: 60
+  DEFAULT_PY_VERSION: "3.9" # for the jobs that don't use a matrix
 
 jobs:
   lint:
@@ -19,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - uses: pre-commit/action@v3.0.0
@@ -30,17 +31,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         include:
           - os: macos-latest
-            python-version: "3.9"
+            python-version: ${{ env.DEFAULT_PY_VERSION }}
           - os: windows-latest
-            python-version: "3.9"
+            python-version: ${{ env.DEFAULT_PY_VERSION }}
 
     steps:
-      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
@@ -50,42 +51,35 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install -e .[coverage]
-          python -m pip list
 
-      - name: Test Sphinx==4.2
-        if: matrix.python-version == '3.7'
-        run: |
-          python -m pip install sphinx==4.2
-          python -m pip list
+      - name: Show installed versions
+        run: python -m pip list
 
-      - name: Build docs to store
+      - name: Build docs
         run: sphinx-build -b html docs/ docs/_build/html --keep-going -w warnings.txt
 
-      - name: Check that there are no unexpected Sphinx warnings
-        if: matrix.python-version == '3.9'
+      - name: Check for unexpected Sphinx warnings
+        if: matrix.python-version == ${{ env.DEFAULT_PY_VERSION }}
         run: python tests/check_warnings.py
 
-      - name: Run the tests
+      - name: Run tests
         run: pytest --color=yes --cov pydata_sphinx_theme --cov-branch --cov-report term-missing:skip-covered --cov-fail-under ${{ env.COVERAGE_THRESHOLD }}
 
       - name: Upload coverage
-        if: ${{ always() }}
+        if: success() || failure() # always run, unless manually cancelled
         run: codecov
 
   # Run local Lighthouse audit against built site
   audit:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Set up Python ${{ env.DEFAULT_PY_VERSION }}
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
 
@@ -110,7 +104,7 @@ jobs:
 
       # The lighthouse audit runs directly on the HTML files, no serving needed
       - name: Audit with Lighthouse
-        uses: treosh/lighthouse-ci-action@v9
+      - uses: treosh/lighthouse-ci-action@v9
         with:
           configPath: ".github/workflows/lighthouserc.json"
           temporaryPublicStorage: true
@@ -120,17 +114,14 @@ jobs:
   # Generate a profile of the code and upload as an artifact
   profile:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up Python ${{ env.DEFAULT_PY_VERSION }}
+      - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.DEFAULT_PY_VERSION }}
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ from gallery_directive import GalleryDirective
 # -- Project information -----------------------------------------------------
 
 project = "PyData Theme"
-copyright = "2019, PyData Community"
+copyright = "2023, PyData Community"
 author = "PyData Community"
 
 import pydata_sphinx_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ classifiers = [
 [project.optional-dependencies]
 doc_base = [
   "numpydoc",
-  "myst-nb",
   "linkify-it-py",  # for link shortening
   "pytest",
   "pytest-regressions",
@@ -62,13 +61,17 @@ doc_base = [
   "xarray",
   "sphinx-copybutton",
   "sphinx-togglebutton",
-  "ipyleaflet",
-]
-doc = [
-  "sphinx-design",
   # Install nbsphinx in case we want to test it locally even though we can't load
   # it at the same time as MyST-NB.
   "nbsphinx",
+  "ipyleaflet",
+]
+doc = [
+  # these place an upper pin on Sphinx, so we separate them out and exclude
+  # them from the `[test]` set of dependencies so we can test against latest
+  # Sphinx.
+  "myst-nb",
+  "sphinx-design",
   "pydata-sphinx-theme[doc_base]"
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-doc = [
+doc_base = [
   "numpydoc",
   "myst-nb",
   "linkify-it-py",  # for link shortening
@@ -61,22 +61,25 @@ doc = [
   "numpy",
   "xarray",
   "sphinx-copybutton",
-  "sphinx-design",
   "sphinx-togglebutton",
+  "ipyleaflet",
+]
+doc = [
+  "sphinx-design",
   # Install nbsphinx in case we want to test it locally even though we can't load
   # it at the same time as MyST-NB.
   "nbsphinx",
-  "ipyleaflet",
+  "pydata-sphinx-theme[doc_base]"
 ]
 test = [
   "pytest",
-  "pydata-sphinx-theme[doc]",
+  "pydata-sphinx-theme[doc_base]",
 ]
 coverage = [
   "pytest-cov",
   "codecov",
   "colorama",
-  "pydata-sphinx-theme[test]",
+  "pydata-sphinx-theme[doc]",
 ]
 dev = [
   "pyyaml",


### PR DESCRIPTION
This PR hopefully gets us a CI environment that runs Sphinx 6. It does this by:

- in `pyproject.toml`, separates out `mystnb` and `sphinx-design` because they put an upper pin on sphinx. This allows us to do `pip install -e .[test]` and get an environment that includes sphinx 6 instead of sphinx 5. I cherry-picked a commit from @nicoa from #1113 to give credit; but this will supersede that PR.
- adds a new workflow file that only runs tests (not lint, audit, doc build, etc) and runs them only on 2 configs: oldest python + oldest sphinx, and newest python + newest sphinx. Currently this is Sphinx 4.2 on Python 3.7, and Sphinx 6.x on Python 3.12 alpha.
- cleans up the existing `.github/workflows/tests.yml` to remove redundancy (i.e., don't need py 3.7 in the matrix anymore) and to standardize the other (non-matrix) jobs to all use the same Python version.

closes #1113
