### PR TITLE
fix highlighting of active version in version dropdown

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -18,6 +18,10 @@
   opacity: 0.1;
 }
 
+.version-switcher__button[data-active-version-name*="dev"] {
+  background-color: var(--pst-color-secondary);
+}
+
 /* custom CSS classes (used in docs/user_guide/extending.rst) NOTE: the begin
  *  and end markers are necessary for partial file includes! don't remove them.
  */

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -351,8 +351,7 @@ if (themeSwitchBtns.length) {
         // also highlight the dropdown entry for the currently-viewed
         // version's entry
         if (
-          entry.version ==
-          "DOCUMENTATION_OPTIONS.version_switcher_version_match"
+          entry.version == DOCUMENTATION_OPTIONS.version_switcher_version_match
         ) {
           node.classList.add("active");
           themeSwitchBtns.forEach((btn) => {


### PR DESCRIPTION
this might fix the problem in #1128 but the version switcher doesn't load correctly on local builds so I need a CI build to test it.