### PR TITLE
fix wheel by bumping STB version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["sphinx-theme-builder >= 0.2.0a7"]
+requires = ["sphinx-theme-builder >= 0.2.0b2"]
 build-backend = "sphinx_theme_builder"
 
 [tool.sphinx-theme-builder]


### PR DESCRIPTION
# Description

See #1253

This PR upgrades the version of STB (build backend used by this project) to the latest release, which includes [my PR that fixes the `RECORD` hashes in built wheels](https://github.com/pradyunsg/sphinx-theme-builder/pull/39). This will allow Poetry projects to install `pydata-sphinx-theme`.

# Verification

Add this script (`validate_wheel.py`) to the project root:

```python
import os
from installer.sources import WheelFile

WHEEL_RELPATH = 'dist/pydata_sphinx_theme-0.13.2.dev0-py3-none-any.whl'

wheel_abspath = os.path.join(os.path.dirname(__file__), WHEEL_RELPATH)

with WheelFile.open(wheel_abspath) as source:
    source.validate_record()
```

Then, build the wheel and verify the script does not except:

```
$ python -m build
$ python validate_wheel.py
```

# Next steps

Cut a release after this is merged to update the published wheel on PyPi. Then we can close the issue.