### PR TITLE
Fix some CSS header bugs on mobile

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -11,7 +11,7 @@
     left: 25px;
   }
 
-  i.fa-solid.fa-magnifying-glass {
+  .fa-solid.fa-magnifying-glass {
     position: absolute;
     left: calc((2.5rem - 0.7em) / 2);
     color: var(--pst-color-text-muted);
@@ -123,7 +123,7 @@
   }
 
   // Font and input text a bit bigger
-  i,
+  svg,
   input {
     font-size: var(--pst-font-size-icon);
   }

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -165,7 +165,7 @@
   }
 
   // Only the icon should be visible on narrow screens
-  >:not(svg) {
+  > :not(svg) {
     display: none;
 
     @include media-breakpoint-up(lg) {

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -3,7 +3,8 @@
  **/
 .bd-search {
   position: relative;
-  padding: 1rem;
+  padding-left: .5rem;
+  gap: .5rem;
   background-color: var(--pst-color-background);
   border-radius: $admonition-border-radius;
   border: 1px solid var(--pst-color-border);

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -160,7 +160,7 @@
   }
 
   // Only the icon should be visible on narrow screens
-  :not(i) {
+  :not(svg) {
     display: none;
 
     @include media-breakpoint-up(lg) {

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -159,8 +159,13 @@
     font-size: 0.75em;
   }
 
+  // Ensures that all the text lines up in the middle
+  > * {
+    align-items: center;
+  }
+
   // Only the icon should be visible on narrow screens
-  :not(svg) {
+  >:not(svg) {
     display: none;
 
     @include media-breakpoint-up(lg) {

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -3,7 +3,17 @@
  **/
 .bd-search {
   position: relative;
-  padding: 1rem 0;
+  padding: 1rem;
+  background-color: var(--pst-color-background);
+  border-radius: $admonition-border-radius;
+  border: 1px solid var(--pst-color-border);
+  color: var(--pst-color-text-base);
+
+  // Background should always be same color regardless of active or not
+  &:active {
+    background-color: var(--pst-color-background);
+    color: var(--pst-color-text-muted);
+  }
 
   .icon {
     position: absolute;
@@ -18,20 +28,8 @@
   }
 
   input {
-    background-color: var(--pst-color-background);
-    border-radius: $admonition-border-radius;
-    border: 1px solid var(--pst-color-border);
-    padding-left: 2.5rem;
-    color: var(--pst-color-text-base);
-
     // Inner-text of the search bar
     &::placeholder {
-      color: var(--pst-color-text-muted);
-    }
-
-    // Background should always be same color regardless of active or not
-    &:active {
-      background-color: var(--pst-color-background);
       color: var(--pst-color-text-muted);
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -3,8 +3,8 @@
  **/
 .bd-search {
   position: relative;
-  padding-left: .5rem;
-  gap: .5rem;
+  padding-left: 0.5rem;
+  gap: 0.5rem;
   background-color: var(--pst-color-background);
   border-radius: $admonition-border-radius;
   border: 1px solid var(--pst-color-border);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -163,7 +163,7 @@
     }
 
     &.primary-toggle {
-      margin-left: 1rem;
+      margin-right: 1rem;
       @include media-breakpoint-up($breakpoint-sidebar-primary) {
         display: none;
       }


### PR DESCRIPTION
Trying to fix two bugs that I noticed on mobile:

- The search button isn't showing and some of the font sizes + spacing are off, I think because when we switched it from `i` to `svg` some of the CSS rules weren't updated
- The left sidebar toggle has a margin to the left instead of the right, which is making it scrunched against the logo