### PR TITLE
FIX: Javascript incorrect check for variable

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -306,7 +306,7 @@ function checkPageExistsAndRedirect(event) {
 
 // Populate the version switcher from the JSON config file
 var themeSwitchBtns = document.querySelectorAll("version-switcher__button");
-if (themeSwitchBtns) {
+if (themeSwitchBtns.length) {
   fetch(DOCUMENTATION_OPTIONS.theme_switcher_json_url)
     .then((res) => {
       return res.json();


### PR DESCRIPTION
I noticed that JavaScript was erroring when there was no theme-switcher present. This is because we were incorrectly checking for the presence of a variable selected with `querySelectorAll`. This adds the proper `.length` for the check.