### PR TITLE
fix: set back align content for header navbar

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -3,14 +3,14 @@
   <label class="sidebar-toggle primary-toggle" for="__primary">
     <span class="fa-solid fa-bars"></span>
   </label>
+  {% set navbar_start, navbar_class, navbar_align = navbar_align_class() %}
   {% if theme_navbar_start %}
-  <div class="navbar-header-items__start">
+  <div class="{{ navbar_start }} navbar-header-items__start">
     {% for navbar_item in theme_navbar_start %}
       <div class="navbar-item">{% include navbar_item %}</div>
     {% endfor %}
   </div>
   {% endif %}
-  {% set navbar_class, navbar_align = navbar_align_class() %}
   <div class="{{ navbar_class }} navbar-header-items">
     {% if theme_navbar_center %}
     <div class="{{ navbar_align }} navbar-header-items__center">

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -285,9 +285,9 @@ def add_toctree_functions(
         """Return the class that aligns the navbar based on config."""
         align = context.get("theme_navbar_align", "content")
         align_options = {
-            "content": ("col-lg-9", "me-auto"),
-            "left": ("", "me-auto"),
-            "right": ("", "ms-auto"),
+            "content": ("col-lg-3", "col-lg-9", "me-auto"),
+            "left": ("", "", "me-auto"),
+            "right": ("", "", "ms-auto"),
         }
         if align not in align_options:
             raise ValueError(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -273,25 +273,27 @@ def test_logo_template_rejected(sphinx_build_factory) -> None:
         sphinx_build_factory("base", confoverrides=confoverrides).build()
 
 
-def test_navbar_align_default(sphinx_build_factory) -> None:
+@pytest.mark.parametrize(
+    "align,klass",
+    [
+        ("content", ("col-lg-3", "col-lg-9", "me-auto")),
+        ("left", ("", "", "me-auto")),
+        ("right", ("", "", "ms-auto")),
+    ],
+)
+def test_navbar_align(align, klass, sphinx_build_factory) -> None:
     """The navbar items align with the proper part of the page."""
-    sphinx_build = sphinx_build_factory("base").build()
-    index_html = sphinx_build.html_tree("index.html")
-    assert "col-lg-9" in index_html.select(".navbar-header-items")[0].attrs["class"]
-
-
-def test_navbar_align_right(sphinx_build_factory) -> None:
-    """The navbar items align with the proper part of the page."""
-    confoverrides = {"html_theme_options.navbar_align": "right"}
+    confoverrides = {"html_theme_options.navbar_align": align}
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
-
-    # Both the column alignment and the margin should be changed
     index_html = sphinx_build.html_tree("index.html")
-    assert "col-lg-9" not in index_html.select(".navbar-header-items")[0].attrs["class"]
-    assert (
-        "ms-auto"
-        in index_html.select("div.navbar-header-items__center")[0].attrs["class"]
-    )
+    if klass[0]:
+        header_start = index_html.select(".navbar-header-items__start")[0]
+        assert klass[0] in header_start.attrs["class"]
+    if klass[1]:
+        header_items = index_html.select(".navbar-header-items")[0]
+        assert klass[1] in header_items.attrs["class"]
+    header_center = index_html.select(".navbar-header-items__center")[0]
+    assert klass[2] in header_center.attrs["class"]
 
 
 def test_navbar_no_in_page_headers(sphinx_build_factory, file_regression) -> None:


### PR DESCRIPTION
Fix #1235 

I added a class to navbar_start to make sure "content" parameter works again. checked on our documentation.

right: 

![image](https://github.com/pydata/pydata-sphinx-theme/assets/12596392/296d5ade-0035-4da4-90dc-77fc45e36407)

left:

![image](https://github.com/pydata/pydata-sphinx-theme/assets/12596392/7398f51a-cd24-4d41-860a-7f21881fd2c5)

content: 

![image](https://github.com/pydata/pydata-sphinx-theme/assets/12596392/3f59e675-bbeb-4594-9791-a6eb84948f62)
