### PR TITLE
docs: change rational of the gallery grid

### DIFF
--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -38,7 +38,7 @@ GRID_CARD = """
 ````
 """
 
-LIST_ITEM = "[{title}]({link}): {description}"
+LIST_ITEM = "[{title}]({link})"
 
 
 class GalleryGridDirective(SphinxDirective):
@@ -73,7 +73,7 @@ class GalleryGridDirective(SphinxDirective):
             yaml_string = "\n".join(self.content)
 
         # Read in YAML so we can generate the gallery
-        grid_data = safe_load(yaml_string)
+        grid_data = [i for i in safe_load(yaml_string) if "img-bottom" in i]
 
         grid_items = []
         for item in grid_data:
@@ -179,7 +179,7 @@ class GalleryListDirective(SphinxDirective):
             yaml_string = "\n".join(self.content)
 
         # Read in YAML so we can generate the gallery
-        grid_data = safe_load(yaml_string)
+        grid_data = [i for i in safe_load(yaml_string) if "img-bottom" not in i]
 
         grid_items = []
         for item in grid_data:

--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -96,7 +96,7 @@ class GalleryGridDirective(SphinxDirective):
             content = f"{item.pop('content')}  \n" if "content" in item else ""
 
             # optional parameter that influence all cards
-            if "card-class" in self.options:
+            if "class-card" in self.options:
                 item["class-card"] = self.options["class-card"]
 
             loc_options_str = "\n".join(f":{k}: {v}" for k, v in item.items()) + "  \n"

--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -103,10 +103,8 @@ class GalleryGridDirective(SphinxDirective):
 
         # Parse the template with Sphinx Design to create an output container
         # Prep the options for the template grid
-        class_container = (
-            "gallery-directive" + f' {self.options.get("class-container", "")}'
-        )
-        options = {"gutter": 2, "class-container": class_container}
+        class_ = "gallery-directive" + f' {self.options.get("class-container", "")}'
+        options = {"gutter": 2, "class-container": class_}
         options_str = "\n".join(f":{k}: {v}" for k, v in options.items())
 
         # Create the directive string for the grid

--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -40,12 +40,17 @@ GRID_CARD = """
 
 
 class GalleryGridDirective(SphinxDirective):
-    """A directive to show a gallery of images and links in a grid.
+    """A directive to show a gallery of images and links in a Bootstrap grid.
 
-    The grid is generated from a YAML file that contains a list of items or directly from the content of directive (also formatted in YAM). We added a new parameter "card-class" to customize all cards at once. in the items; users can use all parameters from "grid-item-card" directive to customize the cards + ["image", "header", "content", "title"].
+    The grid can be generated from a YAML file that contains a list of items, or
+    from the content of the directive (also formatted in YAML). Use the parameter
+    "class-card" to add an additional CSS class to all cards. When specifying the grid
+    items, you can use all parameters from "grid-item-card" directive to customize
+    individual cards + ["image", "header", "content", "title"].
 
     Danger:
-        This directive can only be used in the context of a Myst documentation page as the templates are using Markdown flavored formatting.
+        This directive can only be used in the context of a Myst documentation page as
+        the templates use Markdown flavored formatting.
     """
 
     name = "gallery-grid"
@@ -61,7 +66,7 @@ class GalleryGridDirective(SphinxDirective):
     }
 
     def run(self) -> List[nodes.Node]:
-
+        """Create the gallery grid."""
         if self.arguments:
             # If an argument is given, assume it's a path to a YAML file
             # Parse it and load it into the directive content

--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -39,7 +39,7 @@ GRID_CARD = """
 """
 
 
-class GalleryDirective(SphinxDirective):
+class GalleryGridDirective(SphinxDirective):
     """A directive to show a gallery of images and links in a grid."""
 
     name = "gallery-grid"
@@ -153,7 +153,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     Returns:
         the 2 parallel parameters set to ``True``.
     """
-    app.add_directive("gallery-grid", GalleryDirective)
+    app.add_directive("gallery-grid", GalleryGridDirective)
 
     return {
         "parallel_read_safe": True,

--- a/docs/_static/contributors.yaml
+++ b/docs/_static/contributors.yaml
@@ -1,27 +1,27 @@
 - header: "@bollwyvl"
   image: https://avatars.githubusercontent.com/u/45380
-  website: https://github.com/bollwyvl
+  link: https://github.com/bollwyvl
 - header: "@jarrodmillman"
   image: https://avatars.githubusercontent.com/u/123428
-  website: https://github.com/jarrodmillman
+  link: https://github.com/jarrodmillman
 - header: "@hoetmaaiers"
   image: https://avatars.githubusercontent.com/u/468045
-  website: https://github.com/hoetmaaiers
+  link: https://github.com/hoetmaaiers
 - header: "@jorisvandenbossche"
   image: https://avatars.githubusercontent.com/u/1020496
-  website: https://github.com/jorisvandenbossche
+  link: https://github.com/jorisvandenbossche
 - header: "@damianavila"
   image: https://avatars.githubusercontent.com/u/1640669
-  website: https://github.com/damianavila
+  link: https://github.com/damianavila
 - header: "@drammock"
   image: https://avatars.githubusercontent.com/u/1810515
-  website: https://github.com/drammock
+  link: https://github.com/drammock
 - header: "@choldgraf"
   image: https://avatars.githubusercontent.com/u/1839645
-  website: https://github.com/choldgraf
+  link: https://github.com/choldgraf
 - header: "@12rambau"
   image: https://avatars.githubusercontent.com/u/12596392
-  website: https://github.com/12rambau
+  link: https://github.com/12rambau
 - header: "@trallard"
   image: https://avatars.githubusercontent.com/u/23552331
-  website: https://github.com/trallard
+  link: https://github.com/trallard

--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -4,60 +4,45 @@
 # 2. Used by our Gallery Grid directive to create the grid on our `examples/gallery.md` page.
 #
 # title: The title of each gallery item
-# website: The website that will be used to create a snapshot of this item.
+# link: The link that will be used to create a snapshot of this item.
 #    An image will be placed in docs/_static/gallery/{sanitized_title}.png
 # img-bottom: The location where img-bottoms will be placed for each entry by generate_gallery_img-bottoms.py
 #    This should follow the form shown above and is roughly the same for all items.
 #    This is an optional parameter only relevant for promoted items. If not provided, the documentation
 #    will be added to the list. Only maintainers should add this parameter.
 - title: Pandas
-  website: https://pandas.pydata.org/docs/
+  link: https://pandas.pydata.org/docs/
   img-bottom: ../_static/gallery/pandas.png
 - title: NumPy
-  website: https://numpy.org/doc/stable/
+  link: https://numpy.org/doc/stable/
   img-bottom: ../_static/gallery/numpy.png
 - title: SciPy
-  website: https://docs.scipy.org/doc/scipy/
+  link: https://docs.scipy.org/doc/scipy/
   img-bottom: ../_static/gallery/scipy.png
 - title: Bokeh
-  website: https://docs.bokeh.org/en/latest/
+  link: https://docs.bokeh.org/en/latest/
   img-bottom: ../_static/gallery/bokeh.png
 - title: PyVista
-  website: https://docs.pyvista.org
+  link: https://docs.pyvista.org
   img-bottom: ../_static/gallery/pyvista.png
 - title: MNE-Python
-  website: https://mne.tools/stable/index.html
+  link: https://mne.tools/stable/index.html
   img-bottom: ../_static/gallery/mne-python.png
 - title: NetworkX
-  website: https://networkx.org/documentation/stable/
+  link: https://networkx.org/documentation/stable/
   img-bottom: ../_static/gallery/networkx.png
 - title: Jupyter Book
-  website: https://jupyterbook.org/en/stable/intro.html
+  link: https://jupyterbook.org/en/stable/intro.html
   img-bottom: ../_static/gallery/jupyter_book.png
 - title: Jupyter
-  website: https://docs.jupyter.org/en/latest/
+  link: https://docs.jupyter.org/en/latest/
   img-bottom: ../_static/gallery/jupyter.png
 - title: ArviZ
-  website: https://python.arviz.org/
+  link: https://python.arviz.org/
   img-bottom: ../_static/gallery/arviz.png
 - title: SEPAL
-  website: https://docs.sepal.io/en/latest/index.html
+  link: https://docs.sepal.io/en/latest/index.html
   img-bottom: ../_static/gallery/sepal.png
 - title: Matplotlib
-  website: https://matplotlib.org/stable/
+  link: https://matplotlib.org/stable/
   img-bottom: ../_static/gallery/matplotlib.png
-- title: MegEngine
-  website: https://www.megengine.org.cn/doc/stable/en/index.html
-  #img-bottom: ../_static/gallery/megengine.png
-- title: Feature-engine
-  website: https://feature-engine.readthedocs.io/
-  #img-bottom: ../_static/gallery/feature-engine.png
-- title: CuPy
-  website: https://docs.cupy.dev/en/stable/index.html
-  #img-bottom: ../_static/gallery/cupy.png
-- title: Fairlearn
-  website: https://fairlearn.org/main/about/
-  #img-bottom: ../_static/gallery/fairlearn.png
-- title: Binder
-  website: https://mybinder.readthedocs.io/en/latest/index.html
-  #img-bottom: ../_static/gallery/binder.png

--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -22,9 +22,6 @@
 - title: Bokeh
   website: https://docs.bokeh.org/en/latest/
   img-bottom: ../_static/gallery/bokeh.png
-- title: CuPy
-  website: https://docs.cupy.dev/en/stable/index.html
-  img-bottom: ../_static/gallery/cupy.png
 - title: PyVista
   website: https://docs.pyvista.org
   img-bottom: ../_static/gallery/pyvista.png
@@ -34,24 +31,12 @@
 - title: NetworkX
   website: https://networkx.org/documentation/stable/
   img-bottom: ../_static/gallery/networkx.png
-- title: Fairlearn
-  website: https://fairlearn.org/main/about/
-  img-bottom: ../_static/gallery/fairlearn.png
 - title: Jupyter Book
   website: https://jupyterbook.org/en/stable/intro.html
   img-bottom: ../_static/gallery/jupyter_book.png
-- title: Binder
-  website: https://mybinder.readthedocs.io/en/latest/index.html
-  img-bottom: ../_static/gallery/binder.png
 - title: Jupyter
   website: https://docs.jupyter.org/en/latest/
   img-bottom: ../_static/gallery/jupyter.png
-- title: MegEngine
-  website: https://www.megengine.org.cn/doc/stable/en/index.html
-  img-bottom: ../_static/gallery/megengine.png
-- title: Feature-engine
-  website: https://feature-engine.readthedocs.io/
-  img-bottom: ../_static/gallery/feature-engine.png
 - title: ArviZ
   website: https://python.arviz.org/
   img-bottom: ../_static/gallery/arviz.png
@@ -61,3 +46,18 @@
 - title: Matplotlib
   website: https://matplotlib.org/stable/
   img-bottom: ../_static/gallery/matplotlib.png
+- title: MegEngine
+  website: https://www.megengine.org.cn/doc/stable/en/index.html
+  #img-bottom: ../_static/gallery/megengine.png
+- title: Feature-engine
+  website: https://feature-engine.readthedocs.io/
+  #img-bottom: ../_static/gallery/feature-engine.png
+- title: CuPy
+  website: https://docs.cupy.dev/en/stable/index.html
+  #img-bottom: ../_static/gallery/cupy.png
+- title: Fairlearn
+  website: https://fairlearn.org/main/about/
+  #img-bottom: ../_static/gallery/fairlearn.png
+- title: Binder
+  website: https://mybinder.readthedocs.io/en/latest/index.html
+  #img-bottom: ../_static/gallery/binder.png

--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -3,13 +3,8 @@
 # 1. Used by `generate_gallery_images.py` to take snapshots of each item and place an image in `gallery`.
 # 2. Used by our Gallery Grid directive to create the grid on our `examples/gallery.md` page.
 #
-# title: The title of each gallery item
-# link: The link that will be used to create a snapshot of this item.
-#    An image will be placed in docs/_static/gallery/{sanitized_title}.png
-# img-bottom: The location where img-bottoms will be placed for each entry by generate_gallery_img-bottoms.py
-#    This should follow the form shown above and is roughly the same for all items.
-#    This is an optional parameter only relevant for promoted items. If not provided, the documentation
-#    will be added to the list. Only maintainers should add this parameter.
+# This file should only be modified by maintainer, contributors should add their project
+# to the list of `gallery.md`.
 - title: Pandas
   link: https://pandas.pydata.org/docs/
   img-bottom: ../_static/gallery/pandas.png

--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -8,6 +8,8 @@
 #    An image will be placed in docs/_static/gallery/{sanitized_title}.png
 # img-bottom: The location where img-bottoms will be placed for each entry by generate_gallery_img-bottoms.py
 #    This should follow the form shown above and is roughly the same for all items.
+#    This is an optional parameter only relevant for promoted items. If not provided, the documentation
+#    will be added to the list. Only maintainers should add this parameter.
 - title: Pandas
   website: https://pandas.pydata.org/docs/
   img-bottom: ../_static/gallery/pandas.png

--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -5,39 +5,36 @@
 #
 # This file should only be modified by maintainer, contributors should add their project
 # to the list of `gallery.md`.
-- title: Pandas
-  link: https://pandas.pydata.org/docs/
-  img-bottom: ../_static/gallery/pandas.png
-- title: NumPy
-  link: https://numpy.org/doc/stable/
-  img-bottom: ../_static/gallery/numpy.png
-- title: SciPy
-  link: https://docs.scipy.org/doc/scipy/
-  img-bottom: ../_static/gallery/scipy.png
+- title: ArviZ
+  link: https://python.arviz.org/
+  img-bottom: ../_static/gallery/arviz.png
 - title: Bokeh
   link: https://docs.bokeh.org/en/latest/
   img-bottom: ../_static/gallery/bokeh.png
-- title: PyVista
-  link: https://docs.pyvista.org
-  img-bottom: ../_static/gallery/pyvista.png
+- title: Jupyter
+  link: https://docs.jupyter.org/en/latest/
+  img-bottom: ../_static/gallery/jupyter.png
+- title: Jupyter Book
+  link: https://jupyterbook.org/en/stable/intro.html
+  img-bottom: ../_static/gallery/jupyter_book.png
+- title: Matplotlib
+  link: https://matplotlib.org/stable/
+  img-bottom: ../_static/gallery/matplotlib.png
 - title: MNE-Python
   link: https://mne.tools/stable/index.html
   img-bottom: ../_static/gallery/mne-python.png
 - title: NetworkX
   link: https://networkx.org/documentation/stable/
   img-bottom: ../_static/gallery/networkx.png
-- title: Jupyter Book
-  link: https://jupyterbook.org/en/stable/intro.html
-  img-bottom: ../_static/gallery/jupyter_book.png
-- title: Jupyter
-  link: https://docs.jupyter.org/en/latest/
-  img-bottom: ../_static/gallery/jupyter.png
-- title: ArviZ
-  link: https://python.arviz.org/
-  img-bottom: ../_static/gallery/arviz.png
+- title: NumPy
+  link: https://numpy.org/doc/stable/
+  img-bottom: ../_static/gallery/numpy.png
+- title: Pandas
+  link: https://pandas.pydata.org/docs/
+  img-bottom: ../_static/gallery/pandas.png
+- title: SciPy
+  link: https://docs.scipy.org/doc/scipy/
+  img-bottom: ../_static/gallery/scipy.png
 - title: SEPAL
   link: https://docs.sepal.io/en/latest/index.html
   img-bottom: ../_static/gallery/sepal.png
-- title: Matplotlib
-  link: https://matplotlib.org/stable/
-  img-bottom: ../_static/gallery/matplotlib.png

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -8,7 +8,7 @@ If you'd like to add your documentation to this list, simply add an entry to lis
 These projects are our earliest adopters and/or present some interesting customization. Check their repositories for more information.
 
 ```{gallery-grid} ../_static/gallery.yaml
-:grid-columns: "1 2 2 3"
+:grid-columns: "1 1 2 2"
 ```
 
 ## Other projects using this theme
@@ -16,7 +16,7 @@ These projects are our earliest adopters and/or present some interesting customi
 Thanks to all the projects that are now using `pydata-sphinx-theme` for their documentation, here is a non exhaustive list of our users.
 
 ```{gallery-grid}
-:grid-columns: "1 2 2 3"
+:grid-columns: "1 2 3 4"
 
 - title: MegEngine
   link: https://www.megengine.org.cn/doc/stable/en/index.html

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -3,10 +3,17 @@
 This is a gallery of documentation built on top of the `pydata-sphinx-theme`.
 If you'd like to add your documentation to this list, simply add an entry to [this gallery.yaml file](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/_static/gallery.yaml) and open a Pull Request to add it.
 
+## Featured projects
+
+These projects are our earliest adopters and/or present some interesting customization. Check their repositories for more information.
+
 ```{gallery-grid} ../_static/gallery.yaml
 :grid-columns: "1 2 2 3"
-
 ```
+
+## Other projects using this theme
+
+Thanks to all the projects that are now using `pydata-sphinx-theme` for their documentation, here is a non exhaustive list of our users.
 
 ```{gallery-list} ../_static/gallery.yaml
 

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -15,6 +15,17 @@ These projects are our earliest adopters and/or present some interesting customi
 
 Thanks to all the projects that are now using `pydata-sphinx-theme` for their documentation, here is a non exhaustive list of our users.
 
-```{gallery-list} ../_static/gallery.yaml
+```{gallery-grid}
+:grid-columns: "1 2 2 3"
 
+- title: MegEngine
+  link: https://www.megengine.org.cn/doc/stable/en/index.html
+- title: Feature-engine
+  link: https://feature-engine.readthedocs.io/
+- title: CuPy
+  link: https://docs.cupy.dev/en/stable/index.html
+- title: Fairlearn
+  link: https://fairlearn.org/main/about/
+- title: Binder
+  link: https://mybinder.readthedocs.io/en/latest/index.html
 ```

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -22,14 +22,16 @@ Thanks for your support!
 ```{gallery-grid}
 :grid-columns: "1 2 3 4"
 
-- title: MegEngine
-  link: https://www.megengine.org.cn/doc/stable/en/index.html
-- title: Feature-engine
-  link: https://feature-engine.readthedocs.io/
+- title: Binder
+  link: https://mybinder.readthedocs.io/en/latest/index.html
 - title: CuPy
   link: https://docs.cupy.dev/en/stable/index.html
 - title: Fairlearn
   link: https://fairlearn.org/main/about/
-- title: Binder
-  link: https://mybinder.readthedocs.io/en/latest/index.html
+- title: Feature-engine
+  link: https://feature-engine.readthedocs.io/
+- title: MegEngine
+  link: https://www.megengine.org.cn/doc/stable/en/index.html
+- title: PyVista
+  link: https://docs.pyvista.org
 ```

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -1,7 +1,7 @@
 # Gallery of sites using this theme
 
 This is a gallery of documentation built on top of the `pydata-sphinx-theme`.
-If you'd like to add your documentation to this list, simply add an entry to [this gallery.yaml file](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/_static/gallery.yaml) and open a Pull Request to add it.
+If you'd like to add your documentation to this list, simply add an entry to list at the end of [this page](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/examples/gallery.md) and open a Pull Request to add it.
 
 ## Featured projects
 

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -7,3 +7,7 @@ If you'd like to add your documentation to this list, simply add an entry to [th
 :grid-columns: "1 2 2 3"
 
 ```
+
+```{gallery-list} ../_static/gallery.yaml
+
+```

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -1,11 +1,14 @@
 # Gallery of sites using this theme
 
-This is a gallery of documentation built on top of the `pydata-sphinx-theme`.
-If you'd like to add your documentation to this list, simply add an entry to list at the end of [this page](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/examples/gallery.md) and open a Pull Request to add it.
+This is a gallery of documentation sites built with `pydata-sphinx-theme`. If you'd like
+to add your documentation to this list, add an entry (in alphabetical order) to the list
+at the end of [this page](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/examples/gallery.md)
+and open a Pull Request to add it.
 
 ## Featured projects
 
-These projects are our earliest adopters and/or present some interesting customization. Check their repositories for more information.
+These projects are our earliest adopters and/or present some interesting customization.
+Check their repositories for more information.
 
 ```{gallery-grid} ../_static/gallery.yaml
 :grid-columns: "1 1 2 2"
@@ -13,7 +16,8 @@ These projects are our earliest adopters and/or present some interesting customi
 
 ## Other projects using this theme
 
-Thanks to all the projects that are now using `pydata-sphinx-theme` for their documentation, here is a non exhaustive list of our users.
+Here are some other projects using `pydata-sphinx-theme` for their documentation.
+Thanks for your support!
 
 ```{gallery-grid}
 :grid-columns: "1 2 3 4"

--- a/docs/scripts/generate_collaborators_gallery.py
+++ b/docs/scripts/generate_collaborators_gallery.py
@@ -21,7 +21,7 @@ for collaborator in collaborators:
         {
             "header": f"@{collaborator['login']}",
             "image": f"https://avatars.githubusercontent.com/u/{collaborator['id']}",
-            "website": collaborator["html_url"],
+            "link": collaborator["html_url"],
         }
     )
 

--- a/docs/scripts/generate_gallery_images.py
+++ b/docs/scripts/generate_gallery_images.py
@@ -44,11 +44,11 @@ def regenerate_gallery() -> None:
             # Visit the page and take a screenshot
             for ii in range(3):
                 try:
-                    page.goto(item["website"])
+                    page.goto(item["link"])
                     page.screenshot(path=screenshot)
                     break
                 except TimeoutError:
-                    print(f"Page visit start timed out for: {item['website']}")
+                    print(f"Page visit start timed out for: {item['link']}")
                     print(f"Trying again (attempt {ii+2}/3)")
 
             # copy the 404 only if the screenshot file was not manually

--- a/tests/warning_list.txt
+++ b/tests/warning_list.txt
@@ -2,7 +2,6 @@ WARNING: image file not readable: _static/gallery/pandas.png
 WARNING: image file not readable: _static/gallery/numpy.png
 WARNING: image file not readable: _static/gallery/scipy.png
 WARNING: image file not readable: _static/gallery/bokeh.png
-WARNING: image file not readable: _static/gallery/pyvista.png
 WARNING: image file not readable: _static/gallery/mne-python.png
 WARNING: image file not readable: _static/gallery/networkx.png
 WARNING: image file not readable: _static/gallery/jupyter_book.png

--- a/tests/warning_list.txt
+++ b/tests/warning_list.txt
@@ -2,16 +2,11 @@ WARNING: image file not readable: _static/gallery/pandas.png
 WARNING: image file not readable: _static/gallery/numpy.png
 WARNING: image file not readable: _static/gallery/scipy.png
 WARNING: image file not readable: _static/gallery/bokeh.png
-WARNING: image file not readable: _static/gallery/cupy.png
 WARNING: image file not readable: _static/gallery/pyvista.png
 WARNING: image file not readable: _static/gallery/mne-python.png
 WARNING: image file not readable: _static/gallery/networkx.png
-WARNING: image file not readable: _static/gallery/fairlearn.png
 WARNING: image file not readable: _static/gallery/jupyter_book.png
-WARNING: image file not readable: _static/gallery/binder.png
 WARNING: image file not readable: _static/gallery/jupyter.png
-WARNING: image file not readable: _static/gallery/megengine.png
-WARNING: image file not readable: _static/gallery/feature-engine.png
 WARNING: image file not readable: _static/gallery/arviz.png
 WARNING: image file not readable: _static/gallery/sepal.png
 WARNING: image file not readable: _static/gallery/matplotlib.png


### PR DESCRIPTION
Fix #1121 

## Choose who goes where

- In the featured area, I decded to keep the earliest adopters of the theme and add some from the maintainers projects (SEPAL, Bokeh, Jupyter Book, MNE) + the most beautiful one (yes I'm thinking about you Arviz). 
-  All the others goes to the bottom list 

## Refactoring 

I didn't realized that the `gallery-grid` was used in so many places. I tried to improve compactness, documentation and logic (remove parameters that were legacy and not used).

## Docs

The rational is simple: people add their projects to the list at the bottom of the page (clicking on "Edit on Github" will do the trick) and fill the list. Then in a second step, if the maintainers agree that the project deserve biggest highlight (e.g. fancy customization), then we can promote it to the gallery file. 

## TODO 

I'm not very satisfied with the wording in gallery.md feel free to update it. 

## Side note 

I also realized that this directive is only working for MyST. I'm not a big fan of this as it prevents anybody to use it in a normal rst file. I'll open an issue for that later.

https://pydata-sphinx-theme--1390.org.readthedocs.build/en/1390/examples/gallery.html
