### PR TITLE
FIX: Remove index.html from version switcher example.

### DIFF
--- a/docs/user_guide/version-dropdown.rst
+++ b/docs/user_guide/version-dropdown.rst
@@ -49,19 +49,19 @@ Here is an example JSON file:
         {
             "name": "v2.1 (stable)",
             "version": "2.1",
-            "url": "https://mysite.org/en/2.1/index.html"
+            "url": "https://mysite.org/en/2.1/"
         },
         {
             "version": "2.1rc1",
-            "url": "https://mysite.org/en/2.1rc1/index.html"
+            "url": "https://mysite.org/en/2.1rc1/"
         },
         {
             "version": "2.0",
-            "url": "https://mysite.org/en/2.0/index.html"
+            "url": "https://mysite.org/en/2.0/"
         },
         {
             "version": "1.0",
-            "url": "https://mysite.org/en/1.0/index.html"
+            "url": "https://mysite.org/en/1.0/"
         }
     ]
 


### PR DESCRIPTION
When following the example in the docs for the `switcher.json` file, I ended up with issues once I tried to navigate to other pages because the `index.html` part stays in the URL (e.g., clicking on `api` goes to `https://mysite.org/en/2.1/index.htmlapi.html`). Removing `index.html` and ending with a trailing slash seems to be [the fix](https://github.com/stefmolin/data-morph/blob/main/docs/_static/switcher.json#L1-L12) (see also the [Matplotlib switcher.json file](https://matplotlib.org/devdocs/_static/switcher.json)).