### PR TITLE
docs: ensure edit links point to main branch

### DIFF
--- a/docs/_templates/edit-this-page.html
+++ b/docs/_templates/edit-this-page.html
@@ -1,0 +1,16 @@
+{% if sourcename is defined and theme_use_edit_page_button==true and page_source_suffix %}
+  {% set src = sourcename.split('.') %}
+  <div class="tocsection editthispage">
+    <a href="{{ to_main(get_edit_provider_and_url()[1]) }}">
+      <i class="fa-solid fa-pencil"></i>
+      {% set provider = get_edit_provider_and_url()[0] %}
+      {% block edit_this_page_text %}
+        {% if provider %}
+          {% trans provider=provider %}Edit on {{ provider }}{% endtrans %}
+        {% else %}
+          {% trans %}Edit{% endtrans %}
+        {% endif %}
+      {% endblock %}
+    </a>
+  </div>
+{% endif %}

--- a/docs/_templates/edit-this-page.html
+++ b/docs/_templates/edit-this-page.html
@@ -1,4 +1,4 @@
-{% if sourcename is defined and theme_use_edit_page_button==true and page_source_suffix %}
+{% if sourcename is defined and theme_use_edit_page_button and page_source_suffix %}
   {% set src = sourcename.split('.') %}
   <div class="tocsection editthispage">
     <a href="{{ to_main(get_edit_provider_and_url()[1]) }}">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -221,5 +221,23 @@ favicons = [
 # -- application setup -------------------------------------------------------
 
 
+def setup_to_main(app, pagename, templatename, context, doctree):
+    def to_main(link: str) -> str:
+        """Transform "edit on github" links and make sure they always point to the main branch
+
+        Args:
+            link: the link to the github edit interface
+
+        Returns:
+            the link to the tip of the main branch for the same file
+        """
+        links = link.split("/")
+        idx = links.index("edit")
+        return "/".join(links[: idx + 1]) + "/main/" + "/".join(links[idx + 2 :])
+
+    context["to_main"] = to_main
+
+
 def setup(app):
     app.add_directive("gallery-grid", GalleryDirective)
+    app.connect("html-page-context", setup_to_main)


### PR DESCRIPTION
Fix #1237 

Proposal to solve the issue using solution 1.
- overwrite our template to add an extra method in the url parsing
- create a `to_main` method to digest the link and reroute it to main branch