### PR TITLE
Copyright semicolon

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html
@@ -1,10 +1,10 @@
 {% if show_copyright and copyright %}
   <p class="copyright">
     {% if hasdoc('copyright') %}
-      {% trans path=pathto('copyright'), copyright=copyright|e %}©; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+      {% trans path=pathto('copyright'), copyright=copyright|e %}© <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
       <br/>
     {% else %}
-      {% trans copyright=copyright|e %}©; Copyright {{ copyright }}.{% endtrans %}
+      {% trans copyright=copyright|e %}© Copyright {{ copyright }}.{% endtrans %}
       <br/>
     {% endif %}
   </p>


### PR DESCRIPTION
This removes the semicolon from our Copyright component, so that it is now:

`© Copyright 2019, PyData Community.`

Instead of

`©; Copyright 2019, PyData Community.`

This matches what ReadTheDocs does

closes #1159 