### PR TITLE
DOCS: Remove <p> from announcement sample text

### DIFF
--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -18,7 +18,7 @@ For example, the following configuration adds a simple ``<p>`` with an announcem
 
    html_theme_options = {
       ...
-      "announcement": "<p>Here's a <a href='https://pydata.org'>PyData Announcement!</a></p>",
+      "announcement": "Here's a <a href='https://pydata.org'>PyData Announcement!</a>",
    }
 
 Insert remote HTML with JavaScript


### PR DESCRIPTION
The `<p>` tags will actually mess up the text formatting, so I'm removing them here!