### PR TITLE
feat: add a scroll to top btn

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
+++ b/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
@@ -22,7 +22,35 @@ function TriggerTooltip() {
 }
 
 /*******************************************************************************
+ * back to top button
+ */
+function backToTop() {
+  var btn = document.getElementById("pst-back-to-top");
+  btn.addEventListener("click", function () {
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  });
+}
+
+function showBackToTop() {
+  var btn = document.getElementById("pst-back-to-top");
+  var header = document
+    .getElementsByClassName("bd-header")[0]
+    .getBoundingClientRect();
+  window.addEventListener("scroll", function () {
+    if (this.oldScroll > this.scrollY && this.scrollY > header.bottom) {
+      btn.style.display = "block";
+    } else {
+      btn.style.display = "none";
+    }
+    this.oldScroll = this.scrollY;
+  });
+}
+
+/*******************************************************************************
  * Call functions after document loading.
  */
 
 documentReady(TriggerTooltip);
+documentReady(backToTop);
+documentReady(showBackToTop);

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -186,4 +186,7 @@ pre {
   top: calc(var(--pst-header-height) + 1rem);
   left: 50%;
   transform: translate(-50%);
+  color: var(--pst-color-primary);
+  background-color: var(--pst-color-background);
+  border: 1px solid var(--pst-color-border);
 }

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -183,10 +183,10 @@ pre {
   z-index: $zindex-tooltip;
   position: fixed;
   display: none;
-  top: calc(var(--pst-header-height) + 1rem);
+  top: 80vh;
   left: 50vw;
   transform: translate(-50%);
-  color: var(--pst-color-primary);
-  background-color: var(--pst-color-on-background);
+  color: var(--pst-color-text-base);
+  background-color: var(--pst-color-primary);
   border: 1px solid var(--pst-color-border);
 }

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -177,3 +177,13 @@ pre {
     padding-right: 10px;
   }
 }
+
+// the back to top btn
+#pst-back-to-top {
+  z-index: $zindex-tooltip;
+  position: fixed;
+  display: none;
+  top: calc(var(--pst-header-height) + 1rem);
+  left: 50%;
+  transform: translate(-50%);
+}

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -184,7 +184,7 @@ pre {
   position: fixed;
   display: none;
   top: calc(var(--pst-header-height) + 1rem);
-  left: auto;
+  left: 50vw;
   transform: translate(-50%);
   color: var(--pst-color-primary);
   background-color: var(--pst-color-on-background);

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -187,6 +187,6 @@ pre {
   left: 50%;
   transform: translate(-50%);
   color: var(--pst-color-primary);
-  background-color: var(--pst-color-background);
+  background-color: var(--pst-color-on-background);
   border: 1px solid var(--pst-color-border);
 }

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -186,7 +186,7 @@ pre {
   top: 80vh;
   left: 50vw;
   transform: translate(-50%);
-  color: var(--pst-color-text-base);
-  background-color: var(--pst-color-primary);
-  border: 1px solid var(--pst-color-border);
+  color: var(--pst-color-secondary-text);
+  background-color: var(--pst-color-secondary);
+  border: none;
 }

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -184,7 +184,7 @@ pre {
   position: fixed;
   display: none;
   top: calc(var(--pst-header-height) + 1rem);
-  left: 50%;
+  left: auto;
   transform: translate(-50%);
   color: var(--pst-color-primary);
   background-color: var(--pst-color-on-background);

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -55,7 +55,7 @@ or not theme_secondary_sidebar_items %}
   {# A tiny helper pixel to detect if we've scrolled #}
   <div id="pst-scroll-pixel-helper"></div>
 
-  {# the scroll to tpo button #}
+  {# the scroll to top button #}
   <button type="button" class="btn rounded-pill" id="pst-back-to-top">
     <i class="fa-solid fa-arrow-up"></i>
     {{ _("Scroll to top") }}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -58,7 +58,7 @@ or not theme_secondary_sidebar_items %}
   {# the scroll to top button #}
   <button type="button" class="btn rounded-pill" id="pst-back-to-top">
     <i class="fa-solid fa-arrow-up"></i>
-    {{ _("Scroll to top") }}
+    {{ _("Back to top") }}
   </button>
 
   {# checkbox to toggle primary sidebar #}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -52,6 +52,15 @@ or not theme_secondary_sidebar_items %}
 {%- endblock %}
 
 {%- block content %}
+  {# A tiny helper pixel to detect if we've scrolled #}
+  <div id="pst-scroll-pixel-helper"></div>
+
+  {# the scroll to tpo button #}
+  <button type="button" class="btn rounded-pill" id="pst-back-to-top">
+    <i class="fa-solid fa-arrow-up"></i>
+    {{ _("Scroll to top") }}
+  </button>
+
   {# checkbox to toggle primary sidebar #}
   <input type="checkbox"
           class="sidebar-toggle"


### PR DESCRIPTION
Fix #1126 

I added a scroll to top btn to the main article page. It's located 2 * header sidebar from the top and centered on the page. Following instrcution from @choldgraf and the bootstrap implementation (https://mdbootstrap.com/snippets/standard/mdbootstrap/2964350#js-tab-view) I manage to get something lightweight and working. 

The trigger is simply: "when scolling up and under the header initial bottom". I decided to avoid the hidden pixel and to rely on the header bottom to avoid issue when there is a disclaimer. 

let me know what you think. pinging @trallard as you mentioned some a11y issues that I may failed to apply. 

