### PR TITLE
copy_logo_images: do not render dynamic Sphinx template content

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1129,6 +1129,11 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
             continue
         if not (Path(app.srcdir) / path_image).exists():
             logger.warning(f"Path to {kind} image logo does not exist: {path_image}")
+        if path_image.lower().endswith("_t"):
+            raise ExtensionError(
+                f"The {kind} logo path '{path_image}' looks like a Sphinx template; "
+                "please provide a static logo image."
+            )
         copy_asset_file(path_image, staticdir)
 
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1129,6 +1129,7 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
             continue
         if not (Path(app.srcdir) / path_image).exists():
             logger.warning(f"Path to {kind} image logo does not exist: {path_image}")
+        # Ensure templates cannot be passed for logo path to avoid security vulnerability
         if path_image.lower().endswith("_t"):
             raise ExtensionError(
                 f"The {kind} logo path '{path_image}' looks like a Sphinx template; "

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -312,6 +312,20 @@ def test_logo_external_image(sphinx_build_factory):
     assert f'src="{test_url}"' in index_str
 
 
+def test_logo_template_rejected(sphinx_build_factory):
+    """Test that dynamic Sphinx templates are not accepted as logo files"""
+    # Test with a specified external logo image source
+    confoverrides = {
+        "html_theme_options": {
+            "logo": {
+                "image_dark": "image_dark_t",
+            }
+        },
+    }
+    with pytest.raises(sphinx.errors.ExtensionError, match="static logo image"):
+        sphinx_build_factory("base", confoverrides=confoverrides).build()
+
+
 def test_favicons(sphinx_build_factory):
     """Test that arbitrary favicons are included."""
     html_theme_options_favicons = {


### PR DESCRIPTION
This seems like the kind of situation that is both unlikely, and would probably only occur accidentally, but I did learn (and was surprised) that the `copy_asset_file` method may interpret and render some files as dynamic Sphinx templates (by default, Jinja templates).

After learning about that, I felt like the responsible thing to do was to look for cases where template-file interpretation could (even theoretically) be a problem, and this theme is a popular one (going by the more than three hundred GitHub stars).

Since someone would likely already have access to much of a `sphinx` host's infrastructure in order to configure theme settings, I don't think it's likely to be much of a problem, but configuring a dynamic template logo (especially without sandboxing enabled) could do some unexpected things.  Maybe I'm being a spoilsport for cases where a dynamic logo could provide some genuine value; I think the file copy operations are one-time, though - so even then it'd seem reasonable to pregenerate the static images.

All in all: probably a fairly pointless change, and not likely to detect or prevent any problems in reality.  Possibly best considered a practice case for working through a potentially-security-related issue.

Affects the v0.13 release candidate versions only.