### PR TITLE
MNT: more flexible static

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1166,6 +1166,10 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
         path_image = logo.get(f"image_{kind}")
         if not path_image or isurl(path_image):
             continue
+        if (staticdir / Path(path_image).name).exists():
+            # file already exists in static dir e.g. because a theme has
+            # bundled the logo and installed it there
+            continue
         if not (Path(app.srcdir) / path_image).exists():
             logger.warning(f"Path to {kind} image logo does not exist: {path_image}")
         # Ensure templates cannot be passed for logo path to avoid security vulnerability


### PR DESCRIPTION
EDIT: 

In mpl-sphinx-theme, we provide `static/logo.svg` which gets copied to `_build/html/_static/logo.svg`. 

#1132  changed the behaviour of "logo" config option to do what sphinx's html_logo does, which is just copy the logo file from a relative path (relative to the conf.py) into `_static`, and raised a warning if the file did not exist.  So:

```
html_theme_options = {
    "logo": {"link": "https://foo.bar/stable/",
             "image_light": "mylogos/wherever/logo2.svg",
             "image_dark": "mylogos/whereever/logo_dark.svg"},
...
```

would copy to `_build/html/_static/logo2.svg`, `_build/html/_static/logo_dark.svg`.  

However, because we provide the logo as part of the theme payload, its "source" never exists - it gets copied directly into `_static/logo2.svg`.  The PR here checks if that file exists, and doesn't warn if it already there.   We specify that file in the `conf.py` as 

```
"logo": {"link": "https://matplotlib.org/stable/",
             "image_light": "_static/logo2.svg",
             "image_dark": "_static/logo_dark.svg"},
```
 
which makes the links work properly in `setup_logo_path`.  Unfortunately we cannot check for the existence of `_build/html/_static/logo2.svg` in `setup_logo_path`, because the build directory has not been populated yet.  
