### PR TITLE
remove emoji from landing page

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,11 +104,7 @@ jobs:
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - name: Install dependencies
-        shell: bash
-        # setting shell to BASH and using PYTHONUTF8 env var makes the editable
-        # install work on Windows even though there are emoji in our README
         run: |
-          export PYTHONUTF8=1
           python -m pip install --upgrade pip wheel setuptools
           python -m pip install -e .[doc]
       - name: Show installed versions

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 A clean, three-column, Bootstrap-based Sphinx theme by and for the [PyData community](https://pydata.org).
 
-- 📚 Documentation: https://pydata-sphinx-theme.readthedocs.io/en/stable
-- 💡 Examples: https://pydata-sphinx-theme.readthedocs.io/en/stable/examples
-- 🙌 Contribute: https://pydata-sphinx-theme.readthedocs.io/en/stable/community
+- :books: Documentation: https://pydata-sphinx-theme.readthedocs.io/en/stable
+- :bulb: Examples: https://pydata-sphinx-theme.readthedocs.io/en/stable/examples
+- :raised_hands: Contribute: https://pydata-sphinx-theme.readthedocs.io/en/stable/community
 
 [![Example documentation with this theme](./docs/_static/theme_landing.png)](https://pydata-sphinx-theme.readthedocs.io/en/stable)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,18 +14,18 @@ A clean, Bootstrap-based Sphinx theme by and for [the PyData community](https://
 ```{gallery-grid}
 :grid-columns: 1 2 2 3
 
-- header: "{fab}`bootstrap;sd-text-primary` Built with Bootstrap"
+- header: "{fab}`bootstrap;pst-color-primary` Built with Bootstrap"
   content: "Use Bootstrap classes and functionality in your documentation."
-- header: "{fas}`bolt;sd-text-primary` Responsive Design"
+- header: "{fas}`bolt;pst-color-primary` Responsive Design"
   content: "Site sections will change behavior and size at different screen sizes."
-- header: "{fas}`circle-half-stroke;sd-text-primary` Light / Dark theme"
+- header: "{fas}`circle-half-stroke;pst-color-primary` Light / Dark theme"
   content: "Users can toggle between light and dark themes interactively."
-- header: "{fas}`palette;sd-text-primary` Customizable UI and themes"
+- header: "{fas}`palette;pst-color-primary` Customizable UI and themes"
   content: "Customize colors and branding with CSS variables, and build custom UIs with [Sphinx Design](user_guide/web-components)."
-- header: "{fab}`python;sd-text-primary` Supports PyData and Jupyter"
+- header: "{fab}`python;pst-color-primary` Supports PyData and Jupyter"
   content: "CSS and UI support for Jupyter extensions and PyData execution outputs."
   link: "examples/pydata.html"
-- header: "{fas}`lightbulb;sd-text-primary` Example Gallery"
+- header: "{fas}`lightbulb;pst-color-primary` Example Gallery"
   content: "See our gallery of projects that use this theme."
   link: "examples/gallery.html"
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,18 +14,18 @@ A clean, Bootstrap-based Sphinx theme by and for [the PyData community](https://
 ```{gallery-grid}
 :grid-columns: 1 2 2 3
 
-- header: "{guilabel}`B` Built with Bootstrap"
+- header: "{fab}`bootstrap;sd-text-primary` Built with Bootstrap"
   content: "Use Bootstrap classes and functionality in your documentation."
-- header: "⚡ Responsive Design"
+- header: "{fas}`bolt;sd-text-primary` Responsive Design"
   content: "Site sections will change behavior and size at different screen sizes."
-- header: "🌗 Light / Dark theme"
+- header: "{fas}`circle-half-stroke;sd-text-primary` Light / Dark theme"
   content: "Users can toggle between light and dark themes interactively."
-- header: "🎨 Customizable UI and themes"
+- header: "{fas}`palette;sd-text-primary` Customizable UI and themes"
   content: "Customize colors and branding with CSS variables, and build custom UIs with [Sphinx Design](user_guide/web-components)."
-- header: "{fab}`python` Supports PyData and Jupyter"
+- header: "{fab}`python;sd-text-primary` Supports PyData and Jupyter"
   content: "CSS and UI support for Jupyter extensions and PyData execution outputs."
   link: "examples/pydata.html"
-- header: "💡 Example Gallery"
+- header: "{fas}`lightbulb;sd-text-primary` Example Gallery"
   content: "See our gallery of projects that use this theme."
   link: "examples/gallery.html"
 ```

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -94,10 +94,6 @@ $pst-semantic-colors: (
         $value: map-get($value, $mode);
       }
       --pst-color-#{$name}: #{$value};
-      // assign classes too, for runtime use of theme colors
-      .pst-color-#{$name} {
-        color: #{$value};
-      }
     }
     // assign the "duplicate" colors (ones that just reference other variables)
     --pst-color-link: var(--pst-color-primary);
@@ -131,5 +127,12 @@ $pst-semantic-colors: (
         fill: var(--pst-color-text-base);
       }
     }
+  }
+}
+
+// assign classes too, for runtime use of theme colors
+@each $name, $value in $pst-semantic-colors {
+  .pst-color-#{$name} {
+    color: var(--pst-color-#{$name});
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -94,6 +94,10 @@ $pst-semantic-colors: (
         $value: map-get($value, $mode);
       }
       --pst-color-#{$name}: #{$value};
+      // assign classes too, for runtime use of theme colors
+      .pst-color-#{$name} {
+        color: #{$value};
+      }
     }
     // assign the "duplicate" colors (ones that just reference other variables)
     --pst-color-link: var(--pst-color-primary);


### PR DESCRIPTION
Fix #1125

The emojis are hard coded in the .md file which is crashing the windows build. Instead of adding extra env parameter I suggest we stop using emojis in the card header and move to fontawesome icons instead. 

I also replaced the one in the readme with markups which is nicely interpreted in all the parsers I know