### PR TITLE
Fix icon links requirement

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -196,10 +196,11 @@ def update_config(app):
     ]
     # Add extra icon links entries if there were shortcuts present
     # TODO: Deprecate this at some point in the future?
+    icon_links = theme_options.get("icon_links", [])
     for url, icon, name in shortcuts:
         if theme_options.get(url):
             # This defaults to an empty list so we can always insert
-            theme_options["icon_links"].insert(
+            icon_links.insert(
                 0,
                 {
                     "url": theme_options.get(url),
@@ -208,6 +209,7 @@ def update_config(app):
                     "type": "fontawesome",
                 },
             )
+    theme_options["icon_links"] = icon_links
 
     # Prepare the logo config dictionary
     theme_logo = theme_options.get("logo")


### PR DESCRIPTION
This fixes the case that no icon links are given, and a github/gitlab/etc URL _is_ given, and the logic assumed that icon_links wasn't `None`.

I think we might want to deprecate this "auto-add icon links" behavior soon, but this at least fixes the immediate bug.

- fixes https://github.com/pydata/pydata-sphinx-theme/issues/1226

I tested locally by building the docs after commenting out our `icon_links` config. On `main` this breaks, and on this PR it works. I thought this might be too edge-casey to warrant a full test esp since we don't really encourage the shortcut syntax for links