### PR TITLE
FIX: Get theme options in a more robust way

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 def _get_theme_options(app):
     """Return theme options for the application w/ a fallback if they don't exist.
-    
+
     In general we want to modify app.builder.theme_options if it exists, so prefer that first.
     """
     if hasattr(app.builder, "theme_options"):

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -33,9 +33,12 @@ logger = logging.getLogger(__name__)
 
 
 def _get_theme_options(app):
-    """Return theme options for the application w/ a fallback if they don't exist."""
+    """Return theme options for the application w/ a fallback if they don't exist.
+    
+    In general we want to modify app.builder.theme_options if it exists, so prefer that first.
+    """
     if hasattr(app.builder, "theme_options"):
-        # In most HTML build cases this will exists except for some circumstances.
+        # In most HTML build cases this will exist except for some circumstances (see below).
         return app.builder.theme_options
     elif hasattr(app.config, "html_theme_options"):
         # For example, linkcheck will have this configured but won't be in builder obj.


### PR DESCRIPTION
This is a slight modification to how we return the `theme_options` object because we realized there are some cases when `theme_options` doesn't exist in the builder, and this would error if that happened (e.g. with `make linkcheck`). So this just makes a little function that checks for the existence of `theme_options` before trying to return it.