### PR TITLE
Fix redirection for pages missing in other docs versions

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -287,21 +287,23 @@ var setupSearchButtons = () => {
  *
  * @param {event} event the event that trigger the check
  */
-function checkPageExistsAndRedirect(event) {
+async function checkPageExistsAndRedirect(event) {
   // ensure we don't follow the initial link
   event.preventDefault();
-
-  const currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
-  const tryUrl = event.currentTarget.getAttribute("href");
+  let currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
+  let tryUrl = event.currentTarget.getAttribute("href");
   let otherDocsHomepage = tryUrl.replace(currentFilePath, "");
-
-  fetch(tryUrl, { method: "HEAD" })
-    .then(() => {
-      location.href = tryUrl;
-    }) // if the page exists, go there
-    .catch((error) => {
+  try {
+    let head = await fetch(tryUrl, { method: "HEAD" });
+    if (head.ok) {
+      location.href = tryUrl; // the page exists, go there
+    } else {
       location.href = otherDocsHomepage;
-    });
+    }
+  } catch (err) {
+    // something went wrong, probably CORS restriction, fallback to other docs homepage
+    location.href = otherDocsHomepage;
+  }
 }
 
 /**


### PR DESCRIPTION
related #844 
related #1343 

I think this should fix our redirection problems. The error was that we assumed that a `404` response would be an error, but as far as Javascript is concerned a `404` response is still a real response!  Now we check for `response.ok` (meaning a response in the 200-299 range) and triage the URL accordingly. The try/catch is left in place as a fallback in case something actually *did* go wrong with the request/response (i.e., on local or PR builds when the request is blocked due to CORS restrictions).

cc @lagru would appreciate if you could test this branch and report back