### PR TITLE
Properly handle default_mode=auto when writing logos

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -17,7 +17,7 @@
      # Thus we should add the extra image using JavaScript, defaulting
      # depending on the value of default_mode; and light if unset.
      #}
-    {% if default_mode is undefined %}
+    {% if default_mode is undefined or default_mode == "auto" %}
       {% set default_mode = "light" %}
     {% endif %}
     {% set js_mode = "light" if default_mode == "dark" else "dark" %}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -216,6 +216,21 @@ def test_primary_logo_is_light_when_no_default_mode(sphinx_build_factory):
     assert navbar_brand.find("script", string=re.compile("only-dark")) is not None
 
 
+def test_primary_logo_is_light_when_default_mode_is_set_to_auto(sphinx_build_factory):
+    """Test that the primary logo image is light
+    (and secondary, written through JavaScript, is dark)
+    when default mode is explicitly set to auto."""
+    # Ensure no default mode is set
+    confoverrides = {
+        "html_context": {"default_mode": "auto"},
+    }
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
+    index_html = sphinx_build.html_tree("index.html")
+    navbar_brand = index_html.select(".navbar-brand")[0]
+    assert navbar_brand.find("img", class_="only-light") is not None
+    assert navbar_brand.find("script", string=re.compile("only-dark")) is not None
+
+
 def test_primary_logo_is_light_when_default_mode_is_light(sphinx_build_factory):
     """Test that the primary logo image is light
     (and secondary, written through JavaScript, is dark)


### PR DESCRIPTION
We used to only defaulting to the light version when `default_mode` was undefined, not when it was explicitly set to `auto` (#1180). We also need to handle the latter, as the new test shows.

The proposed fix adds a test in the `navbar-logo` template. I worry that having to  take care every time of handling both an undefined `default_mode`  and a `default_mode` set to `auto` is going to be troublesome in the future. If not setting `default_mode` is equivalent to setting `default_mode` to `auto`, it's probably worthwhile to have `default_mode` set to `auto` by default and not leave it undefined.