### PR TITLE
fix: hide captions associated with hidden images

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -105,11 +105,13 @@ $pst-semantic-colors: (
   }
   // adapt to light/dark-specific content
   @if $mode == "light" {
-    .only-dark {
+    .only-dark,
+    .only-dark ~ figcaption {
       display: none !important;
     }
   } @else {
-    .only-light {
+    .only-light,
+    .only-light ~ figcaption {
       display: none !important;
     }
     /* Adjust images in dark mode (unless they have class .only-dark or


### PR DESCRIPTION
Fix #1218

Lucky for us the figcaptions are siblings of the images in the figure strucure. this small pathc should ensure that the caption associated with a figure is only displayed when we are in the appropriate theme: 

I used the following code for testing 

```rst 
.. figure:: https://source.unsplash.com/200x200/daily?cute+dog
    :class: only-light

    ceci est un chien

.. figure:: https://source.unsplash.com/200x200/daily?cute+cat
    :class: only-dark

    ceci est un chat
```

![Capture d’écran 2023-03-13 212326](https://user-images.githubusercontent.com/12596392/224825067-b2d7bfd9-543d-4bb2-8a6f-7b5d9fbcadcf.png)

![Capture d’écran 2023-03-13 212308](https://user-images.githubusercontent.com/12596392/224825072-13c648fe-79cf-48de-b00a-de9e8a8e6d18.png)
