### PR TITLE
FIX: Some style bugs

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -40,6 +40,9 @@ a {
   color: var(--pst-color-link);
   text-decoration: none;
 
+  // So that really long links don't spill out of their container
+  word-wrap: break-word;
+
   &:hover {
     color: var(--pst-color-link-hover);
     text-decoration: underline;

--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -36,7 +36,7 @@ div.math {
   mjx-container {
     flex-grow: 1;
     padding-bottom: 0.2rem;
-    overflow-x: auto;
+    overflow-x: visible;
     @include scrollbar-style();
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -25,6 +25,14 @@
     padding-right: 1rem;
   }
 
+  // These items will define the height of the header
+  .navbar-item {
+    height: var(--pst-header-height);
+    max-height: var(--pst-header-height);
+    display: flex;
+    align-items: center;
+  }
+
   // Hide the header items on mobile
   .navbar-header-items {
     display: none;
@@ -33,14 +41,6 @@
       display: flex;
       flex-grow: 1;
       padding: 0 0 0 0.5rem;
-    }
-
-    // These items will define the height of the header
-    .navbar-item {
-      height: var(--pst-header-height);
-      max-height: var(--pst-header-height);
-      display: flex;
-      align-items: center;
     }
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -191,7 +191,6 @@ nav.bd-links {
     display: block;
     padding: 0.25rem 0;
     color: var(--pst-color-text-muted);
-    word-wrap: break-word;
 
     &:hover {
       color: var(--pst-color-primary);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -191,6 +191,7 @@ nav.bd-links {
     display: block;
     padding: 0.25rem 0;
     color: var(--pst-color-text-muted);
+    word-wrap: break-word;
 
     &:hover {
       color: var(--pst-color-primary);


### PR DESCRIPTION
This fixes three more style bugs I found out while testing the RC:

- Math containers had an unnecessary scrollbar. I've set math containers to `overflow-y: visible` now, under the idea that I don't think there's a situation where we expect mathjax to *want* us to scroll.
- The navbar items had a rule that was too-selective and was missing stuff in the `start` section
- I added a word wrap rule so that sidebar words that are really long still have line breaks and don't spill out of the sidebar

closes #1190 