### PR TITLE
maint: update GitLab URL tests

### DIFF
--- a/tests/sites/base/page1.rst
+++ b/tests/sites/base/page1.rst
@@ -24,6 +24,8 @@ Page 1
     https://gitlab.com/gitlab-org/gitlab
     https://gitlab.com/gitlab-org/gitlab/-/issues/375583
     https://gitlab.com/gitlab-org/gitlab/issues/375583
+    https://gitlab.com/gitlab-org/gitlab/issues/
+    https://gitlab.com/gitlab-org/gitlab/issues
     https://gitlab.com/gitlab-org/gitlab/-/merge_requests/84669
     https://gitlab.com/gitlab-org/gitlab/-/pipelines/511894707
     https://gitlab.com/gitlab-com/gl-infra/production/-/issues/6788

--- a/tests/test_build/gitlab_links.html
+++ b/tests/test_build/gitlab_links.html
@@ -15,6 +15,12 @@
   <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/issues/375583">
    gitlab-org/gitlab/issues/375583
   </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/issues/">
+   gitlab-org/gitlab/issues/
+  </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/issues">
+   gitlab-org/gitlab/issues
+  </a>
   <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/-/merge_requests/84669">
    gitlab-org/gitlab!84669
   </a>


### PR DESCRIPTION
closes #1148 

This supersedes #1148 and cherry-picks just the additional test that was added there (to make sure we don't have a regression in future).