### PR TITLE
FIX: Remove icon links component when no icon links given

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -159,6 +159,28 @@ def update_config(app):
     if "ablog" in app.config.extensions:
         app.config.__dict__["fontawesome_included"] = True
 
+    # Handle icon link shortcuts
+    shortcuts = [
+        ("twitter_url", "fa-brands fa-square-twitter", "Twitter"),
+        ("bitbucket_url", "fa-brands fa-bitbucket", "Bitbucket"),
+        ("gitlab_url", "fa-brands fa-square-gitlab", "GitLab"),
+        ("github_url", "fa-brands fa-square-github", "GitHub"),
+    ]
+    # Add extra icon links entries if there were shortcuts present
+    # TODO: Deprecate this at some point in the future?
+    for url, icon, name in shortcuts:
+        if theme_options.get(url):
+            # This defaults to an empty list so we can always insert
+            theme_options["icon_links"].insert(
+                0,
+                {
+                    "url": theme_options.get(url),
+                    "icon": icon,
+                    "name": name,
+                    "type": "fontawesome",
+                },
+            )
+
 
 def prepare_html_config(app, pagename, templatename, context, doctree):
     """Prepare some configuration values for the HTML build.
@@ -718,7 +740,6 @@ def soup_to_python(soup, only_pages=False):
     #       ...
 
     def extract_level_recursive(ul, navs_list):
-
         for li in ul.find_all("li", recursive=False):
             ref = li.a
             url = ref["href"]

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -25,15 +25,11 @@
         </li>
   {%- endif -%}
 {%- endmacro -%}
+{%- if theme_icon_links -%}
 <ul class="navbar-icon-links navbar-nav"
     aria-label="{{ _(theme_icon_links_label) }}">
-  {%- block icon_link_shortcuts -%}
-    {{ icon_link_nav_item(theme_github_url, "fa-brands fa-square-github", "GitHub", "fontawesome") -}}
-    {{ icon_link_nav_item(theme_gitlab_url, "fa-brands fa-square-gitlab", "GitLab", "fontawesome") -}}
-    {{ icon_link_nav_item(theme_bitbucket_url, "fa-brands fa-bitbucket", "Bitbucket", "fontawesome") -}}
-    {{ icon_link_nav_item(theme_twitter_url, "fa-brands fa-square-twitter", "Twitter", "fontawesome") -}}
-  {% endblock icon_link_shortcuts -%}
   {%- for icon_link in theme_icon_links -%}
     {{ icon_link_nav_item(icon_link["url"], icon_link["icon"], icon_link["name"], icon_link.get("type", "fontawesome"), icon_link.get("attributes", {})) -}}
   {%- endfor %}
 </ul>
+{%- endif -%}

--- a/tests/check_warnings.py
+++ b/tests/check_warnings.py
@@ -53,7 +53,6 @@ def check_warnings(file):
 
 
 if __name__ == "__main__":
-
     # cast the file to path and resolve to an absolute one
     file = Path.cwd() / "warnings.txt"
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -918,10 +918,17 @@ def test_empty_templates(sphinx_build_factory):
     """If a template is empty (e.g., via a config), it should be removed."""
     # When configured to be gone, the template should be removed w/ its parent.
     # ABlog needs to be added so we can test that template rendering works w/ it.
-    confoverrides = {"html_show_sourcelink": False}
+    confoverrides = {
+        "html_show_sourcelink": False,
+    }
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
-    toc_items = sphinx_build.html_tree("page1.html").select(".toc-item")
-    assert not any(ii.select(".tocsection.sourcelink") for ii in toc_items)
+    html = sphinx_build.html_tree("page1.html")
+
+    # We've set this to fase in the config so the template shouldn't show up at all
+    assert not html.select(".tocsection.sourcelink")
+
+    # Should not be any icon link wrapper because none are given in conf
+    assert not html.select(".navbar-icon-links")
 
 
 def test_translations(sphinx_build_factory):

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -46,10 +46,6 @@
 `);
     </script>
    </div>
-   <div class="navbar-item">
-    <ul aria-label="Icon Links" class="navbar-icon-links navbar-nav">
-    </ul>
-   </div>
   </div>
  </div>
  <div class="sidebar-primary-items__start sidebar-primary__section">


### PR DESCRIPTION
I realized that our icon links template was being inserted even if there were no icon links specified in the theme. This is because the component wasn't using the typical check for whether it had any content to insert before creating the parent wrapper. So this PR just refactors the logic to have a single list of icon links, and the parent `<ul>` wrapper is only inserted if the `icon_links` list is not empty. I also added a test to make sure that the icon links wrapper is being removed when `icon_links` is empty.