### PR TITLE
ENH: Add parameters `navigation_startdepth` and `toc_caption_maxdepth`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,6 +145,7 @@ html_theme_options = {
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "navbar_center": ["version-switcher", "navbar-nav"],
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
+    "navigation_startdepth": 0,
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,8 @@ html_theme_options = {
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "navbar_center": ["version-switcher", "navbar-nav"],
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
-    "navigation_startdepth": 0,
+    # "navigation_startdepth": 0,
+    # "toc_caption_maxdepth": 3,
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],

--- a/docs/examples/subpages/index.rst
+++ b/docs/examples/subpages/index.rst
@@ -5,6 +5,7 @@ To create an additional level of nesting in the sidebar, construct a
 nested ``toctree``:
 
 .. toctree::
+    :caption: Sub TOC with caption
 
     subpage1
     subpage2

--- a/docs/examples/subpages/subsubpages/index.rst
+++ b/docs/examples/subpages/subsubpages/index.rst
@@ -5,7 +5,13 @@ To create an additional level of nesting in the sidebar, construct a
 nested ``toctree``:
 
 .. toctree::
+    :caption: Sub sub TOC with caption
 
     subsubpage1
     subsubpage2
+
+
+.. toctree::
+    :caption: Sub sub TOC with another caption
+
     subsubpage3

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1,6 +1,7 @@
 """
 Bootstrap-based sphinx theme from the PyData community
 """
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, cast
 import os
 from pathlib import Path
 from functools import lru_cache
@@ -11,14 +12,17 @@ import types
 import jinja2
 from bs4 import BeautifulSoup as bs
 from docutils import nodes
+from docutils.nodes import Element
 from sphinx import addnodes
+from sphinx.locale import __
 from sphinx.application import Sphinx
 from sphinx.environment.adapters.toctree import TocTree
 from sphinx.addnodes import toctree as toctree_node
 from sphinx.transforms.post_transforms import SphinxPostTransform
-from sphinx.util.nodes import NodeMatcher
+from sphinx.util.nodes import NodeMatcher, clean_astext, process_only_nodes
+from sphinx.util.matching import Matcher
 from sphinx.errors import ExtensionError
-from sphinx.util import logging, isurl
+from sphinx.util import logging, isurl, url_re
 from sphinx.util.fileutil import copy_asset_file
 from pygments.formatters import HtmlFormatter
 from pygments.styles import get_all_styles
@@ -26,6 +30,9 @@ import requests
 from requests.exceptions import ConnectionError, HTTPError, RetryError
 
 from .translator import BootstrapHTML5TranslatorMixin
+
+if TYPE_CHECKING:
+    from sphinx.builders import Builder
 
 __version__ = "0.13.2dev0"
 
@@ -797,7 +804,237 @@ def soup_to_python(soup, only_pages=False):
 
     return navs
 
+def resolve(self, docname: str, builder: "Builder", toctree: addnodes.toctree,
+            prune: bool = True, maxdepth: int = 0, titles_only: bool = False,
+            collapse: bool = False, includehidden: bool = False) -> Optional[Element]:
+    """Resolve a *toctree* node into individual bullet lists with titles
+    as items, returning None (if no containing titles are found) or
+    a new node.
 
+    If *prune* is True, the tree is pruned to *maxdepth*, or if that is 0,
+    to the value of the *maxdepth* option on the *toctree* node.
+    If *titles_only* is True, only toplevel document titles will be in the
+    resulting tree.
+    If *collapse* is True, all branches not containing docname will
+    be collapsed.
+    """
+    if toctree.get('hidden', False) and not includehidden:
+        return None
+    generated_docnames: Dict[str, Tuple[str, str, str]] = self.env.domains['std'].initial_data['labels'].copy()  # NoQA: E501
+
+    # For reading the following two helper function, it is useful to keep
+    # in mind the node structure of a toctree (using HTML-like node names
+    # for brevity):
+    #
+    # <ul>
+    #   <li>
+    #     <p><a></p>
+    #     <p><a></p>
+    #     ...
+    #     <ul>
+    #       ...
+    #     </ul>
+    #   </li>
+    # </ul>
+    #
+    # The transformation is made in two passes in order to avoid
+    # interactions between marking and pruning the tree (see bug #1046).
+
+    toctree_ancestors = self.get_toctree_ancestors(docname)
+    included = Matcher(self.env.config.include_patterns)
+    excluded = Matcher(self.env.config.exclude_patterns)
+
+    def _toctree_add_classes(node: Element, depth: int) -> None:
+        """Add 'toctree-l%d' and 'current' classes to the toctree."""
+        for subnode in node.children:
+            if isinstance(subnode, (addnodes.compact_paragraph,
+                                    nodes.list_item)):
+                # for <p> and <li>, indicate the depth level and recurse
+                subnode['classes'].append('toctree-l%d' % (depth - 1))
+                _toctree_add_classes(subnode, depth)
+            elif isinstance(subnode, nodes.bullet_list):
+                # for <ul>, just recurse
+                _toctree_add_classes(subnode, depth + 1)
+            elif isinstance(subnode, nodes.reference):
+                # for <a>, identify which entries point to the current
+                # document and therefore may not be collapsed
+                if subnode['refuri'] == docname:
+                    if not subnode['anchorname']:
+                        # give the whole branch a 'current' class
+                        # (useful for styling it differently)
+                        branchnode: Element = subnode
+                        while branchnode:
+                            branchnode['classes'].append('current')
+                            branchnode = branchnode.parent
+                    # mark the list_item as "on current page"
+                    if subnode.parent.parent.get('iscurrent'):
+                        # but only if it's not already done
+                        return
+                    while subnode:
+                        subnode['iscurrent'] = True
+                        subnode = subnode.parent
+
+    def _entries_from_toctree(toctreenode: addnodes.toctree, parents: List[str],
+                                separate: bool = False, subtree: bool = False
+                                ) -> List[Element]:
+        """Return TOC entries for a toctree node."""
+        refs = [(e[0], e[1]) for e in toctreenode['entries']]
+        entries: List[Element] = []
+        for (title, ref) in refs:
+            try:
+                refdoc = None
+                if url_re.match(ref):
+                    if title is None:
+                        title = ref
+                    reference = nodes.reference('', '', internal=False,
+                                                refuri=ref, anchorname='',
+                                                *[nodes.Text(title)])
+                    para = addnodes.compact_paragraph('', '', reference)
+                    item = nodes.list_item('', para)
+                    toc = nodes.bullet_list('', item)
+                elif ref == 'self':
+                    # 'self' refers to the document from which this
+                    # toctree originates
+                    ref = toctreenode['parent']
+                    if not title:
+                        title = clean_astext(self.env.titles[ref])
+                    reference = nodes.reference('', '', internal=True,
+                                                refuri=ref,
+                                                anchorname='',
+                                                *[nodes.Text(title)])
+                    para = addnodes.compact_paragraph('', '', reference)
+                    item = nodes.list_item('', para)
+                    # don't show subitems
+                    toc = nodes.bullet_list('', item)
+                elif ref in generated_docnames:
+                    docname, _, sectionname = generated_docnames[ref]
+                    if not title:
+                        title = sectionname
+                    reference = nodes.reference('', title, internal=True,
+                                                refuri=docname, anchorname='')
+                    para = addnodes.compact_paragraph('', '', reference)
+                    item = nodes.list_item('', para)
+                    # don't show subitems
+                    toc = nodes.bullet_list('', item)
+                else:
+                    if ref in parents:
+                        logger.warning(__('circular toctree references '
+                                            'detected, ignoring: %s <- %s'),
+                                        ref, ' <- '.join(parents),
+                                        location=ref, type='toc', subtype='circular')
+                        continue
+                    refdoc = ref
+                    toc = self.env.tocs[ref].deepcopy()
+                    maxdepth = self.env.metadata[ref].get('tocdepth', 0)
+                    if ref not in toctree_ancestors or (prune and maxdepth > 0):
+                        self._toctree_prune(toc, 2, maxdepth, collapse)
+                    process_only_nodes(toc, builder.tags)
+                    if title and toc.children and len(toc.children) == 1:
+                        child = toc.children[0]
+                        for refnode in child.findall(nodes.reference):
+                            if refnode['refuri'] == ref and \
+                                not refnode['anchorname']:
+                                refnode.children = [nodes.Text(title)]
+                if not toc.children:
+                    # empty toc means: no titles will show up in the toctree
+                    logger.warning(__('toctree contains reference to document %r that '
+                                        'doesn\'t have a title: no link will be generated'),
+                                    ref, location=toctreenode)
+            except KeyError:
+                # this is raised if the included file does not exist
+                if excluded(self.env.doc2path(ref, False)):
+                    message = __('toctree contains reference to excluded document %r')
+                elif not included(self.env.doc2path(ref, False)):
+                    message = __('toctree contains reference to non-included document %r')
+                else:
+                    message = __('toctree contains reference to nonexisting document %r')
+
+                logger.warning(message, ref, location=toctreenode)
+            else:
+                # if titles_only is given, only keep the main title and
+                # sub-toctrees
+                if titles_only:
+                    # children of toc are:
+                    # - list_item + compact_paragraph + (reference and subtoc)
+                    # - only + subtoc
+                    # - toctree
+                    children = cast(Iterable[nodes.Element], toc)
+
+                    # delete everything but the toplevel title(s)
+                    # and toctrees
+                    for toplevel in children:
+                        # nodes with length 1 don't have any children anyway
+                        if len(toplevel) > 1:
+                            subtrees = list(toplevel.findall(addnodes.toctree))
+                            if subtrees:
+                                toplevel[1][:] = subtrees  # type: ignore
+                            else:
+                                toplevel.pop(1)
+                # resolve all sub-toctrees
+                for subtocnode in list(toc.findall(addnodes.toctree)):
+                    if not (subtocnode.get('hidden', False) and
+                            not includehidden):
+                        i = subtocnode.parent.index(subtocnode) + 1
+                        for entry in _entries_from_toctree(
+                                subtocnode, [refdoc] + parents,
+                                subtree=True):
+                            subtocnode.parent.insert(i, entry)
+                            i += 1
+                        subtocnode.parent.remove(subtocnode)
+                if separate:
+                    entries.append(toc)
+                else:
+                    children = cast(Iterable[nodes.Element], toc)
+                    entries.extend(children)
+        if not subtree and not separate:
+            ret = nodes.bullet_list()
+            ret += entries
+            return [ret]
+        return entries
+
+    maxdepth = maxdepth or toctree.get('maxdepth', -1)
+    if not titles_only and toctree.get('titlesonly', False):
+        titles_only = True
+    if not includehidden and toctree.get('includehidden', False):
+        includehidden = True
+
+    # NOTE: previously, this was separate=True, but that leads to artificial
+    # separation when two or more toctree entries form a logical unit, so
+    # separating mode is no longer used -- it's kept here for history's sake
+    tocentries = _entries_from_toctree(toctree, [], separate=False)
+    if not tocentries:
+        return None
+
+    newnode = addnodes.compact_paragraph('', '')
+    caption = toctree.attributes.get('caption')
+    if caption:
+        caption_node = nodes.title(caption, '', *[nodes.Text(caption)])
+        caption_node.line = toctree.line
+        caption_node.source = toctree.source
+        caption_node.rawsource = toctree['rawcaption']
+        if hasattr(toctree, 'uid'):
+            # move uid to caption_node to translate it
+            caption_node.uid = toctree.uid  # type: ignore
+            del toctree.uid  # type: ignore
+        newnode += caption_node
+    newnode.extend(tocentries)
+    newnode['toctree'] = True
+
+    # prune the tree to maxdepth, also set toc depth and current classes
+    _toctree_add_classes(newnode, 1)
+    self._toctree_prune(newnode, 1, maxdepth if prune else 0, collapse)
+
+    if isinstance(newnode[-1], nodes.Element) and len(newnode[-1]) == 0:  # No titles found
+        return None
+
+    # set the target paths in the toctrees (they are not known at TOC
+    # generation time)
+    for refnode in newnode.findall(nodes.reference):
+        if not url_re.match(refnode['refuri']):
+            refnode['refuri'] = builder.get_relative_uri(
+                docname, refnode['refuri']) + refnode['anchorname']
+    return newnode
+        
 # -----------------------------------------------------------------------------
 
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -10,6 +10,7 @@
 {# Create the sidebar links HTML here to re-use in a few places #}
 {# If we have no sidebar links, pop the links component from the sidebar list #}
 {%- set sidebar_nav_html = generate_toctree_html("sidebar",
+startdepth=theme_navigation_startdepth|int,
 show_nav_level=theme_show_nav_level|int,
 maxdepth=theme_navigation_depth|int,
 collapse=theme_collapse_navigation|tobool,

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -14,6 +14,7 @@ startdepth=theme_navigation_startdepth|int,
 show_nav_level=theme_show_nav_level|int,
 maxdepth=theme_navigation_depth|int,
 collapse=theme_collapse_navigation|tobool,
+toc_caption_maxdepth=theme_toc_caption_maxdepth|int,
 includehidden=True,
 titles_only=True)
 -%}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -29,6 +29,7 @@ navigation_startdepth = 1
 navigation_depth = 4
 show_nav_level = 1
 show_toc_level = 1
+toc_caption_maxdepth = 1
 navbar_align = content
 header_links_before_dropdown = 5
 switcher =

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -25,6 +25,7 @@ search_bar_text = Search the docs ...
 search_bar_position = sidebar
 navigation_with_keys = True
 collapse_navigation = False
+navigation_startdepth = 1
 navigation_depth = 4
 show_nav_level = 1
 show_toc_level = 1


### PR DESCRIPTION
Hi,

As discussed in Issue #1181 it is quite straight forward to implement a new parameter that allows users to decide which level the sidebar TOC should start at. By introducing a new global theme-parameter, `navigation_startdepth` , that is passed to the `generate_toctree_html` function. I have made a separate branch [here](https://github.com/SimenZhor/pydata-sphinx-theme/tree/enh/navigation_startdepth) that showcases only this functionality. 

Here is a screenshot showing all top-level TOCs collapsed (`navigation_startdepth=0`):
![collapsed](https://user-images.githubusercontent.com/16973329/224490015-2784be88-6128-4c21-8f30-ddc40f83daa6.png)

As I developed this on my own project, everything worked as expected. But when I tested it on the pydata-sphinx-theme docs I noticed that setting the startdepth to 0 would break the nice looking subcategories generated by the `toctree` `:captions:`, as these were only rendered for the first layer of toctrees (discussed in: #192 and #135)

Screenshots:
![comparison before and after](https://user-images.githubusercontent.com/16973329/224490399-59822d91-f651-48eb-83c1-2cc505156e83.png)

So, to avoid breaking this feature for `navigation_startdepth=0` I've also introduced a parameter for specifying how deep the toctree captions should be rendered: `toc_caption_maxdepth`.

![toc_caption_maxdepth enabled](https://user-images.githubusercontent.com/16973329/224490753-00b1a946-af19-4a44-8c36-5f73a0155fdc.png)

Here is a screenshot of how it looks when `toc_caption_maxdepth` is set to a high number: 
![bilde](https://user-images.githubusercontent.com/16973329/224490914-d5d26c2a-3ad5-4f0a-842e-5060fd72c252.png)

I had to copy and edit yet another giant function from the Sphinx library into the monolithic `__init__.py`, so I've not yet written any documentation for these new parameters as I wanted a "go" from one of the maintainers before putting more time into this.

Other relevant issues: #944 
