### PR TITLE
fix: correctly add DOM listeners

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/mixin.js
+++ b/src/pydata_sphinx_theme/assets/scripts/mixin.js
@@ -9,5 +9,5 @@
  */
 export function documentReady(callback) {
   if (document.readyState != "loading") callback();
-  else document.addEventListener("DOMContentLoaded", callback());
+  else document.addEventListener("DOMContentLoaded", callback);
 }


### PR DESCRIPTION
currently our listener functions are executed *when being added* as `DOMContentLoaded` listeners (instead of being executed *when the `DOMContentLoaded` event fires*). This PR fixes that.