### PR TITLE
fix: version switcher on sidebar (#1340)

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -345,7 +345,11 @@ if (themeSwitchBtns.length) {
         node.dataset["versionName"] = entry.name;
         node.dataset["version"] = entry.version;
 
-        document.querySelector(".version-switcher__menu").append(node);
+        document.querySelectorAll(".version-switcher__menu").forEach((menu) => {
+          // There may be multiple version-switcher elements, e.g. one
+          // in a slide-over panel displayed on smaller screens.
+          menu.append(node);
+        });
         // replace dropdown button text with the preferred display name of
         // this version, rather than using sphinx's {{ version }} variable.
         // also highlight the dropdown entry for the currently-viewed


### PR DESCRIPTION
Fixes #1340.  Thanks to Adam Plowman (@aplowman) for reporting.

With this change, the switcher in the sidebar looks like this when clicked:

![fixed](https://github.com/pydata/pydata-sphinx-theme/assets/601365/10e7ae10-7aed-4422-ae6b-fef4d7232305)
