### PR TITLE
FIX: Make wide equations scroll

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -36,7 +36,8 @@ div.math {
   mjx-container {
     flex-grow: 1;
     padding-bottom: 0.2rem;
-    overflow-x: visible;
+    overflow-y: visible;
+    overflow-x: auto;
     @include scrollbar-style();
   }
 }


### PR DESCRIPTION
I realized that our recent `visible` change for math had an unintended side effect - it meant that wide math equations were no longer able to scroll. So this makes the `x` and the `y` behavior explicit, and fixes the problem.

As an example, here it's broken in latest: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/theme-elements.html#equation-my-label-2

