### PR TITLE
Only use ``sphinx.testing.path`` on Sphinx 7.1 and earlier

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ from shutil import copytree
 from typing import Callable
 
 import pytest
+import sphinx
 from bs4 import BeautifulSoup
-from sphinx.testing.path import path as sphinx_path
 from sphinx.testing.util import SphinxTestApp
 from typing_extensions import Self
 
@@ -70,10 +70,15 @@ def sphinx_build_factory(make_app: Callable, tmp_path: Path) -> Callable:
 
     def _func(src_folder: Path, **kwargs) -> SphinxBuild:
         """Create the Sphinxbuild from the source folder."""
+
+        srcdir = tmp_path / src_folder
+        if sphinx.version_info < (7, 2):
+            from sphinx.testing.path import path as sphinx_path
+
+            srcdir = sphinx_path(srcdir)
+
         copytree(path_tests / "sites" / src_folder, tmp_path / src_folder)
-        app = make_app(
-            srcdir=sphinx_path(Path(tmp_path / src_folder).resolve()), **kwargs
-        )
+        app = make_app(srcdir=srcdir, **kwargs)
         return SphinxBuild(app, tmp_path / src_folder)
 
     yield _func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,6 @@ def sphinx_build_factory(make_app: Callable, tmp_path: Path) -> Callable:
 
     def _func(src_folder: Path, **kwargs) -> SphinxBuild:
         """Create the Sphinxbuild from the source folder."""
-
         srcdir = tmp_path / src_folder
         if sphinx.version_info < (7, 2):
             from sphinx.testing.path import path as sphinx_path


### PR DESCRIPTION
Sphinx 7.2 (unreleased) has deprecated ``sphinx.testing.path.path``.

A