### PR TITLE
NEW: Dropdown links in header

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,18 +91,19 @@ if not version_match or version_match.isdigit():
         version_match = "v" + release
 
 html_theme_options = {
-    "external_links": [
+    "dropdown_links": [
         {
-            "url": "https://pydata.org",
-            "name": "PyData",
+            "url": "https://github.com/pydata/pydata-sphinx-theme/releases",
+            "name": "Changelog",
         },
+        {"url": "examples/gallery", "name": "Gallery"},
         {
-            "url": "https://numfocus.org/",
-            "name": "NumFocus",
-        },
-        {
-            "url": "https://numfocus.org/donate",
-            "name": "Donate to NumFocus",
+            "name": "Community links",
+            "items": [
+                {"url": "https://pydata.org", "name": "PyData"},
+                {"url": "https://numfocus.org/", "name": "NumFocus"},
+                {"url": "https://numfocus.org/donate", "name": "Donate to NumFocus"},
+            ],
         },
     ],
     "github_url": "https://github.com/pydata/pydata-sphinx-theme",

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,9 +63,3 @@ Several example pages to demonstrate the functionality of this theme when used a
 
 examples/index
 ```
-
-```{toctree}
-:hidden:
-
-Changelog <https://github.com/pydata/pydata-sphinx-theme/releases>
-```

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -90,10 +90,17 @@
 
     // Dropdowns for the extra links
     .dropdown {
-      button {
+      // The button that people click on
+      > button {
         display: unset;
         color: var(--pst-color-text-muted);
         border: none;
+
+        &:hover,
+        &:active,
+        &:focus {
+          color: var(--pst-color-primary);
+        }
       }
 
       .dropdown-menu {

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/dropdown-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/dropdown-links.html
@@ -1,0 +1,44 @@
+{# One or more extra links and dropdown links with Bootstrap -#}
+
+{# A macro so we can save some boilerplate #}
+{%- macro dropdown_link(name, url, tooltip_placement="left") -%}
+
+{#- Parse the URL to determine if it is an internal document link or a URI #}
+{% if not url.startswith("http") %}
+{% set url=pathto(url) %}
+{% set extra_classes="" %}
+{% else %}
+{% set extra_classes=" nav-external" %}
+{% endif -%}
+
+<a class="nav-link{{ extra_classes }}" href="{{ url }}" data-bs-toggle="tooltip" data-bs-placement="{{ tooltip_placement }}" aria-label="{{ name }}">
+  {{ name }}
+</a>
+{%- endmacro %}
+
+{% if theme_dropdown_links %}
+{% for dropdown in theme_dropdown_links %}
+
+  {#- If "items" is in the list item then it is a dropdown with a collection of links #}
+  {% if "items" in dropdown %}
+  <div class="nav-item dropdown">
+    <button class="btn dropdown-toggle nav-item" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        {{ dropdown["name"] }}
+    </button>
+    <div class="dropdown-menu">
+    {% for link in dropdown["items"] %}
+    <li class="nav-item">
+      {{ dropdown_link(link["name"], link["url"])}}
+    </li>
+    {% endfor %}
+    </div>
+  </div>
+
+  {% else %}
+  {# Otherwise assume it is just an extra link, not a dropdown -#}
+  <li class="nav-item">
+    {{ dropdown_link(dropdown["name"], dropdown["url"])}}
+  </li>
+  {% endif %}
+{% endfor %}
+{% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-first-level-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-first-level-links.html
@@ -1,0 +1,1 @@
+{{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown) }}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
@@ -6,6 +6,7 @@
     {{ _("Site Navigation") }}
   </p>
   <ul id="navbar-main-elements" class="navbar-nav">
-    {{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown) }}
+    {% include "components/navbar-first-level-links.html" %}
+    {% include "components/dropdown-links.html" %}
   </ul>
 </nav>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -11,6 +11,7 @@ sidebarwidth = 270
 sidebar_includehidden = True
 use_edit_page_button = False
 external_links =
+dropdown_links =
 bitbucket_url =
 github_url =
 gitlab_url =


### PR DESCRIPTION
This is a demonstration of allowing users to manually add dropdown links in the header. Currently this PR adds a new configuration value (`dropdown_links`). This takes a list of dictionaries. Each dictionary has a `name`, and either has:

1. `url` in it, in which case it is treated as an extra top-level link in the header.
2. `items` in it, in which case `items` is treated as a list of links that will populate a dropdown menu.

If `url` does not start with `http`, then we assume it is a document and we resolve it by using `pathto(`

In this way, you can add extra items in the header in dropdown menus in order to save space. I also refactored this and the document links into their own templates in case other folks want to over-ride them.

### Should this be merged into `extra_links` behavior?

Currently, `extra_links` allows users to provide extra top-level links that are "appended" to our site's document tree. We then use the `n_links_before_dropdown` to automatically create a `More` dropdown when the number of top-level links are above that number.

Instead, we could allow `extra_links` to accept the Dropdown configuration provided here (it already accepts a list of dictionaries, so this would only mean supporting the `items` value to add dropdowns). Then, `n_links_before_dropdown` would only apply to the site's documents, and `extra_links` would be used for any extra links.

### To do

- [ ] Answer question above
- [ ] Agree on config and UX
- [ ] Add tests
- [ ] Document

### References

- maybe closes https://github.com/pydata/pydata-sphinx-theme/issues/1061
- maybe closes https://github.com/pydata/pydata-sphinx-theme/issues/1016