### PR TITLE
Update link to FontAwesome free icon gallery in the user guide

### DIFF
--- a/docs/user_guide/header-links.rst
+++ b/docs/user_guide/header-links.rst
@@ -89,7 +89,7 @@ as well as brand-specific icons (e.g. "github").
 You can use FontAwesome icons by specifying ``"type": "fontawesome"``, and
 specifying a FontAwesome class in the ``icon`` value.
 The value of ``icon`` can be any full
-`FontAwesome 6 Free <https://fontawesome.com/icons?d=gallery&m=free>`__ icon.
+`FontAwesome 6 Free <https://fontawesome.com/search?o=r&m=free>`__ icon.
 In addition to the main icon class, e.g. ``fa-cat``, the "style" class must
 also be provided e.g. `fa-brands` for *branding*, or `fa-solid` for *solid*.
 


### PR DESCRIPTION
The current link opens up a search page, but after searching, the "free" filter must be activated again manually. 
The updated link opens up a search page with the "free" filter already activated.