### PR TITLE
MAINT: update prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install (prerelease) dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          python -m pip install --upgrade --pre -e .[test]
+          python -m pip install --upgrade --pre -e .[doc,test]
 
       - name: Build docs to store
         run: |


### PR DESCRIPTION
after changes to `pyproject.toml` in #1136 the prerelease tests will fail. This should allow them to continue to work.