### PR TITLE
Standardize template structure in more sections

### DIFF
--- a/docs/_templates/test.html
+++ b/docs/_templates/test.html
@@ -1,0 +1,2 @@
+{# This is just used for testing in our documentation #}
+<button>TEST</button>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,12 +133,13 @@ html_theme_options = {
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "navbar_center": ["version-switcher", "navbar-nav"],
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
+    "footer_end": ["navbar-icon-links.html"],
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],
     # "navbar_persistent": ["search-button"],
     # "primary_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
-    # "footer_items": ["copyright", "sphinx-version"],
+    # "footer_start": ["test.html", "test.html"],
     # "secondary_sidebar_items": ["page-toc.html"],  # Remove the source buttons
     "switcher": {
         "json_url": json_url,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,6 @@ html_theme_options = {
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "navbar_center": ["version-switcher", "navbar-nav"],
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
-    "footer_end": ["navbar-icon-links.html"],
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -10,7 +10,8 @@ Overview of theme layout
 
 Below is a brief overview of the major layout of this theme.
 Take a look at the diagram to understand what the major sections are called.
-You can click on section titles to learn more about them and some basic layout configuration.
+Where you can insert component templates in ``html_theme_options``, we include the variable name ``in inline code``.
+Click on section titles to learn more about them and some basic layout configuration.
 
 .. The directives below generate a grid-like layout that mimics the structure of this theme.
 .. It uses Sphinx Design grids: https://sphinx-design.readthedocs.io/en/latest/grids.html
@@ -52,17 +53,23 @@ You can click on section titles to learn more about them and some basic layout c
 
                 Logo
 
+                ``navbar_start``
+
             .. grid-item::
                 :padding: 2
                 :columns: 6
 
                 Section links
 
+                ``navbar_center``
+
             .. grid-item::
                 :padding: 2
                 :columns: 3
 
                 Components
+
+                ``navbar_end``
 
     .. grid-item::
         :padding: 2
@@ -78,6 +85,10 @@ You can click on section titles to learn more about them and some basic layout c
 
         Links between pages in the active section.
 
+        ``sidebars``
+
+        ``primary_sidebar_end``
+
     .. grid-item::
         :columns: 8
 
@@ -88,7 +99,7 @@ You can click on section titles to learn more about them and some basic layout c
             .. grid-item::
                 :class: content
                 :padding: 2
-                :columns: 8
+                :columns: 6
                 :outline:
 
                 .. button-ref:: layout-article-header
@@ -96,6 +107,9 @@ You can click on section titles to learn more about them and some basic layout c
                     :outline:
 
                     Article Header
+
+                ``article_header_start``
+                ``article_header_end``
 
                 **Article Content**
 
@@ -107,7 +121,7 @@ You can click on section titles to learn more about them and some basic layout c
 
             .. grid-item::
                 :padding: 2
-                :columns: 4
+                :columns: 6
                 :outline:
                 :class: sidebar-secondary
 
@@ -118,6 +132,8 @@ You can click on section titles to learn more about them and some basic layout c
                     Secondary Sidebar
 
                 Within-page header links
+
+                ``secondary_sidebar_items``
 
         .. grid::
             :margin: 0
@@ -149,7 +165,8 @@ You can click on section titles to learn more about them and some basic layout c
 
             Footer
 
-        Site-wide links.
+        ``footer_start``
+        ``footer_end``
 
 Horizontal spacing
 ------------------
@@ -425,17 +442,26 @@ Footer
 Located in ``sections/footer.html``.
 
 The footer is just below a page’s main content, and is configured in ``conf.py``
-with ``html_theme_options['footer_items']``.
+with ``html_theme_options['footer_start']`` and ``html_theme_options['footer_end']``.
 
-By default, it has the following templates:
+By default, ``footer_end`` is empty, and ``footer_start`` has the following templates:
 
 .. code-block:: python
 
     html_theme_options = {
       ...
-      "footer_items": ["copyright", "sphinx-version", "theme-version"],
+      "footer_start": ["copyright", "sphinx-version", "theme-version"],
       ...
     }
+
+Within each subsection, components will stack **vertically**.
+If you'd like them to stack **horizontally** use a custom CSS rule like the following:
+
+.. code-block:: scss
+
+   .footer-items__start, .footer-items__end {
+     flex-direction: row;
+   }
 
 Change footer display
 ---------------------

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -457,7 +457,7 @@ By default, ``footer_end`` is empty, and ``footer_start`` has the following temp
 Within each subsection, components will stack **vertically**.
 If you'd like them to stack **horizontally** use a custom CSS rule like the following:
 
-.. code-block:: scss
+.. code-block:: css
 
    .footer-items__start, .footer-items__end {
      flex-direction: row;

--- a/docs/user_guide/search.rst
+++ b/docs/user_guide/search.rst
@@ -14,7 +14,8 @@ You can also configure some aspects of the search button and search field, descr
 Configure the search field position
 -----------------------------------
 
-The position of the search *button* is controlled by ``search-button`` and by default is included in ``html_theme_options["navbar_persistent"]``; you may move it elsewhere as befits your site's layout, or remove it. You can also add an always-visible search field to some/all pages in your site by adding ``search-field.html`` to one of the configuration variables (e.g., ``html_sidebars``, ``html_theme_options["footer_items"]``, etc).
+The position of the search *button* is controlled by ``search-button`` and by default is included in ``html_theme_options["navbar_persistent"]``; you may move it elsewhere as befits your site's layout, or remove it.
+You can also add an always-visible search field to some/all pages in your site by adding ``search-field.html`` to one of the configuration variables (e.g., ``html_sidebars``, ``html_theme_options["footer_start"]``, etc).
 
 For example, if you'd like the search field to be in your side-bar, add it to
 the sidebar templates like so:

--- a/docs/user_guide/version-dropdown.rst
+++ b/docs/user_guide/version-dropdown.rst
@@ -23,7 +23,7 @@ The switcher requires the following configuration steps:
 
 3. Specify where to place the switcher in your page layout. For example, add
    the ``"version-switcher"`` template to one of the layout lists in
-   ``html_theme_options`` (e.g., ``navbar_end``, ``footer_items``, etc).
+   ``html_theme_options`` (e.g., ``navbar_end``, ``footer_start``, etc).
 
 Below is a more in-depth description of each of these configuration steps.
 
@@ -156,7 +156,7 @@ Specify where to display the switcher
 Finally, tell the theme where on your site's pages you want the switcher to
 appear. There are many choices here: you can add ``"version-switcher"`` to one
 of the locations in ``html_theme_options`` (e.g., ``navbar_end``,
-``footer_items``, etc). For example:
+``footer_start``, etc). For example:
 
 .. code:: python
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -67,6 +67,13 @@ def update_config(app):
             "Use `secondary_sidebar_items`."
         )
 
+    # DEPRECATE after 0.14
+    if theme_options.get("footer_items"):
+        theme_options["footer_start"] = theme_options.get("footer_items")
+        logger.warning(
+            "`footer_items` is deprecated. Use `footer_start` or `footer_end` instead."
+        )
+
     # Validate icon links
     if not isinstance(theme_options.get("icon_links", []), list):
         raise ExtensionError(
@@ -205,7 +212,8 @@ def update_and_remove_templates(app, pagename, templatename, context, doctree):
         "theme_navbar_end",
         "theme_article_header_start",
         "theme_article_header_end",
-        "theme_footer_items",
+        "theme_footer_start",
+        "theme_footer_end",
         "theme_secondary_sidebar_items",
         "theme_primary_sidebar_end",
         "sidebars",

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -305,7 +305,7 @@ function checkPageExistsAndRedirect(event) {
 }
 
 // Populate the version switcher from the JSON config file
-var themeSwitchBtns = document.querySelectorAll("version-switcher__button");
+var themeSwitchBtns = document.querySelectorAll(".version-switcher__button");
 if (themeSwitchBtns.length) {
   fetch(DOCUMENTATION_OPTIONS.theme_switcher_json_url)
     .then((res) => {

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -100,13 +100,13 @@ function addModeListener() {
  */
 function addTOCInteractivity() {
   window.addEventListener("activate.bs.scrollspy", function () {
-    const navLinks = document.querySelectorAll("#bd-toc-nav a");
+    const navLinks = document.querySelectorAll(".bd-toc-nav a");
 
     navLinks.forEach((navLink) => {
       navLink.parentElement.classList.remove("active");
     });
 
-    const activeNavLinks = document.querySelectorAll("#bd-toc-nav a.active");
+    const activeNavLinks = document.querySelectorAll(".bd-toc-nav a.active");
     activeNavLinks.forEach((navLink) => {
       navLink.parentElement.classList.add("active");
     });
@@ -122,7 +122,7 @@ function addTOCInteractivity() {
  */
 function scrollToActive() {
   // If the docs nav doesn't exist, do nothing (e.g., on search page)
-  if (!document.getElementById("bd-docs-nav")) {
+  if (!document.querySelector(".bd-docs-nav")) {
     return;
   }
 
@@ -141,7 +141,7 @@ function scrollToActive() {
     console.log("[PST]: Scrolled sidebar using stored browser position...");
   } else {
     // Otherwise, calculate a position to scroll to based on the lowest `active` link
-    var sidebarNav = document.getElementById("bd-docs-nav");
+    var sidebarNav = document.querySelector(".bd-docs-nav");
     var active_pages = sidebarNav.querySelectorAll(".active");
     if (active_pages.length > 0) {
       // Use the last active page as the offset since it's the page we're on

--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: row;
   column-gap: 1rem;
+  flex-wrap: wrap;
 
   // Remove the padding so that we can define it with flexbox gap above
   li.nav-item a.nav-link {

--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -2,7 +2,24 @@
  * Icon links in the navbar
  */
 
-#navbar-icon-links {
+.navbar-icon-links {
+  display: flex;
+  flex-direction: row;
+  column-gap: 1rem;
+
+  // Remove the padding so that we can define it with flexbox gap above
+  li.nav-item a.nav-link {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  // Spacing and centering
+  a span {
+    display: flex;
+    align-items: center;
+  }
+
+  // Icons styling
   i {
     &.fa-brands,
     &.fa-regular,
@@ -12,7 +29,7 @@
       font-size: var(--pst-font-size-icon);
     }
 
-    /* Social media buttons */
+    /* Social media buttons hard-code the brand color */
     &.fa-square-twitter:before {
       color: #55acee;
     }
@@ -26,29 +43,9 @@
     }
   }
 
+  // Force images to be icon-sized
   img.icon-link-image {
     height: 1.5em;
     border-radius: 0.2rem;
-  }
-
-  li:first-child a {
-    padding-left: 0;
-  }
-
-  a span {
-    display: flex;
-    align-items: center;
-  }
-
-  // inline the element in the navbar as long as they fit and use display block when collapsing
-  // One breakpoint less than $breakpoint-sidebar-primary.
-  // See variables/_layout.scss for more info.
-  @include media-breakpoint-down(lg) {
-    flex-direction: row;
-
-    // Use Bootstrap padding for these nav links to get the spacing right
-    a {
-      padding: 0rem 0.5rem;
-    }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_page-toc.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_page-toc.scss
@@ -1,0 +1,27 @@
+/**
+ * The list of in-page TOC links
+ */
+.page-toc {
+  .section-nav {
+    padding-left: 0;
+    border-bottom: none;
+
+    ul {
+      padding-left: 1rem;
+    }
+  }
+
+  // override bootstrap settings
+  .nav-link {
+    font-size: var(--pst-sidebar-font-size-mobile);
+    @include media-breakpoint-up($breakpoint-sidebar-secondary) {
+      font-size: var(--pst-sidebar-font-size);
+    }
+  }
+
+  .onthispage {
+    color: var(--pst-color-text-base);
+    font-weight: var(--pst-sidebar-header-font-weight);
+    margin-bottom: 0.5rem;
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/components/_searchbox.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_searchbox.scss
@@ -36,8 +36,6 @@ div#searchbox {
         text-decoration: none;
       }
 
-      // add icon via CSS because the link is created by javascript
-      // match padding to .toc-item > i above
       &:before {
         content: var(--pst-icon-search-minus);
         color: unset;

--- a/src/pydata_sphinx_theme/assets/styles/pydata-sphinx-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/pydata-sphinx-theme.scss
@@ -36,6 +36,7 @@
 @import "./components/icon-links";
 @import "./components/header/header-logo";
 @import "./components/navbar-links";
+@import "./components/page-toc";
 @import "./components/prev-next";
 @import "./components/search";
 @import "./components/searchbox";

--- a/src/pydata_sphinx_theme/assets/styles/sections/_footer.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_footer.scss
@@ -1,8 +1,24 @@
-footer.bd-footer {
-  width: 100%;
-  border-top: 1px solid var(--pst-color-border);
-  padding: 10px;
+.bd-footer {
+  .bd-footer__inner {
+    border-top: 1px solid var(--pst-color-border);
+    padding: 1rem 2rem;
+    display: flex;
+    flex-grow: 1;
+  }
 
+  .footer-items__start,
+  .footer-items__end {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    justify-content: center;
+  }
+
+  .footer-items__end {
+    margin-left: auto;
+  }
+
+  // So that paragraphs don't take up extra room
   .footer-item p {
     margin-bottom: 0;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_footer.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_footer.scss
@@ -1,9 +1,12 @@
 .bd-footer {
+  width: 100%;
+  border-top: 1px solid var(--pst-color-border);
+
   .bd-footer__inner {
-    border-top: 1px solid var(--pst-color-border);
-    padding: 1rem 2rem;
     display: flex;
     flex-grow: 1;
+    padding: 1rem;
+    margin: auto;
   }
 
   .footer-items__start,

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header-article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header-article.scss
@@ -1,7 +1,12 @@
 .header-article__inner {
-  min-height: var(--pst-header-article-height);
   display: flex;
   padding: 0 0.5rem;
+
+  // The items define the height so that it disappears if there are no items
+  .header-article-item {
+    min-height: var(--pst-header-article-height);
+    height: var(--pst-header-article-height);
+  }
 
   .header-article-items__start,
   .header-article-items__end {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -36,9 +36,7 @@
     }
 
     // These items will define the height of the header
-    .navbar-start-item,
-    .navbar-center-item,
-    .navbar-end-item {
+    .navbar-item {
       height: var(--pst-header-height);
       max-height: var(--pst-header-height);
       display: flex;
@@ -126,7 +124,7 @@
 
 // inline the element in the navbar as long as they fit and use display block when collapsing
 @include media-breakpoint-up($breakpoint-sidebar-primary) {
-  .navbar-center-item {
+  .navbar-center-items .navbar-item {
     display: inline-block;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -44,9 +44,9 @@
     }
   }
 
-  #navbar-end,
-  #navbar-center,
-  #navbar-start {
+  .navbar-header-items__end,
+  .navbar-header-items__center,
+  .navbar-header-items__start {
     display: flex;
     align-items: center;
     flex-flow: wrap;
@@ -54,19 +54,19 @@
     row-gap: 0;
   }
 
-  #navbar-end,
-  #navbar-center {
+  .navbar-header-items__end,
+  .navbar-header-items__center {
     column-gap: 1rem;
   }
 
   // A little smaller because this is displayed by default on mobile
-  #navbar-start {
+  .navbar-header-items__start {
     flex-shrink: 0;
     margin-right: auto;
     gap: 0.5rem;
   }
 
-  #navbar-end {
+  .navbar-header-items__end {
     // End navbar items should snap to the right
     justify-content: end;
   }
@@ -150,7 +150,7 @@
   }
 }
 
-#navbar-main-elements li.nav-item i {
+.bd-navbar-elements li.nav-item i {
   font-size: 0.7rem;
   padding-left: 2px;
   vertical-align: middle;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -47,8 +47,8 @@
     color: var(--pst-color-text-base);
   }
 
-  .sidebar-start-items,
-  .sidebar-end-items {
+  .sidebar-primary-items__start,
+  .sidebar-primary-items__end {
     .sidebar-primary-item {
       padding: 0.5rem 0;
     }
@@ -102,7 +102,7 @@
     }
   }
 
-  .sidebar-start-items {
+  .sidebar-primary-items__start {
     // Add a border on mobile to separate it from the header sidebar area
     border-top: 1px solid var(--pst-color-border);
     @include media-breakpoint-up($breakpoint-sidebar-primary) {
@@ -110,7 +110,7 @@
     }
   }
 
-  .sidebar-end-items {
+  .sidebar-primary-items__end {
     margin-top: auto;
     margin-bottom: 1em;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -47,9 +47,11 @@
     color: var(--pst-color-text-base);
   }
 
-  .sidebar-start-items__item,
-  .sidebar-end-items__item {
-    padding: 0.5rem 0;
+  .sidebar-start-items,
+  .sidebar-end-items {
+    .sidebar-primary-item {
+      padding: 0.5rem 0;
+    }
   }
 
   // Hide the sidebar header items on widescreen since they are visible in the header

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -10,38 +10,21 @@
   position: sticky;
   top: var(--pst-header-height);
   max-height: calc(100vh - var(--pst-header-height));
-
+  padding: 2rem 1rem 1rem 1rem;
+  width: var(--pst-sidebar-secondary);
   font-size: var(--pst-sidebar-font-size-mobile);
   @include media-breakpoint-up($breakpoint-sidebar-secondary) {
     font-size: var(--pst-sidebar-font-size);
   }
 
-  // override bootstrap settings
-  .nav-link {
-    font-size: var(--pst-sidebar-font-size-mobile);
-    @include media-breakpoint-up($breakpoint-sidebar-secondary) {
-      font-size: var(--pst-sidebar-font-size);
-    }
-  }
-
-  padding: 2rem 1rem 1rem 1rem;
-  width: var(--pst-sidebar-secondary);
-
   // Color and border
   background-color: var(--pst-color-background);
   overflow-y: auto;
 
-  .onthispage {
-    color: var(--pst-color-text-base);
-    font-weight: var(--pst-sidebar-header-font-weight);
-    margin-bottom: 0.5rem;
-  }
-
   @include scrollbar-style();
 }
 
-// Each TOC item is wrapped in this
-.toc-item {
+.sidebar-secondary-item {
   padding: 0.5rem 0.5rem;
   @include media-breakpoint-up($breakpoint-sidebar-secondary) {
     border-left: 1px solid var(--pst-color-border);
@@ -50,15 +33,5 @@
 
   i {
     padding-right: 0.5rem;
-  }
-}
-
-// The list of in-page TOC
-.section-nav {
-  padding-left: 0;
-  border-bottom: none;
-
-  ul {
-    padding-left: 1rem;
   }
 }

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html
@@ -2,7 +2,6 @@
 <div class="prev-next-area">
   {%- if prev %}
     <a class="left-prev"
-       id="prev-link"
        href="{{ prev.link|e }}"
        title="{{ _('previous') }} {{ _('page') }}">
       <i class="fa-solid fa-angle-left"></i>
@@ -14,7 +13,6 @@
   {%- endif %}
   {%- if next %}
     <a class="right-next"
-       id="next-link"
        href="{{ next.link|e }}"
        title="{{ _('next') }} {{ _('page') }}">
       <div class="prev-next-info">

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -25,8 +25,7 @@
         </li>
   {%- endif -%}
 {%- endmacro -%}
-<ul id="navbar-icon-links"
-    class="navbar-nav"
+<ul class="navbar-icon-links navbar-nav"
     aria-label="{{ _(theme_icon_links_label) }}">
   {%- block icon_link_shortcuts -%}
     {{ icon_link_nav_item(theme_github_url, "fa-brands fa-square-github", "GitHub", "fontawesome") -}}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
@@ -5,7 +5,7 @@
      aria-label="{{ _('Site Navigation') }}">
     {{ _("Site Navigation") }}
   </p>
-  <ul id="navbar-main-elements" class="navbar-nav">
+  <ul class="bd-navbar-elements navbar-nav">
     {{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown) }}
   </ul>
 </nav>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
@@ -1,6 +1,6 @@
 {% set page_toc = generate_toc_html() %}
 {%- if page_toc | length >= 1 %}
-  <div class="tocsection onthispage">
+  <div class="page-toc tocsection onthispage">
     <i class="fa-solid fa-list"></i> {{ _("On this page") }}
   </div>
   <nav id="bd-toc-nav" class="page-toc">

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
@@ -3,7 +3,7 @@
   <div class="page-toc tocsection onthispage">
     <i class="fa-solid fa-list"></i> {{ _("On this page") }}
   </div>
-  <nav id="bd-toc-nav" class="page-toc">
+  <nav class="bd-toc-nav page-toc">
     {{ page_toc }}
   </nav>
 {%- endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
@@ -1,5 +1,4 @@
-<nav class="bd-links"
-     id="bd-docs-nav"
+<nav class="bd-docs-nav bd-links"
      aria-label="{{ _('Section navigation') }}">
   <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
   <div class="bd-toc-item navbar-nav">{{ sidebar_nav_html }}</div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -43,7 +43,7 @@ or not theme_secondary_sidebar_items %}
 {% block body_tag %}
   {# set up with scrollspy to update the toc as we scroll #}
   {# ref: https://getbootstrap.com/docs/4.0/components/scrollspy/ #}
-  <body data-bs-spy="scroll" data-bs-target="#bd-toc-nav" data-offset="180" data-bs-root-margin="0px 0px -60%" data-default-mode="{{ default_mode }}">
+  <body data-bs-spy="scroll" data-bs-target=".bd-toc-nav" data-offset="180" data-bs-root-margin="0px 0px -60%" data-default-mode="{{ default_mode }}">
 
   {# A button hidden by default to help assistive devices quickly jump to main content #}
   {# ref: https://www.youtube.com/watch?v=VUR0I5mqq7I #}
@@ -73,7 +73,7 @@ or not theme_secondary_sidebar_items %}
     {% include "sections/announcement.html" %}
   {%- endif %}
   {% block docs_navbar %}
-    <nav class="bd-header navbar navbar-expand-lg bd-navbar" id="navbar-main">
+    <nav class="bd-header navbar navbar-expand-lg bd-navbar">
       {%- include "sections/header.html" %}
     </nav>
   {% endblock docs_navbar %}
@@ -83,6 +83,7 @@ or not theme_secondary_sidebar_items %}
       <div class="bd-sidebar-primary bd-sidebar{% if not sidebars %} hide-on-wide{% endif %}">
         {% include "sections/sidebar-primary.html" %}
       </div>
+      {# Using an ID here so that the skip-link works #}
       <main id="main-content" class="bd-main">
         {# Main content area #}
         {% block docs_main %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
@@ -3,11 +3,11 @@
 {# If we are remote, add a script to make an HTTP request for the value on page load #}
 {%- if is_remote %}
 <script>
-document.write(`<div id="header-announcement"></div>`);
+document.write(`<div class="bd-header-announcement"></div>`);
 fetch("{{ theme_announcement }}")
   .then(res => {return res.text();})
   .then(data => {
-    div = document.querySelector("#header-announcement");
+    div = document.querySelector(".bd-header-announcement");
     div.classList.add(...{{ header_classes | tojson }});
     div.innerHTML = `<div class="bd-header-announcement__content">${data}</div>`;
   })
@@ -17,7 +17,7 @@ fetch("{{ theme_announcement }}")
 </script>
 {#- if announcement text is not remote, populate announcement w/ local content -#}
 {%- else %}
-  <div class="{{ header_classes | join(' ') }}" id="header-announcement">
+  <div class="{{ header_classes | join(' ') }} bd-header-announcement">
     <div class="bd-header-announcement__content">{{ theme_announcement }}</div>
   </div>
 {% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer.html
@@ -1,5 +1,18 @@
-<div class="bd-footer__inner container">
-  {% for footer_item in theme_footer_items %}
-    <div class="footer-item">{% include footer_item %}</div>
-  {% endfor %}
+{% if theme_footer_start or theme_footer_end %}
+<div class="bd-footer__inner">
+  {% if theme_footer_start %}
+    <div class="footer-items__start">
+      {% for item in theme_footer_start %}
+        <div class="footer-item">{% include item %}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
+  {% if theme_footer_end %}
+    <div class="footer-items__end">
+      {% for item in theme_footer_end %}
+        <div class="footer-item">{% include item %}</div>
+      {% endfor %}
+    </div>
+  {% endif %}
 </div>
+{% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer.html
@@ -1,5 +1,5 @@
 {% if theme_footer_start or theme_footer_end %}
-<div class="bd-footer__inner">
+<div class="bd-footer__inner bd-page-width">
   {% if theme_footer_start %}
     <div class="footer-items__start">
       {% for item in theme_footer_start %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header-article.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header-article.html
@@ -1,16 +1,18 @@
+{% if theme_article_header_start or theme_article_header_end %}
 <div class="header-article-items header-article__inner">
   {% if theme_article_header_start %}
     <div class="header-article-items__start">
       {% for item in theme_article_header_start %}
-        <div class="header-article-start-item">{% include item %}</div>
+        <div class="header-article-item">{% include item %}</div>
       {% endfor %}
     </div>
   {% endif %}
   {% if theme_article_header_end %}
     <div class="header-article-items__end">
       {% for item in theme_article_header_end %}
-        <div class="header-article-end-item">{% include item %}</div>
+        <div class="header-article-item">{% include item %}</div>
       {% endfor %}
     </div>
   {% endif %}
 </div>
+{% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -4,7 +4,7 @@
     <span class="fa-solid fa-bars"></span>
   </label>
   {% if theme_navbar_start %}
-  <div id="navbar-start" class="navbar-header-items__start">
+  <div class="navbar-header-items__start">
     {% for navbar_item in theme_navbar_start %}
       <div class="navbar-item">{% include navbar_item %}</div>
     {% endfor %}
@@ -13,14 +13,14 @@
   {% set navbar_class, navbar_align = navbar_align_class() %}
   <div class="{{ navbar_class }} navbar-header-items">
     {% if theme_navbar_center %}
-    <div id="navbar-center" class="{{ navbar_align }} navbar-header-items__center">
+    <div class="{{ navbar_align }} navbar-header-items__center">
       {% for navbar_item in theme_navbar_center %}
         <div class="navbar-item">{% include navbar_item %}</div>
       {% endfor %}
     </div>
     {% endif %}
     {% if theme_navbar_end or theme_navbar_persistent %}
-    <div id="navbar-end" class="navbar-header-items__end">
+    <div class="navbar-header-items__end">
       {% for navbar_item in theme_navbar_persistent %}
         <div class="navbar-item navbar-persistent--container">
           {% include navbar_item %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -1,27 +1,28 @@
+{% if theme_navbar_start or theme_navbar_center or theme_navbar_end or theme_navbar_persistent %}
 <div class="bd-header__inner bd-page-width">
   <label class="sidebar-toggle primary-toggle" for="__primary">
     <span class="fa-solid fa-bars"></span>
   </label>
   <div id="navbar-start">
     {% for navbar_item in theme_navbar_start %}
-      {% include navbar_item %}
+      <div class="navbar-item">{% include navbar_item %}</div>
     {% endfor %}
   </div>
   {% set navbar_class, navbar_align = navbar_align_class() %}
   <div class="{{ navbar_class }} navbar-header-items">
     <div id="navbar-center" class="{{ navbar_align }}">
       {% for navbar_item in theme_navbar_center %}
-        <div class="navbar-center-item">{% include navbar_item %}</div>
+        <div class="navbar-item">{% include navbar_item %}</div>
       {% endfor %}
     </div>
     <div id="navbar-end">
       {% for navbar_item in theme_navbar_persistent %}
-        <div class="navbar-end-item navbar-persistent--container">
+        <div class="navbar-item navbar-persistent--container">
           {% include navbar_item %}
         </div>
       {% endfor %}
       {% for navbar_item in theme_navbar_end %}
-        <div class="navbar-end-item">{% include navbar_item %}</div>
+        <div class="navbar-item">{% include navbar_item %}</div>
       {% endfor %}
     </div>
   </div>
@@ -38,3 +39,4 @@
     </label>
   {% endif %}
 </div>
+{% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -3,19 +3,24 @@
   <label class="sidebar-toggle primary-toggle" for="__primary">
     <span class="fa-solid fa-bars"></span>
   </label>
-  <div id="navbar-start">
+  {% if theme_navbar_start %}
+  <div id="navbar-start" class="navbar-header-items__start">
     {% for navbar_item in theme_navbar_start %}
       <div class="navbar-item">{% include navbar_item %}</div>
     {% endfor %}
   </div>
+  {% endif %}
   {% set navbar_class, navbar_align = navbar_align_class() %}
   <div class="{{ navbar_class }} navbar-header-items">
-    <div id="navbar-center" class="{{ navbar_align }}">
+    {% if theme_navbar_center %}
+    <div id="navbar-center" class="{{ navbar_align }} navbar-header-items__center">
       {% for navbar_item in theme_navbar_center %}
         <div class="navbar-item">{% include navbar_item %}</div>
       {% endfor %}
     </div>
-    <div id="navbar-end">
+    {% endif %}
+    {% if theme_navbar_end or theme_navbar_persistent %}
+    <div id="navbar-end" class="navbar-header-items__end">
       {% for navbar_item in theme_navbar_persistent %}
         <div class="navbar-item navbar-persistent--container">
           {% include navbar_item %}
@@ -25,6 +30,7 @@
         <div class="navbar-item">{% include navbar_item %}</div>
       {% endfor %}
     </div>
+    {% endif %}
   </div>
   {# A search button to show up only on mobile #}
   {% for navbar_item in theme_navbar_persistent %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -1,11 +1,12 @@
 {% block docs_sidebar %}
+{% if theme_navbar_center or theme_navbar_end or sidebars or theme_primary_sidebar_end %}
   {# Header items that will be displayed in the sidebar on mobile #}
   <div class="sidebar-header-items sidebar-primary__section">
     {# The header center items #}
     {% if theme_navbar_center %}
       <div class="sidebar-header-items__center">
         {% for navbar_item in theme_navbar_center %}
-          <div class="navbar-center-item">{% include navbar_item %}</div>
+          <div class="navbar-item">{% include navbar_item %}</div>
         {% endfor %}
       </div>
     {% endif %}
@@ -13,7 +14,7 @@
     {% if theme_navbar_end %}
       <div class="sidebar-header-items__end">
         {% for navbar_item in theme_navbar_end %}
-          <div class="navbar-end-item">{% include navbar_item %}</div>
+          <div class="navbar-item">{% include navbar_item %}</div>
         {% endfor %}
       </div>
     {% endif %}
@@ -21,16 +22,17 @@
   {% if sidebars %}
     <div class="sidebar-start-items sidebar-primary__section">
       {%- for sidebartemplate in sidebars %}
-        <div class="sidebar-start-items__item">{%- include sidebartemplate %}</div>
+        <div class="sidebar-primary-item">{%- include sidebartemplate %}</div>
       {%- endfor %}
     </div>
   {% endif %}
   {# Items that will snap to the bottom of the screen #}
   <div class="sidebar-end-items sidebar-primary__section">
     {%- for sidebartemplate in theme_primary_sidebar_end %}
-      <div class="sidebar-end-items__item">{%- include sidebartemplate %}</div>
+      <div class="sidebar-primary-item">{%- include sidebartemplate %}</div>
     {%- endfor %}
   </div>
   {# add the rtd flyout in the sidebar if existing #}
   <div id="rtd-footer-container"></div>
+{% endif %}
 {% endblock docs_sidebar %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -20,14 +20,14 @@
     {% endif %}
   </div>
   {% if sidebars %}
-    <div class="sidebar-start-items sidebar-primary__section">
+    <div class="sidebar-primary-items__start sidebar-primary__section">
       {%- for sidebartemplate in sidebars %}
         <div class="sidebar-primary-item">{%- include sidebartemplate %}</div>
       {%- endfor %}
     </div>
   {% endif %}
   {# Items that will snap to the bottom of the screen #}
-  <div class="sidebar-end-items sidebar-primary__section">
+  <div class="sidebar-primary-items__end sidebar-primary__section">
     {%- for sidebartemplate in theme_primary_sidebar_end %}
       <div class="sidebar-primary-item">{%- include sidebartemplate %}</div>
     {%- endfor %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-secondary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-secondary.html
@@ -1,3 +1,7 @@
+{% if theme_secondary_sidebar_items -%}
+<div class="sidebar-secondary-items sidebar-secondary__inner">
 {% for toc_item in theme_secondary_sidebar_items %}
-  <div class="toc-item">{% include toc_item %}</div>
+  <div class="sidebar-secondary-item">{% include toc_item %}</div>
 {% endfor %}
+</div>
+{%- endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -44,8 +44,8 @@ navbar_persistent = search-button.html
 article_header_start = breadcrumbs.html
 article_header_end =
 primary_sidebar_end = sidebar-ethical-ads.html
-footer_start = copyright.html, theme-version.html, sphinx-version.html
-footer_end =
+footer_start = copyright.html, sphinx-version.html
+footer_end = theme-version.html
 secondary_sidebar_items = page-toc.html, edit-this-page.html, sourcelink.html
 announcement =
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -7,6 +7,7 @@ pygments_style = tango
 sidebars = sidebar-nav-bs.html
 
 [options]
+# General configuration
 sidebarwidth = 270
 sidebar_includehidden = True
 use_edit_page_button = False
@@ -28,21 +29,24 @@ navigation_depth = 4
 show_nav_level = 1
 show_toc_level = 1
 navbar_align = content
+header_links_before_dropdown = 5
+switcher =
+check_switcher = True
+pygment_light_style = a11y-high-contrast-light
+pygment_dark_style = a11y-high-contrast-dark
+logo =
+
+# Template placement in theme layouts
 navbar_start = navbar-logo.html
 navbar_center = navbar-nav.html
 navbar_end = theme-switcher.html, navbar-icon-links.html
 navbar_persistent = search-button.html
 article_header_start = breadcrumbs.html
 article_header_end =
-header_links_before_dropdown = 5
 primary_sidebar_end = sidebar-ethical-ads.html
-footer_items = copyright.html, theme-version.html, sphinx-version.html
+footer_start = copyright.html, theme-version.html, sphinx-version.html
+footer_end =
 secondary_sidebar_items = page-toc.html, edit-this-page.html, sourcelink.html
-switcher =
-check_switcher = True
-pygment_light_style = a11y-high-contrast-light
-pygment_dark_style = a11y-high-contrast-dark
-logo =
 announcement =
 
 # DEPRECATE after 0.11
@@ -51,3 +55,6 @@ logo_text =
 # DEPRECATE after 0.12
 left_sidebar_end =
 page_sidebar_items =
+
+# DEPRECATE after 0.14
+footer_items =

--- a/tests/sites/sidebars/_templates_sidebar_level2/sidebar-nav-bs.html
+++ b/tests/sites/sidebars/_templates_sidebar_level2/sidebar-nav-bs.html
@@ -1,4 +1,4 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+<nav class="bd-links bd-docs-nav" aria-label="Main navigation">
   <div class="bd-toc-item active">
     <!-- Use deeper level for sidebar -->
     {% if pagename.startswith("section1/subsection1") %}

--- a/tests/sites/sidebars/_templates_single_sidebar/components/sidebar-nav-bs.html
+++ b/tests/sites/sidebars/_templates_single_sidebar/components/sidebar-nav-bs.html
@@ -1,4 +1,4 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+<nav class="bd-links bd-docs-nav" aria-label="Main navigation">
   <div class="bd-toc-item active">
     <!-- Specify a startdepth of 0 instead of default of 1 -->
     {{ generate_toctree_html("sidebar", startdepth=0, maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -156,7 +156,7 @@ def test_icon_links(sphinx_build_factory, file_regression):
 
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     # Navbar should have the right icons
-    icon_links = sphinx_build.html_tree("index.html").select("#navbar-icon-links")[0]
+    icon_links = sphinx_build.html_tree("index.html").select(".navbar-icon-links")[0]
     file_regression.check(
         icon_links.prettify(), basename="navbar_icon_links", extension=".html"
     )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -73,7 +73,7 @@ def test_build_html(sphinx_build_factory, file_regression):
     subpage_html = sphinx_build.html_tree("section1/index.html")
 
     # Navbar structure
-    navbar = index_html.select("div#navbar-center")[0]
+    navbar = index_html.select("div.navbar-header-items__center")[0]
     file_regression.check(navbar.prettify(), basename="navbar_ix", extension=".html")
 
     # Sidebar subpage
@@ -356,7 +356,10 @@ def test_navbar_align_right(sphinx_build_factory):
     # Both the column alignment and the margin should be changed
     index_html = sphinx_build.html_tree("index.html")
     assert "col-lg-9" not in index_html.select(".navbar-header-items")[0].attrs["class"]
-    assert "ms-auto" in index_html.select("div#navbar-center")[0].attrs["class"]
+    assert (
+        "ms-auto"
+        in index_html.select("div.navbar-header-items__center")[0].attrs["class"]
+    )
 
 
 def test_navbar_no_in_page_headers(sphinx_build_factory, file_regression):
@@ -364,7 +367,7 @@ def test_navbar_no_in_page_headers(sphinx_build_factory, file_regression):
     sphinx_build = sphinx_build_factory("test_navbar_no_in_page_headers").build()
 
     index_html = sphinx_build.html_tree("index.html")
-    navbar = index_html.select("ul#navbar-main-elements")[0]
+    navbar = index_html.select("ul.bd-navbar-elements")[0]
     file_regression.check(navbar.prettify(), extension=".html")
 
 
@@ -381,7 +384,7 @@ def test_navbar_header_dropdown(sphinx_build_factory, file_regression, n_links):
     }
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     index_html = sphinx_build.html_tree("index.html")
-    navbar = index_html.select("ul#navbar-main-elements")[0]
+    navbar = index_html.select("ul.bd-navbar-elements")[0]
     if n_links == 0:
         # There should be *only* a dropdown and no standalone links
         assert navbar.select("div.dropdown") and not navbar.select(
@@ -405,7 +408,7 @@ def test_sidebars_captions(sphinx_build_factory, file_regression):
     subindex_html = sphinx_build.html_tree("section1/index.html")
 
     # Sidebar structure with caption
-    sidebar = subindex_html.select("nav#bd-docs-nav")[0]
+    sidebar = subindex_html.select("nav.bd-docs-nav")[0]
     file_regression.check(sidebar.prettify(), extension=".html")
 
 
@@ -415,7 +418,7 @@ def test_sidebars_nested_page(sphinx_build_factory, file_regression):
     subindex_html = sphinx_build.html_tree("section1/subsection1/page1.html")
 
     # For nested (uncollapsed) page, the label included `checked=""`
-    sidebar = subindex_html.select("nav#bd-docs-nav")[0]
+    sidebar = subindex_html.select("nav.bd-docs-nav")[0]
     file_regression.check(sidebar.prettify(), extension=".html")
 
 
@@ -427,7 +430,7 @@ def test_sidebars_level2(sphinx_build_factory, file_regression):
     subindex_html = sphinx_build.html_tree("section1/subsection1/index.html")
 
     # Sidebar structure
-    sidebar = subindex_html.select("nav#bd-docs-nav")[0]
+    sidebar = subindex_html.select("nav.bd-docs-nav")[0]
     file_regression.check(sidebar.prettify(), extension=".html")
 
 
@@ -441,7 +444,7 @@ def test_sidebars_show_nav_level0(sphinx_build_factory, file_regression):
 
     # 1. Home Page
     index_html = sphinx_build.html_tree("section1/index.html")
-    sidebar = index_html.select("nav#bd-docs-nav")[0]
+    sidebar = index_html.select("nav.bd-docs-nav")[0]
 
     # check if top-level ul is present
     ul = sidebar.find("ul")
@@ -461,7 +464,7 @@ def test_sidebars_show_nav_level0(sphinx_build_factory, file_regression):
 
     # 2. Subsection Page
     subsection_html = sphinx_build.html_tree("section1/subsection1/index.html")
-    sidebar = subsection_html.select("nav#bd-docs-nav")[0]
+    sidebar = subsection_html.select("nav.bd-docs-nav")[0]
 
     # get all input elements
     input_elem = sidebar.select("input")
@@ -781,7 +784,7 @@ def test_math_header_item(sphinx_build_factory, file_regression):
     """regression test the math items in a header title"""
 
     sphinx_build = sphinx_build_factory("base").build()
-    li = sphinx_build.html_tree("page2.html").select("#navbar-main-elements li")[1]
+    li = sphinx_build.html_tree("page2.html").select(".bd-navbar-elements li")[1]
     file_regression.check(li.prettify(), basename="math_header_item", extension=".html")
 
 
@@ -854,7 +857,7 @@ def test_deprecated_build_html(sphinx_build_factory, file_regression):
     subpage_html = sphinx_build.html_tree("section1/index.html")
 
     # Navbar structure
-    navbar = index_html.select("div#navbar-center")[0]
+    navbar = index_html.select("div.navbar-header-items__center")[0]
     file_regression.check(navbar.prettify(), basename="navbar_ix", extension=".html")
 
     # Sidebar subpage

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -1,4 +1,4 @@
-<ul aria-label="Icon Links" class="navbar-nav" id="navbar-icon-links">
+<ul aria-label="Icon Links" class="navbar-icon-links navbar-nav">
  <li class="nav-item">
   <a class="nav-link" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>

--- a/tests/test_build/navbar_ix.html
+++ b/tests/test_build/navbar_ix.html
@@ -1,5 +1,5 @@
 <div class="me-auto" id="navbar-center">
- <div class="navbar-center-item">
+ <div class="navbar-item">
   <nav class="navbar-nav">
    <p aria-label="Site Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">
     Site Navigation

--- a/tests/test_build/navbar_ix.html
+++ b/tests/test_build/navbar_ix.html
@@ -1,4 +1,4 @@
-<div class="me-auto" id="navbar-center">
+<div class="me-auto navbar-header-items__center" id="navbar-center">
  <div class="navbar-item">
   <nav class="navbar-nav">
    <p aria-label="Site Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">

--- a/tests/test_build/navbar_ix.html
+++ b/tests/test_build/navbar_ix.html
@@ -1,10 +1,10 @@
-<div class="me-auto navbar-header-items__center" id="navbar-center">
+<div class="me-auto navbar-header-items__center">
  <div class="navbar-item">
   <nav class="navbar-nav">
    <p aria-label="Site Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">
     Site Navigation
    </p>
-   <ul class="navbar-nav" id="navbar-main-elements">
+   <ul class="bd-navbar-elements navbar-nav">
     <li class="nav-item">
      <a class="nav-link nav-internal" href="page1.html">
       Page 1

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -52,7 +52,7 @@
    </div>
   </div>
  </div>
- <div class="sidebar-start-items sidebar-primary__section">
+ <div class="sidebar-primary-items__start sidebar-primary__section">
   <div class="sidebar-primary-item">
    <nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
     <p aria-level="1" class="bd-links__title" role="heading">
@@ -75,7 +75,7 @@
    </nav>
   </div>
  </div>
- <div class="sidebar-end-items sidebar-primary__section">
+ <div class="sidebar-primary-items__end sidebar-primary__section">
  </div>
  <div id="rtd-footer-container">
  </div>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -1,7 +1,7 @@
 <div class="bd-sidebar-primary bd-sidebar">
  <div class="sidebar-header-items sidebar-primary__section">
   <div class="sidebar-header-items__center">
-   <div class="navbar-center-item">
+   <div class="navbar-item">
     <nav class="navbar-nav">
      <p aria-label="Site Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">
       Site Navigation
@@ -35,7 +35,7 @@
    </div>
   </div>
   <div class="sidebar-header-items__end">
-   <div class="navbar-end-item">
+   <div class="navbar-item">
     <script>
      document.write(`
   <button class="theme-switch-button btn btn-sm btn-outline-primary navbar-btn rounded-circle" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
@@ -46,14 +46,14 @@
 `);
     </script>
    </div>
-   <div class="navbar-end-item">
-    <ul aria-label="Icon Links" class="navbar-nav" id="navbar-icon-links">
+   <div class="navbar-item">
+    <ul aria-label="Icon Links" class="navbar-icon-links navbar-nav">
     </ul>
    </div>
   </div>
  </div>
  <div class="sidebar-start-items sidebar-primary__section">
-  <div class="sidebar-start-items__item">
+  <div class="sidebar-primary-item">
    <nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
     <p aria-level="1" class="bd-links__title" role="heading">
      Section Navigation

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -6,7 +6,7 @@
      <p aria-label="Site Navigation" aria-level="1" class="sidebar-header-items__title" role="heading">
       Site Navigation
      </p>
-     <ul class="navbar-nav" id="navbar-main-elements">
+     <ul class="bd-navbar-elements navbar-nav">
       <li class="nav-item">
        <a class="nav-link nav-internal" href="../page1.html">
         Page 1
@@ -54,7 +54,7 @@
  </div>
  <div class="sidebar-primary-items__start sidebar-primary__section">
   <div class="sidebar-primary-item">
-   <nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
+   <nav aria-label="Section navigation" class="bd-docs-nav bd-links">
     <p aria-level="1" class="bd-links__title" role="heading">
      Section Navigation
     </p>

--- a/tests/test_build/test_navbar_no_in_page_headers.html
+++ b/tests/test_build/test_navbar_no_in_page_headers.html
@@ -1,4 +1,4 @@
-<ul class="navbar-nav" id="navbar-main-elements">
+<ul class="bd-navbar-elements navbar-nav">
  <li class="nav-item">
   <a class="nav-link nav-internal" href="page1.html">
    Page 1

--- a/tests/test_build/test_sidebars_captions.html
+++ b/tests/test_build/test_sidebars_captions.html
@@ -1,4 +1,4 @@
-<nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
+<nav aria-label="Section navigation" class="bd-docs-nav bd-links">
  <p aria-level="1" class="bd-links__title" role="heading">
   Section Navigation
  </p>

--- a/tests/test_build/test_sidebars_level2.html
+++ b/tests/test_build/test_sidebars_level2.html
@@ -1,4 +1,4 @@
-<nav aria-label="Main navigation" class="bd-links" id="bd-docs-nav">
+<nav aria-label="Main navigation" class="bd-links bd-docs-nav">
  <div class="bd-toc-item active">
   <!-- Use deeper level for sidebar -->
   <p aria-level="2" class="caption" role="heading">

--- a/tests/test_build/test_sidebars_nested_page.html
+++ b/tests/test_build/test_sidebars_nested_page.html
@@ -1,4 +1,4 @@
-<nav aria-label="Section navigation" class="bd-links" id="bd-docs-nav">
+<nav aria-label="Section navigation" class="bd-docs-nav bd-links">
  <p aria-level="1" class="bd-links__title" role="heading">
   Section Navigation
  </p>


### PR DESCRIPTION
This takes another pass at our HTML section structure and (I think) standardizes it across all of our major sections. So there is now a `start` and `end` component in each of the major sections (`header`, `primary sidebar`, `article header`, `footer`). And they all have the same general inner structure. In the process I also:

- Fixed the CSS for our article header so that if it is empty, it doesn't take up any vertical space.
- Added a `start` and `end` to our footer, and added `icon-links.html` to our `footer_end` as well. This deprecates `footer_items` with a warning.
- Made a few CSS tweaks to generalize the `icon-links` behavior to work in both the header and footer, and to not use `id`
- Fixed a CSS selector bug in our version dropdown that should make it now work again.
- Updated our `layout` page to reflect our most recent changes

Other than the new footer options, the visual style and layout shouldn't be changed at all

- closes #1182 