### PR TITLE
Fix TocTree manipulation on Sphinx 7.2+

### DIFF
--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -66,7 +66,7 @@ def add_toctree_functions(
         # Will be empty if there is no active page (root_doc, or genindex etc)
         if sphinx.version_info[:2] >= (7, 2):
             from sphinx.environment.adapters.toctree import _get_toctree_ancestors
-            
+
             active_header_page = [
                 *_get_toctree_ancestors(app.env.toctree_includes, pagename)
             ]

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -11,7 +11,7 @@ from docutils.nodes import Node
 from sphinx import addnodes
 from sphinx.addnodes import toctree as toctree_node
 from sphinx.application import Sphinx
-from sphinx.environment.adapters.toctree import _get_toctree_ancestors, TocTree
+from sphinx.environment.adapters.toctree import TocTree
 
 from .utils import traverse_or_findall
 
@@ -422,6 +422,8 @@ def index_toctree(
 
     toctree = TocTree(app.env)
     if sphinx.version_info[:2] >= (7, 2):
+        from sphinx.environment.adapters.toctree import _get_toctree_ancestors
+
         ancestors = [*_get_toctree_ancestors(app.env.toctree_includes, pagename)]
     else:
         ancestors = toctree.get_toctree_ancestors(pagename)

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -65,6 +65,8 @@ def add_toctree_functions(
         # Find the active header navigation item so we decide whether to highlight
         # Will be empty if there is no active page (root_doc, or genindex etc)
         if sphinx.version_info[:2] >= (7, 2):
+            from sphinx.environment.adapters.toctree import _get_toctree_ancestors
+            
             active_header_page = [*_get_toctree_ancestors(app.env.toctree_includes, pagename)]
         else:
             active_header_page = toctree.get_toctree_ancestors(pagename)

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -67,7 +67,9 @@ def add_toctree_functions(
         if sphinx.version_info[:2] >= (7, 2):
             from sphinx.environment.adapters.toctree import _get_toctree_ancestors
             
-            active_header_page = [*_get_toctree_ancestors(app.env.toctree_includes, pagename)]
+            active_header_page = [
+                *_get_toctree_ancestors(app.env.toctree_includes, pagename)
+            ]
         else:
             active_header_page = toctree.get_toctree_ancestors(pagename)
         if active_header_page:


### PR DESCRIPTION
See #1404

This is the bare minimum required to restore the previous state. I intend to look into how ``pydata-sphinx-theme`` uses ``get_toctree_ancestors`` and if there are any longer-term improvements to be made.

A