### PR TITLE
refactor: remove custom scrollbars

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -3,42 +3,6 @@
 *********************************************/
 
 /**
-* Scrollbars should be thinner and slightly rounded, with a grey background
-* ref: https://www.nngroup.com/articles/scrolling-and-scrollbars/
-*/
-@mixin scrollbar-style() {
-  &::-webkit-scrollbar {
-    width: 0.5rem;
-    height: 0.5rem;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--pst-color-text-muted);
-    border-radius: 0.25rem;
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--pst-color-on-surface);
-  }
-
-  // Hovering behavior for the scrollbar
-  // Include both hovering on the parent and on the thumb in case thumb is outside parent
-  &:hover {
-    &::-webkit-scrollbar-thumb {
-      background: var(--pst-color-text-muted);
-    }
-  }
-
-  &::-webkit-scrollbar-thumb:hover {
-    background: var(--pst-color-text-muted);
-  }
-}
-
-/**
  * A consistent box shadow style we apply across elements.
  */
 @mixin box-shadow() {

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -13,8 +13,6 @@ body {
   display: flex;
   flex-direction: column;
 
-  @include scrollbar-style();
-
   // hack to avoid the black background on some browser including Safari
   &::-webkit-scrollbar-track {
     background: var(--pst-color-background);
@@ -169,8 +167,6 @@ pre {
   line-height: 1.2em;
   border: 1px solid var(--pst-color-border);
   border-radius: $admonition-border-radius;
-
-  @include scrollbar-style();
 
   .linenos {
     opacity: 0.5;

--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -37,7 +37,7 @@ div.math {
     flex-grow: 1;
     padding-bottom: 0.2rem;
     overflow: auto;
-    @include scrollbar-style();
+
     // Set height to 0 so that it does not cause scrollbars to appear
     // ref: https://github.com/mathjax/MathJax/issues/2521
     mjx-assistive-mml {

--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -9,8 +9,6 @@ table {
   max-width: 100%;
   overflow: auto;
 
-  @include scrollbar-style();
-
   // default to table-center
   margin-left: auto;
   margin-right: auto;

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
@@ -42,8 +42,6 @@ div.nblast.container {
 div.cell_output .output {
   max-width: 100%;
   overflow-x: auto;
-
-  @include scrollbar-style();
 }
 
 // Dark theme special-cases

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -17,7 +17,6 @@
   border-right: 1px solid var(--pst-color-border);
   background-color: var(--pst-color-background);
   overflow-y: auto;
-  @include scrollbar-style();
 
   font-size: var(--pst-sidebar-font-size-mobile);
   @include media-breakpoint-up($breakpoint-sidebar-primary) {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-secondary.scss
@@ -20,8 +20,6 @@
   // Color and border
   background-color: var(--pst-color-background);
   overflow-y: auto;
-
-  @include scrollbar-style();
 }
 
 .sidebar-secondary-item {


### PR DESCRIPTION
Fix #1239

As mentioned in the issue, it seems custom scrollbar are considered a bad practice so this PR remove the customization alltogether. 

