### PR TITLE
Fix version warning banner message

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -253,6 +253,7 @@ def update_and_remove_templates(
 
         # Add variables to our JavaScript for re-use in our main JS script
         js = f"""
+        DOCUMENTATION_OPTIONS.theme_version = '{__version__}';
         DOCUMENTATION_OPTIONS.theme_switcher_json_url = '{json_url}';
         DOCUMENTATION_OPTIONS.theme_switcher_version_match = '{version_match}';
         DOCUMENTATION_OPTIONS.show_version_warning_banner = {str(context["theme_show_version_warning_banner"]).lower()};

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -447,7 +447,7 @@ function showVersionWarningBanner(data) {
   button.innerText = "Switch to stable version";
   button.onclick = checkPageExistsAndRedirect;
   // add the version-dependent text
-  inner.innerText = "This is documentation for an ";
+  inner.innerText = "This is documentation for ";
   const isDev =
     version.includes("dev") ||
     version.includes("rc") ||
@@ -455,9 +455,9 @@ function showVersionWarningBanner(data) {
   const newerThanPreferred =
     versionsAreComparable && compare(version, preferredVersion, ">");
   if (isDev || newerThanPreferred) {
-    bold.innerText = "unstable development version";
+    bold.innerText = "an unstable development version";
   } else if (versionsAreComparable && compare(version, preferredVersion, "<")) {
-    bold.innerText = `old version (${version})`;
+    bold.innerText = `an old version (${version})`;
   } else {
     bold.innerText = `version ${version}`;
   }

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -415,7 +415,7 @@ function populateVersionSwitcher(data, versionSwitcherBtns) {
  * @param {Array} data The version data used to populate the switcher menu.
  */
 function showVersionWarningBanner(data) {
-  const version = DOCUMENTATION_OPTIONS.VERSION;
+  const version = DOCUMENTATION_OPTIONS.theme_version;
   // figure out what latest stable version is
   var preferredEntries = data.filter((entry) => entry.preferred);
   if (preferredEntries.length !== 1) {


### PR DESCRIPTION
Fixes 2 problems with the version warning banner:

1. the grammar was a bit off for cases where the version was unparsable (and thus we couldn't tell if the version was older or newer than `preferred`)
2. it was relying on `DOCUMENTATION_OPTIONS.VERSION` which sometimes is an empty string --- not sure why; on PR builds it is correctly populated but on current dev build it is empty string, yielding this screenshot:

![Screenshot 2023-07-26 at 13-44-15 Contributor Guide — PyData Theme documentation](https://github.com/pydata/pydata-sphinx-theme/assets/1810515/a1b0b9d3-364e-46af-9505-79bdbcf8f5ec)
