### PR TITLE
proof of concept

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,7 @@ html_theme_options = {
     # "footer_start": ["test.html", "test.html"],
     # "secondary_sidebar_items": ["page-toc.html"],  # Remove the source buttons
     "switcher": {
+        "use_rtd": True,
         "json_url": json_url,
         "version_match": version_match,
     },

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/version-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/version-switcher.html
@@ -1,15 +1,21 @@
 {# As the version switcher will only work when JavaScript is enabled, we add it through JavaScript.
  #}
-<script>
-document.write(`
-  <div class="version-switcher__container dropdown">
-    <button id="versionswitcherbutton" type="button" role="button" class="version-switcher__button btn btn-sm navbar-btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="listbox" aria-controls="versionswitcherlist" aria-label="Version switcher list">
-      {{ theme_switcher.get('version_match') }}  <!-- this text may get changed later by javascript -->
-      <span class="caret"></span>
-    </button>
-    <div id="versionswitcherlist" class="version-switcher__menu dropdown-menu list-group-flush py-0" role="listbox" aria-labelledby="versionswitcherbutton">
-    <!-- dropdown will be populated by javascript on page load -->
-    </div>
-  </div>
-`);
-</script>
+{% if theme_switcher.get('use_rtd') is defined and theme_switcher.get('use_rtd') %}
+  <script>
+    document.write(`<div id="readthedocs-embed-flyout"></div>`);
+  </script>
+{% else %}
+  <script>
+    document.write(`
+      <div class="version-switcher__container dropdown">
+        <button id="versionswitcherbutton" type="button" role="button" class="version-switcher__button btn btn-sm navbar-btn dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="listbox" aria-controls="versionswitcherlist" aria-label="Version switcher list">
+          {{ theme_switcher.get('version_match') }}  <!-- this text may get changed later by javascript -->
+          <span class="caret"></span>
+        </button>
+        <div id="versionswitcherlist" class="version-switcher__menu dropdown-menu list-group-flush py-0" role="listbox" aria-labelledby="versionswitcherbutton">
+        <!-- dropdown will be populated by javascript on page load -->
+        </div>
+      </div>
+    `);
+  </script>
+{% endif %}


### PR DESCRIPTION
(supercedes) closes #705

WIP to fix the problem of the RTD version switcher disappearing on pages where the left sidebar is suppressed.  The solution here is to piggyback on the theme's built-in version switcher, and just place the RTD switcher wherever the theme switcher was requested to go. Let's see if it works, if it does I'll update docs etc accordingly.