### PR TITLE
DOC: Section on RTD version switcher

### DIFF
--- a/docs/user_guide/readthedocs.md
+++ b/docs/user_guide/readthedocs.md
@@ -4,14 +4,12 @@ This theme comes with support for {{ rtd }}, a popular service for hosting docum
 
 ## Version switcher
 
-Rather than using the [version switcher that this theme provides](version-dropdown.rst),
-this theme also supports the ReadTheDocs version switcher by default.
+Projects hosted on {{ rtd }} can use the {{ rtd }} supplied version switcher instead of the [version switcher that this theme provides](version-dropdown.rst).
+Its presence will be automatically detected by this theme, and placed in the `rtd-footer-container` node inside the primary sidebar.
 
 ```{warning}
-Currently the ReadTheDocs version switcher is located in the left sidebar, which
-is only visible on mobile or on pages which implement sectioning (hence
-displaying the left sidebar). Future work is to
-[include the ReadTheDocs version switcher in the top navigation bar](https://github.com/pydata/pydata-sphinx-theme/issues/705).
+The {{ rtd }} version switcher will be hidden any time the primary sidebar is hidden (see [this section](#layout-sidebar-primary) for discussion of when the primary sidebar might get hidden automatically and how to hide it purposely).
+We intend to make {{ rtd }} switcher placement more flexible; you can track progress toward that in [this issue](https://github.com/pydata/pydata-sphinx-theme/issues/705).
 ```
 
 ## Add ethical advertisements to your sidebar

--- a/docs/user_guide/readthedocs.md
+++ b/docs/user_guide/readthedocs.md
@@ -8,7 +8,7 @@ Projects hosted on {{ rtd }} can use the {{ rtd }} supplied version switcher ins
 Its presence will be automatically detected by this theme, and placed in the `rtd-footer-container` node inside the primary sidebar.
 
 ```{warning}
-The {{ rtd }} version switcher will be hidden any time the primary sidebar is hidden (see [this section](#layout-sidebar-primary) for discussion of when the primary sidebar might get hidden automatically and how to hide it purposely).
+The {{ rtd }} version switcher will be hidden any time the primary sidebar is hidden (see [this section](layout-sidebar-primary) for discussion of when the primary sidebar might get hidden automatically and how to hide it purposely).
 We intend to make {{ rtd }} switcher placement more flexible; you can track progress toward that in [this issue](https://github.com/pydata/pydata-sphinx-theme/issues/705).
 ```
 

--- a/docs/user_guide/readthedocs.md
+++ b/docs/user_guide/readthedocs.md
@@ -2,6 +2,18 @@
 
 This theme comes with support for {{ rtd }}, a popular service for hosting documentation in the scientific Python community.
 
+## Version switcher
+
+Rather than using the [version switcher that this theme provides](version-dropdown.rst),
+this theme also supports the ReadTheDocs version switcher by default.
+
+```{warning}
+Currently the ReadTheDocs version switcher is located in the left sidebar, which
+is only visible on mobile or on pages which implement sectioning (hence
+displaying the left sidebar). Future work is to
+[include the ReadTheDocs version switcher in the top navigation bar](https://github.com/pydata/pydata-sphinx-theme/issues/705).
+```
+
 ## Add ethical advertisements to your sidebar
 
 If you're hosting your documentation on ReadTheDocs, you should consider


### PR DESCRIPTION
This clarification confirms this theme supports RTD versioning by default. This is necessary as many users start up with simple projects which may not implement sectioning, which may confuse them as to why the RTD version switcher isn't visible. It reassures its not a bug with their code/docs configuration.

As per discussion at https://github.com/pydata/pydata-sphinx-theme/pull/1005#issuecomment-1493381984 . Related to #705

Maintainers feel free to push changes to this branch if desired.