### PR TITLE
Make heading-style use the font-weight-heading value

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -85,7 +85,7 @@ a {
 .heading-style {
   margin: 2.75rem 0 1.05rem;
   font-family: var(--pst-font-family-heading);
-  font-weight: 400;
+  font-weight: var(--pst-font-weight-heading);
   line-height: 1.15;
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
@@ -24,7 +24,7 @@
 
     p.prev-next-title {
       color: var(--pst-color-primary);
-      font-weight: var(--pst-font-weight-heading);
+      font-weight: var(--pst-admonition-header-font-weight);
       font-size: 1.1em;
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
@@ -24,7 +24,7 @@
 
     p.prev-next-title {
       color: var(--pst-color-primary);
-      font-weight: var(--pst-admonition-header-font-weight);
+      font-weight: var(--pst-admonition-font-weight-heading);
       font-size: 1.1em;
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -28,7 +28,7 @@
         color: var(--pst-color-text-base);
         content: "Read The Docs";
         font-family: var(--pst-font-family-base);
-        font-weight: var(--pst-admonition-header-font-weight);
+        font-weight: var(--pst-admonition-font-weight-heading);
       }
     }
     .fa.fa-caret-down {

--- a/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_readthedocs-switcher.scss
@@ -28,7 +28,7 @@
         color: var(--pst-color-text-base);
         content: "Read The Docs";
         font-family: var(--pst-font-family-base);
-        font-weight: var(--pst-font-weight-heading);
+        font-weight: var(--pst-admonition-header-font-weight);
       }
     }
     .fa.fa-caret-down {

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -36,7 +36,7 @@ div.admonition,
   > .admonition-title {
     margin: 0 -0.6rem;
     padding: 0.4rem 0.6rem 0.4rem 2rem;
-    font-weight: var(--pst-admonition-header-font-weight);
+    font-weight: var(--pst-admonition-font-weight-heading);
     position: relative;
 
     &:after {
@@ -320,7 +320,7 @@ aside.sidebar {
     padding-bottom: 0.5rem;
     border-bottom: 1px solid var(--pst-color-border);
     font-family: var(--pst-font-family-heading);
-    font-weight: var(--pst-admonition-header-font-weight);
+    font-weight: var(--pst-admonition-font-weight-heading);
   }
 
   // Add margin to the first non-`.sidebar-title` item

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -36,7 +36,7 @@ div.admonition,
   > .admonition-title {
     margin: 0 -0.6rem;
     padding: 0.4rem 0.6rem 0.4rem 2rem;
-    font-weight: var(--pst-font-weight-heading);
+    font-weight: var(--pst-admonition-header-font-weight);
     position: relative;
 
     &:after {
@@ -320,7 +320,7 @@ aside.sidebar {
     padding-bottom: 0.5rem;
     border-bottom: 1px solid var(--pst-color-border);
     font-family: var(--pst-font-family-heading);
-    font-weight: var(--pst-font-weight-heading);
+    font-weight: var(--pst-admonition-header-font-weight);
   }
 
   // Add margin to the first non-`.sidebar-title` item

--- a/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
@@ -24,7 +24,7 @@ html {
   --pst-sidebar-header-font-weight: 600;
 
   // Admonition styles
-  --pst-admonition-header-font-weight: 600;
+  --pst-admonition-font-weight-heading: 600;
 
   // Font weights
   --pst-font-weight-caption: 300;

--- a/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
@@ -23,9 +23,12 @@ html {
   --pst-sidebar-header-font-size: 1.2rem;
   --pst-sidebar-header-font-weight: 600;
 
+  // Admonition styles
+  --pst-admonition-header-font-weight: 600;
+
   // Font weights
   --pst-font-weight-caption: 300;
-  --pst-font-weight-heading: 600;
+  --pst-font-weight-heading: 400;
 
   // Font family
   // These are adapted from https://systemfontstack.com/ */


### PR DESCRIPTION
The `heading-style` class is ignoring the `--pst-font-weight-heading` setting. This fixes that, but I'm wondering if the change was intentional at some point. The `--pst-font-weight-heading` seems to be used for admonitions and various boxes, and is set by default to `600`. This fix will now make all main content headings also `600`.

Maybe there should be a separate variable for this? It may make sense to differentiate.

Edit: It seems the variable was added in #818, and only used for those places where font-weight was 600. Since the default font-weight for content headers is 400, maybe there should be a "base" version of the variable for those cases?

Closes #1212