### PR TITLE
DOC: Use only shield.io for badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # The PyData Sphinx Theme
 
-[![pypi](https://img.shields.io/pypi/v/pydata-sphinx-theme)](https://pypi.org/project/pydata-sphinx-theme/)
-[![conda-forge](https://img.shields.io/conda/vn/conda-forge/pydata-sphinx-theme.svg)](https://anaconda.org/conda-forge/pydata-sphinx-theme)
-[![continuous-integration](https://github.com/pydata/pydata-sphinx-theme/actions/workflows/tests.yml/badge.svg)](https://github.com/pydata/pydata-sphinx-theme/actions/workflows/tests.yml)
-[![docs](https://readthedocs.org/projects/pydata-sphinx-theme/badge/)](https://readthedocs.org/projects/pydata-sphinx-theme/builds/)
-[![codecov](https://codecov.io/gh/pydata/pydata-sphinx-theme/branch/main/graph/badge.svg?token=NwOObjYacn)](https://codecov.io/gh/pydata/pydata-sphinx-theme)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-yellow.svg)](https://github.com/pydata/pydata-sphinx-theme/blob/main/LICENSE)
+[![PyPI](https://img.shields.io/pypi/v/pydata-sphinx-theme?logo=python&logoColor=white&color=orange)](https://pypi.org/project/pydata-sphinx-theme/)
+[![conda-forge](https://img.shields.io/conda/vn/conda-forge/pydata-sphinx-theme.svg?logo=anaconda&logoColor=white&color=orange)](https://anaconda.org/conda-forge/pydata-sphinx-theme)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/pydata/pydata-sphinx-theme/tests.yml?logo=github&logoColor=white)](https://github.com/pydata/pydata-sphinx-theme/actions/workflows/tests.yml)
+[![Read the Docs (version)](https://img.shields.io/readthedocs/pydata-sphinx-theme/latest?logo=readthedocs&logoColor=white)](https://readthedocs.org/projects/pydata-sphinx-theme/builds/)
+[![Codecov](https://img.shields.io/codecov/c/github/pydata/pydata-sphinx-theme?logo=codecov&logoColor=white)](https://codecov.io/gh/pydata/pydata-sphinx-theme)
 
 A clean, three-column, Bootstrap-based Sphinx theme by and for the [PyData community](https://pydata.org).
 


### PR DESCRIPTION
The services are providing different tones of green, yellow etc (github build is specifically a different green) and it hurts my OTCs.  I simply replaced all the badges with their corresponding pure shield.io version and added a white icon for all of them (because everyone loves icons). 

Added a link to the license, that's always useful in a pypi presentation page.