### PR TITLE
Fix article header CSS

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_header-article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header-article.scss
@@ -1,10 +1,16 @@
-.bd-header-article__inner {
+.header-article__inner {
   min-height: var(--pst-header-article-height);
   display: flex;
-  align-items: center;
   padding: 0 0.5rem;
 
-  .bd-header-article__end {
+  .header-article-items__start,
+  .header-article-items__end {
+    display: flex;
+    align-items: start;
+    gap: 0.5rem;
+  }
+
+  .header-article-items__end {
     margin-left: auto;
   }
 }

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header-article.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header-article.html
@@ -1,4 +1,4 @@
-<div class="header-article-items header-article__section">
+<div class="header-article-items header-article__inner">
   {% if theme_article_header_start %}
     <div class="header-article-items__start">
       {% for item in theme_article_header_start %}


### PR DESCRIPTION
I was trying to get the article header working in the book theme, and noticed that the CSS rules were slightly wrong for the "end" section of the article header, and some class names weren't matched to the rule names. So this fixes that up.