### PR TITLE
Version warningbar

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,12 +1,11 @@
 [
   {
-    "name": "dev",
-    "version": "latest",
+    "version": "dev",
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/latest/"
   },
   {
     "name": "0.13.3 (stable)",
-    "version": "stable",
+    "version": "v0.13.3",
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/stable/",
     "preferred": true
   },

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -7,7 +7,8 @@
   {
     "name": "0.13.3 (stable)",
     "version": "stable",
-    "url": "https://pydata-sphinx-theme.readthedocs.io/en/stable/"
+    "url": "https://pydata-sphinx-theme.readthedocs.io/en/stable/",
+    "preferred": true
   },
   {
     "name": "0.12.0",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,7 +104,7 @@ if not version_match or version_match.isdigit():
     # For local development, infer the version to match from the package.
     release = pydata_sphinx_theme.__version__
     if "dev" in release or "rc" in release:
-        version_match = "latest"
+        version_match = "dev"
         # We want to keep the relative reference if we are in dev mode
         # but we want the whole url if we are effectively in a released version
         json_url = "_static/switcher.json"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,6 +164,7 @@ html_theme_options = {
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "navbar_center": ["version-switcher", "navbar-nav"],
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
+    "show_version_warning_banner": True,
     # "show_nav_level": 2,
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],

--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -56,17 +56,30 @@ In addition to the general-purpose announcement banner, the theme includes a bui
         ...
         "show_version_warning_banner": True,
     }
-.. warning::
+
+.. important::
 
     This functionality relies on the :ref:`version switcher <version-dropdowns>` to determine the version number of the latest stable release.
     *It will only work* if your version switcher ``.json`` has exactly one entry with property ``"preferred": true``
-    and a ``name`` property that begins with a version string that is parsable by the `compare-versions node module <https://www.npmjs.com/package/compare-versions>`__, for example:
+    and your entries have ``version`` properties that are parsable by the `compare-versions node module <https://www.npmjs.com/package/compare-versions>`__, for example:
 
     .. code-block:: json
 
         {
-            "name": "9.9.9 (current)",
-            "version": "stable",
-            "preferred": true,
-            "url": "https://anything"
+            "name": "stable",
+            "version": "9.9.9",
+            "url": "https://anything",
+            "preferred": true
         }
+
+If you want similar functionality for *older* versions of your docs (i.e. those built before the ``show_version_warning_banner`` configuration option was available), you can manually add a banner by prepending the following HTML to all pages (be sure to replace ``URL_OF_STABLE_VERSION_OF_PROJECT`` with a valid URL, and adjust styling as desired):
+
+.. code-block:: html
+
+    <div style="background-color: rgb(248, 215, 218); color: rgb(114, 28, 36); text-align: center;">
+      <div>
+        <div>This is documentation for <strong>an old version</strong>.
+          <a href="{{ URL_OF_STABLE_VERSION_OF_PROJECT }}" style="background-color: rgb(220, 53, 69); color: rgb(255, 255, 255); margin: 1rem; padding: 0.375rem 0.75rem; border-radius: 4px; display: inline-block; text-align: center;">Switch to stable version</a>
+        </div>
+      </div>
+    </div>

--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -41,6 +41,9 @@ For example, the following configuration tells the theme to load the ``custom-te
       "announcement": "https://github.com/pydata/pydata-sphinx-theme/raw/main/docs/_templates/custom-template.html",
    }
 
+
+.. _version-warning-banners:
+
 Version warning banners
 -----------------------
 

--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -15,6 +15,7 @@ By default, the value of your ``html_theme_options["announcement"]`` will be ins
 For example, the following configuration adds a simple announcement.
 
 .. code-block:: python
+   :caption: conf.py
 
    html_theme_options = {
       ...
@@ -33,8 +34,35 @@ If the value of ``html_theme_options["announcement"]`` begins with **``http``** 
 For example, the following configuration tells the theme to load the ``custom-template.html`` example from this documentation's GitHub repository:
 
 .. code-block:: python
+   :caption: conf.py
 
    html_theme_options = {
       ...
       "announcement": "https://github.com/pydata/pydata-sphinx-theme/raw/main/docs/_templates/custom-template.html",
    }
+
+Version warning banners
+-----------------------
+
+In addition to the general-purpose announcement banner, the theme includes a built-in banner to warn users when they are viewing versions of your docs other than the latest stable version. To use this feature, add the following to your ``conf.py``:
+
+.. code-block:: python
+    :caption: conf.py
+
+    html_theme_options = {
+        ...
+        "show_version_warning_banner": True,
+    }
+.. warning::
+
+    This functionality relies on the :ref:`version switcher <version-dropdowns>` to determine the version number of the latest stable release.
+    *It will only work* if your version switcher ``.json`` has exactly one entry with property ``"preferred": true``
+    and a ``name`` property that begins with a version string that is parsable by the `compare-versions node module <https://www.npmjs.com/package/compare-versions>`__, for example:
+
+    .. code-block:: json
+
+        {
+            "name": "9.9.9 (current)",
+            "version": "stable",
+            "url": "https://anything"
+        }

--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -67,5 +67,6 @@ In addition to the general-purpose announcement banner, the theme includes a bui
         {
             "name": "9.9.9 (current)",
             "version": "stable",
+            "preferred": true,
             "url": "https://anything"
         }

--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -29,7 +29,7 @@ You can specify an arbitrary URL that will be used as the HTML source for your a
 When the page is loaded, JavaScript will attempt to fetch this HTML and insert it as-is into the announcement banner.
 This allows you to define a single HTML announcement that you can pull into multiple documentation sites or versions.
 
-If the value of ``html_theme_options["announcement"]`` begins with **``http``** it will be treated as a URL to remote HTML.
+If the value of ``html_theme_options["announcement"]`` begins with ``http`` it will be treated as a URL to remote HTML.
 
 For example, the following configuration tells the theme to load the ``custom-template.html`` example from this documentation's GitHub repository:
 

--- a/docs/user_guide/version-dropdown.rst
+++ b/docs/user_guide/version-dropdown.rst
@@ -42,6 +42,8 @@ each can have the following fields:
 - ``url``: the URL for this version.
 - ``name``: an optional name to display in the switcher dropdown instead of the
   version string (e.g., "latest", "stable", "dev", etc.).
+- ``preferred``: an optional field that *should occur on at most one entry* in the JSON file.
+  It specifies which version is considered "latest stable", and is used to customize the message used on :ref:`version-warning-banners` (if they are enabled).
 
 Here is an example JSON file:
 

--- a/docs/user_guide/version-dropdown.rst
+++ b/docs/user_guide/version-dropdown.rst
@@ -1,3 +1,5 @@
+.. _version-dropdowns:
+
 Version switcher dropdowns
 ==========================
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "6.1.2",
         "@popperjs/core": "^2.11.6",
-        "bootstrap": "^5.2.2"
+        "bootstrap": "^5.2.2",
+        "compare-versions": "^5.0.3"
       },
       "devDependencies": {
         "axe-core": "^4.6.3",
@@ -992,6 +993,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/compare-versions": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
+      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
     },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
@@ -5292,6 +5298,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-5.0.3.tgz",
+      "integrity": "sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A=="
     },
     "copy-webpack-plugin": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.1.2",
     "@popperjs/core": "^2.11.6",
-    "bootstrap": "^5.2.2"
+    "bootstrap": "^5.2.2",
+    "compare-versions": "^5.0.3"
   }
 }

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -273,6 +273,7 @@ def update_and_remove_templates(
         js = f"""
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = '{json_url}';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '{version_match}';
+        DOCUMENTATION_OPTIONS.show_version_warning_banner = {str(context["theme_show_version_warning_banner"]).lower()};
         """
         app.add_js_file(None, body=js)
 

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -426,7 +426,7 @@ function showVersionWarningBanner(data) {
   button.classList =
     "sd-btn sd-btn-danger sd-shadow-sm sd-text-wrap font-weight-bold ms-3 my-1 align-baseline";
   button.href = `${preferredURL}${DOCUMENTATION_OPTIONS.pagename}.html`;
-  button.innerText = "Switch to latest stable version";
+  button.innerText = "Switch to stable version";
   button.onclick = checkPageExistsAndRedirect;
   // add the version-dependent text
   inner.innerText = "This is documentation for an ";

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -299,34 +299,32 @@ function checkPageExistsAndRedirect(event) {
       location.href = otherDocsHomepage;
     });
 
-  // ensure we don't follow the initial link
+  // ↓ this prevents the browser from following the href of the clicked node
+  // ↓ (which is fine because this function takes care of redirecting)
   event.preventDefault();
 }
 
 /**
- * Check if the corresponding url is absolute and make a absolute path from root if necessary
+ * Load and parse the version switcher JSON file from an absolute or relative URL.
  *
- * @param {string} url the url to check
+ * @param {string} url The URL to load version switcher entries from.
  */
 async function fetchVersionSwitcherJSON(url) {
   // first check if it's a valid URL
   try {
     var result = new URL(url);
   } catch (err) {
-    // if not, assume relative path and fix accordingly
     if (err instanceof TypeError) {
-      // workaround for redirects like https://pydata-sphinx-theme.readthedocs.io
-      // fetch() automatically follows redirects so it should work in every builder
-      // (RDT, GitHub actions, etc)
-      const origin = await fetch(window.location.origin, {
-        method: "HEAD",
-      });
+      // assume we got a relative path, and fix accordingly. But first, we need to
+      // use `fetch()` to follow redirects so we get the correct final base URL
+      const origin = await fetch(window.location.origin, { method: "HEAD" });
       result = new URL(url, origin.url);
     } else {
+      // something unexpected happened
       throw err;
     }
   }
-
+  // load and return the JSON
   const response = await fetch(result);
   const data = await response.json();
   return data;

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -430,7 +430,10 @@ function showVersionWarningBanner(data) {
   button.onclick = checkPageExistsAndRedirect;
   // add the version-dependent text
   inner.innerText = "This is documentation for an ";
-  const isDev = version.includes("dev");
+  const isDev =
+    version.includes("dev") ||
+    version.includes("rc") ||
+    version.includes("pre");
   const newerThanPreferred =
     versionsAreComparable && compare(version, preferredVersion, ">");
   if (isDev || newerThanPreferred) {

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -408,6 +408,9 @@ function showVersionWarningBanner(data) {
   }
   const preferredVersion = preferredEntries[0].version;
   const preferredURL = preferredEntries[0].url;
+  // TODO: make the below logic more forgiving:
+  //       - don't fail if version string not semVer-parsable
+  //       - if not semVer parsable make message more generic
   // if already on preferred version, nothing to do
   if (!version.includes("dev") && compare(version, preferredVersion, "=")) {
     return;

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -481,7 +481,7 @@ function initRTDObserver() {
 var versionSwitcherBtns = document.querySelectorAll(
   ".version-switcher__button"
 );
-const hasSwitcherMenu = themeSwitchBtns.length > 0;
+const hasSwitcherMenu = versionSwitcherBtns.length > 0;
 const hasVersionsJSON = DOCUMENTATION_OPTIONS.hasOwnProperty(
   "theme_switcher_json_url"
 );

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -365,7 +365,6 @@ function populateVersionSwitcher(data, versionSwitcherBtns) {
       anchor.classList.add("active");
       versionSwitcherBtns.forEach((btn) => {
         btn.innerText = entry.name;
-        entry.name;
         btn.dataset["activeVersionName"] = entry.name;
         btn.dataset["activeVersion"] = entry.version;
       });

--- a/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
@@ -1,3 +1,4 @@
+.bd-header-version-warning,
 .bd-header-announcement {
   min-height: 3rem;
   width: 100%;
@@ -18,14 +19,12 @@
     margin: 0;
   }
 
-  // Bg color is now defined in the theme color palette - using our secondary color
   &:after {
     position: absolute;
     width: 100%;
     height: 100%;
     left: 0;
     top: 0;
-    background-color: var(--pst-color-secondary-bg);
     content: "";
     z-index: -1; // So it doesn't hover over the content
   }
@@ -37,5 +36,18 @@
   // Ensure there is enough contrast against the background
   a {
     color: var(--pst-color-inline-code-links);
+  }
+}
+
+// Bg color is now defined in the theme color palette - using our secondary color
+.bd-header-announcement {
+  &:after {
+    background-color: var(--pst-color-secondary-bg);
+  }
+}
+
+.bd-header-version-warning {
+  &:after {
+    background-color: var(--pst-color-danger-bg);
   }
 }

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -49,6 +49,7 @@ primary_sidebar_end = sidebar-ethical-ads.html
 footer_start = copyright.html, sphinx-version.html
 footer_end = theme-version.html
 secondary_sidebar_items = page-toc.html, edit-this-page.html, sourcelink.html
+show_version_warning_banner = False
 announcement =
 
 # DEPRECATE after 0.14

--- a/tests/test_a11y.py
+++ b/tests/test_a11y.py
@@ -127,4 +127,6 @@ def test_version_switcher_highlighting(page: Page, url_base: str) -> None:
     assert entries.count() == 2
     # make sure they're highlighted
     for entry in entries.all():
-        expect(entry).to_have_css("color", "rgb(10, 125, 145)")
+        light_mode = "rgb(39, 107, 233)"
+        # dark_mode = "rgb(121, 163, 142)"
+        expect(entry).to_have_css("color", light_mode)


### PR DESCRIPTION
(supersedes) closes #1335
(supersedes) closes #780 

This PR adds an optional specialized announcement banner to warn users who are viewing versions of the docs other than the latest stable release.  It can coexist with the generic announcement banner (it gets stacked above it) and is styled similarly except that it has the "danger" background color.

- requires new node dependency https://www.npmjs.com/package/compare-versions to compare version strings
- relies on the presence of the version switcher JSON file to know what the latest stable release is --- specifically, **a new version switcher key** `preferred=true` is used
- enabled in `conf.py` / `html_context`
- message adapts depending on whether viewed docs are an old version / the dev version

crossref: https://github.com/scientific-python/summit-2023/issues/10#issuecomment-1542891464