### PR TITLE
Properly set configuration with app.builder.theme_options

### DIFF
--- a/docs/community/topics/config.md
+++ b/docs/community/topics/config.md
@@ -5,15 +5,10 @@ For example, if you want to set a default if the user hasn't provided a value, o
 
 Here are some tips to do this the "right" way in Sphinx.
 
-## Update config: use `app.config.__dict__`
+## Update config: use `app.config`
 
-For example, `app.config.__dict__["foo"] = "bar"`.
-
-Even better, use our provided helper function:
-
-```python
-_set_config_if_not_provided_by_user(app, "foo", "bar")
-```
+For example, `app.config.foo = "bar"`.
+For some reason, when Sphinx sets things it directly uses `__dict__` but this doesn't seem to be different from the pattern described here.
 
 ## Update theme options: use `app.builder.theme_options`
 
@@ -24,3 +19,12 @@ For example, `app.builder.theme_options["logo"] = {"text": "Foo"}`.
 The `app.config._raw_config` attribute contains all of the **user-provided values**.
 Use this if you want to check whether somebody has manually specified something.
 For example, `"somekey" in app.config._raw_config` will be `False` if a user has _not_ provided that option.
+
+You can also check `app.config.overrides` for any CLI-provided overrides.
+
+We bundle both checks in a helper function called `_config_provided_by_user`.
+
+## Avoid the `config-inited` event
+
+This theme is activated **after** `config-inited` is triggered, so if you write an event that depends on it in this theme, then it will never occur.
+The earliest event you can use is `builder-inited`.

--- a/docs/community/topics/config.md
+++ b/docs/community/topics/config.md
@@ -1,0 +1,25 @@
+# Update Sphinx configuration during the build
+
+Sometimes you want to update configuration values _during a build_.
+For example, if you want to set a default if the user hasn't provided a value, or if you want to move the value from one keyword to another for a deprecation.
+
+Here are some tips to do this the "right" way in Sphinx.
+
+## Update config: use `app.config.__dict__`
+
+For example, `app.config.__dict__["foot"] = "bar"`.
+
+Even better, use our provided helper function:
+
+```python
+_set_config_if_not_provided_by_user(app, "foo", "bar")
+```
+
+## Update theme options: use `app.builder.theme_options`
+
+For example, `app.builder.theme_options["logo"] = {"text": "Foo"}`.
+
+## Check if a user has provided a default: `app.config._raw_config`
+
+The `app.config._raw_config` attribute contains all of the **user-provided values**.
+Use this if you want to check whether somebody has manually specified something.

--- a/docs/community/topics/config.md
+++ b/docs/community/topics/config.md
@@ -7,7 +7,7 @@ Here are some tips to do this the "right" way in Sphinx.
 
 ## Update config: use `app.config.__dict__`
 
-For example, `app.config.__dict__["foot"] = "bar"`.
+For example, `app.config.__dict__["foo"] = "bar"`.
 
 Even better, use our provided helper function:
 
@@ -23,3 +23,4 @@ For example, `app.builder.theme_options["logo"] = {"text": "Foo"}`.
 
 The `app.config._raw_config` attribute contains all of the **user-provided values**.
 Use this if you want to check whether somebody has manually specified something.
+For example, `"somekey" in app.config._raw_config` will be `False` if a user has _not_ provided that option.

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -32,8 +32,19 @@ __version__ = "0.13.0rc5dev0"
 logger = logging.getLogger(__name__)
 
 
-def _config_provided_by_user(app, key):
-    return any(key in ii for ii in [app.config.overrides, app.config._raw_config])
+def _set_config_if_not_provided_by_user(app, key, value):
+    """Set a configuration value unless the user has provided their own.
+
+    Sphinx makes it hard to know which config attribute to update,
+    so just use this function.
+    """
+    # Check if the user has manually provided the config
+    if any(key in ii for ii in [app.config.overrides, app.config._raw_config]):
+        return
+
+    # If not, then set the config value
+    app.config.__dict__[key] = value
+    return app
 
 
 def update_config(app):
@@ -78,8 +89,7 @@ def update_config(app):
         )
 
     # Set the anchor link default to be # if the user hasn't provided their own
-    if not _config_provided_by_user(app, "html_permalinks_icon"):
-        app.config.__dict__["html_permalinks_icon"] = "#"
+    _set_config_if_not_provided_by_user(app, "html_permalinks_icon", "#")
 
     # Raise a warning for a deprecated theme switcher config
     # TODO: deprecation; remove after 0.13 release
@@ -166,7 +176,7 @@ def update_config(app):
 
     # Update ABlog configuration default if present
     if "ablog" in app.config.extensions:
-        app.config.__dict__["fontawesome_included"] = True
+        _set_config_if_not_provided_by_user(app, "fontawesome_included", True)
 
     # Prepare the logo config dictionary
     theme_logo = theme_options.get("logo")

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -32,7 +32,7 @@ __version__ = "0.13.0rc5dev0"
 logger = logging.getLogger(__name__)
 
 
-def _was_provided_by_user(app, key):
+def _config_provided_by_user(app, key):
     return any(key in ii for ii in [app.config.overrides, app.config._raw_config])
 
 
@@ -78,7 +78,7 @@ def update_config(app):
         )
 
     # Set the anchor link default to be # if the user hasn't provided their own
-    if not _was_provided_by_user(app, "html_permalinks_icon"):
+    if not _config_provided_by_user(app, "html_permalinks_icon"):
         app.config.__dict__["html_permalinks_icon"] = "#"
 
     # Raise a warning for a deprecated theme switcher config

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -74,8 +74,8 @@ def update_config(app):
         )
 
     # Update the anchor link (it's a tuple, so need to overwrite the whole thing)
-    icon_default = app.config.values["html_permalinks_icon"]
-    app.config.values["html_permalinks_icon"] = ("#", *icon_default[1:])
+    icon_default = app.config.__dict__["html_permalinks_icon"]
+    app.config.__dict__["html_permalinks_icon"] = ("#", *icon_default[1:])
 
     # Raise a warning for a deprecated theme switcher config
     # TODO: deprecation; remove after 0.13 release
@@ -162,7 +162,7 @@ def update_config(app):
 
     # Update ABlog configuration default if present
     if "ablog" in app.config.extensions:
-        app.config.values["fontawesome_included"] = True
+        app.config.__dict__["fontawesome_included"] = True
 
     # Prepare the logo config dictionary
     theme_logo = theme_options.get("logo")

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -32,19 +32,9 @@ __version__ = "0.13.0rc5dev0"
 logger = logging.getLogger(__name__)
 
 
-def _set_config_if_not_provided_by_user(app, key, value):
-    """Set a configuration value unless the user has provided their own.
-
-    Sphinx makes it hard to know which config attribute to update,
-    so just use this function.
-    """
-    # Check if the user has manually provided the config
-    if any(key in ii for ii in [app.config.overrides, app.config._raw_config]):
-        return
-
-    # If not, then set the config value
-    app.config.__dict__[key] = value
-    return app
+def _config_provided_by_user(app, key):
+    """Check if the user has manually provided the config."""
+    return any(key in ii for ii in [app.config.overrides, app.config._raw_config])
 
 
 def update_config(app):
@@ -89,7 +79,8 @@ def update_config(app):
         )
 
     # Set the anchor link default to be # if the user hasn't provided their own
-    _set_config_if_not_provided_by_user(app, "html_permalinks_icon", "#")
+    if not _config_provided_by_user(app, "html_permalinks_icon"):
+        app.config.html_permalinks_icon = "#"
 
     # Raise a warning for a deprecated theme switcher config
     # TODO: deprecation; remove after 0.13 release
@@ -175,8 +166,10 @@ def update_config(app):
             app.add_js_file(None, body=gid_script)
 
     # Update ABlog configuration default if present
-    if "ablog" in app.config.extensions:
-        _set_config_if_not_provided_by_user(app, "fontawesome_included", True)
+    if "ablog" in app.config.extensions and not _config_provided_by_user(
+        app, "fontawesome_included"
+    ):
+        app.config.fontawesome_included = True
 
     # Prepare the logo config dictionary
     theme_logo = theme_options.get("logo")

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -32,6 +32,10 @@ __version__ = "0.13.0rc5dev0"
 logger = logging.getLogger(__name__)
 
 
+def _was_provided_by_user(app, key):
+    return any(key in ii for ii in [app.config.overrides, app.config._raw_config])
+
+
 def update_config(app):
     """Update config with new default values and handle deprecated keys."""
     # By the time `builder-inited` happens, `app.builder.theme_options` already exists.
@@ -73,9 +77,9 @@ def update_config(app):
             f"type {type(theme_options.get('icon_links'))}."
         )
 
-    # Update the anchor link (it's a tuple, so need to overwrite the whole thing)
-    icon_default = app.config.__dict__["html_permalinks_icon"]
-    app.config.__dict__["html_permalinks_icon"] = ("#", *icon_default[1:])
+    # Set the anchor link default to be # if the user hasn't provided their own
+    if not _was_provided_by_user(app, "html_permalinks_icon"):
+        app.config.__dict__["html_permalinks_icon"] = "#"
 
     # Raise a warning for a deprecated theme switcher config
     # TODO: deprecation; remove after 0.13 release

--- a/tests/sites/deprecated/conf.py
+++ b/tests/sites/deprecated/conf.py
@@ -26,7 +26,7 @@ html_theme_options = {
         "edit-this-page.html",
         "sourcelink.html",
     ],
-    "footer_items": ["test.html"],
+    "footer_items": ["page-toc.html"],
 }
 
 html_sidebars = {"section1/index": ["sidebar-nav-bs.html"]}


### PR DESCRIPTION
I was doing a bit more digging this weekend, and I think I figured out why some of our builder updates weren't working as expected. Without going into much detail[^1], we need to update `app.builder.theme_options` and not `app.config.html_theme_options`. This PR does this for our "check for deprecated config" event, and also removes a now-unnecessary event where we were doing this in `html-page-context`. In the process I had to update a test that was actually not doing what we thought it was doing.

[^1]: If you want to learn more about this and other Sphinx config options, I updated my blog post here: https://chrisholdgraf.com/blog/2022/sphinx-update-config/