### PR TITLE
Use CSS transform for skip link

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_skip-link.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_skip-link.scss
@@ -12,12 +12,13 @@
   background-color: var(--pst-color-background);
   color: var(--pst-color-link);
   padding: 0.5rem;
-  translate: 0 -100%;
-  transition: translate 150ms ease-in-out;
   z-index: $zindex-modal;
   border-bottom: 1px solid var(--pst-color-border);
 
+  // This shows / hides the button
+  transform: translateY(-100%);
+  transition: transform 150ms ease-in-out;
   &:focus {
-    translate: 0;
+    transform: translateY(0%);
   }
 }


### PR DESCRIPTION
I think that `transform: translateY` is a safer CSS rule to use for backwards compatibility) than `translate` is directly. This seemed to fix it for the old safari version I tested.

- closes #1205 