### PR TITLE
Style keyword arguments in API docs

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_api.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_api.scss
@@ -88,6 +88,12 @@ table.field-list {
   color: var(--pst-color-inline-code);
 }
 
+.sig-param .o,
+.sig-param .default_value {
+  color: var(--pst-color-text-muted);
+  font-weight: normal;
+}
+
 // change target color for dark theme
 dt:target,
 span.highlighted {


### PR DESCRIPTION
They are now slightly muted and not bold anymore.
This draws more attention to the parameter names
and should make it easier to read long parameter
lists.

before:
![grafik](https://github.com/pydata/pydata-sphinx-theme/assets/2836374/86f43f92-855c-4084-8b61-30fbac5075af)


after:
![grafik](https://github.com/pydata/pydata-sphinx-theme/assets/2836374/1ce25dbd-aa90-4cef-9860-2d1b55f776d0)
