### PR TITLE
fix: avoid infinite loop in docs-live

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,6 @@ import shutil as sh
 import tempfile
 from pathlib import Path
 from shlex import split
-import tempfile
 from textwrap import dedent
 
 import nox
@@ -79,19 +78,8 @@ def docs_live(session: nox.Session) -> None:
     session.run(*split("pybabel compile -d src/pydata_sphinx_theme/locale -D sphinx"))
     if _should_install(session):
         session.install("-e", ".[doc]")
-        session.install("sphinx-autobuild")
-
-    with tempfile.TemporaryDirectory() as destination:
-        session.run(
-            "sphinx-autobuild",
-            "--watch=./docs/",
-            "--port=0",
-            "--open-browser",
-            "-b=dirhtml",
-            "-a",
-            "docs/",
-            destination,
-        )
+        session.install("sphinx-theme-builder[cli]")
+    session.run("stb", "serve", "docs", "--open-browser" "--re-ignore=locale")
 
 
 @nox.session()

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,6 +10,7 @@ import shutil as sh
 import tempfile
 from pathlib import Path
 from shlex import split
+import tempfile
 from textwrap import dedent
 
 import nox
@@ -78,8 +79,19 @@ def docs_live(session: nox.Session) -> None:
     session.run(*split("pybabel compile -d src/pydata_sphinx_theme/locale -D sphinx"))
     if _should_install(session):
         session.install("-e", ".[doc]")
-        session.install("sphinx-theme-builder[cli]")
-    session.run("stb", "serve", "docs", "--open-browser")
+        session.install("sphinx-autobuild")
+
+    with tempfile.TemporaryDirectory() as destination:
+        session.run(
+            "sphinx-autobuild",
+            "--watch=./docs/",
+            "--port=0",
+            "--open-browser",
+            "-b=dirhtml",
+            "-a",
+            "docs/",
+            destination,
+        )
 
 
 @nox.session()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["sphinx-theme-builder >= 0.2.0b2"]
+requires = ["sphinx-theme-builder @ https://github.com/pradyunsg/sphinx-theme-builder/archive/d9f620b1a73839728c95b596343595d3952ec8bf.zip"]
 build-backend = "sphinx_theme_builder"
 
 [tool.sphinx-theme-builder]


### PR DESCRIPTION
Fix #1256 

I didn't really get what the stb serve was used for so I rewrote the nox "docs-live" session the same way as in https://github.com/pradyunsg/sphinx-theme-builder/blob/16979342306d885f4a99c195628001be61e98e5a/noxfile.py#L23.

I don't experience the infinite loop anymore. My only question is what changes should we listen to ? the one from the documentation or the one from the src (or both) ? 

This current implementation listen to the docs but as I'm never using it I don't know if it's the way people use it. 

