### PR TITLE
fix: place the las_update value in the meta of each page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ html_theme = "pydata_sphinx_theme"
 html_logo = "_static/logo.svg"
 html_favicon = "_static/logo.svg"
 html_sourcelink_suffix = ""
+html_last_updated_fmt = ""  # to reveal the build date in the pages meta
 
 # Define the json_url for our version switcher.
 json_url = "https://pydata-sphinx-theme.readthedocs.io/en/latest/_static/switcher.json"

--- a/docs/user_guide/extending.rst
+++ b/docs/user_guide/extending.rst
@@ -246,34 +246,3 @@ And add the following css to your custom.css file:
     :end-before: /* end-custom-youtube
     :code: css
     :class: highlight-css
-
-.. _extending-build-date:
-
-Build date
-==========
-
-No component is available by default to display the build date in this theme. If you need one please consider the following snippets as a starting point to build your custom component.
-
-First go to the ``_templates`` directory of your documentation folder and create a ``last-updated.html`` file:
-
-.. code-block:: html
-
-    <!-- docs/_templates/last-updated.html -->
-    <div class="last-updated">
-        {%- if last_updated %}
-            {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
-        {%- endif %}
-    </div>
-
-Then add this template to any section of the documentation using your ``conf.py`` e.g. the footer:
-
-.. code-block:: python
-
-    # docs/conf.py
-
-    templates_path = ["_templates"] # don't forget to add the templates folder
-    html_last_updated_fmt = "" # select any format you see fit
-    html_theme_options = {
-        # [...]
-        "footer_start": ["last-updated"], # work as well with the extension
-    }

--- a/docs/user_guide/extending.rst
+++ b/docs/user_guide/extending.rst
@@ -246,3 +246,34 @@ And add the following css to your custom.css file:
     :end-before: /* end-custom-youtube
     :code: css
     :class: highlight-css
+
+.. _extending-build-date:
+
+Build date
+==========
+
+No component is available by default to display the build date in this theme. If you need one please consider the following snippets as a starting point to build your custom component.
+
+First go to the ``_templates`` directory of your documentation folder and create a ``last-updated.html`` file:
+
+.. code-block:: html
+
+    <!-- docs/_templates/last-updated.html -->
+    <div class="last-updated">
+        {%- if last_updated %}
+            {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+        {%- endif %}
+    </div>
+
+Then add this template to any section of the documentation using your ``conf.py`` e.g. the footer:
+
+.. code-block:: python
+
+    # docs/conf.py
+
+    templates_path = ["_templates"] # don't forget to add the templates folder
+    html_last_updated_fmt = "" # select any format you see fit
+    html_theme_options = {
+        # [...]
+        "footer_start": ["last-updated"], # work as well with the extension
+    }

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -571,7 +571,17 @@ could do so with the following steps:
 Build date
 ==========
 
-By default the build date cannot be seen in our template even when the `html_last_updated_fmt <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt>`__ is set. Instead the theme adds a ``meta`` tag in the HTML head that specifies the build date, which can be inspected by viewing the page source or extracted with an HTML parser. The tag will look like:
+By default this theme does not display the build date even when Sphinx's `html_last_updated_fmt <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt>`__ variable is set. If you want the build date displayed, the theme includes a :code:`last-updated` template that you can add to one of the page regions in your ``conf.py``. For example:
+
+.. code-block:: python
+    :caption: conf.py
+
+    html_theme_options = {
+        "content_footer_items": ["last-updated"],
+        # other settings...
+    }
+
+If you do specify ``html_last_updated_fmt`` but don't include the :code:`last-updated` template, the theme will still write the build date into a ``meta`` tag in the HTML header, which can be inspected by viewing the page source or extracted with an HTML parser. The tag will look like:
 
 .. code-block:: html
 
@@ -579,6 +589,3 @@ By default the build date cannot be seen in our template even when the `html_las
 
 The tag's ``content`` attribute will follow the format specified in the ``html_last_updated_fmt`` configuration variable.
 
-.. note::
-
-    If a special component to display such an information in your page is your need please use the built-in :code:`last-updated`.

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -571,7 +571,7 @@ could do so with the following steps:
 Build date
 ==========
 
-By design the build date cannot be seen in our template even when the `html_last_updated_fmt <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt>`__ is set. Instead the theme adds a ``meta`` tag in the HTML head that specifies the build date, which can be inspected by viewing the page source or extracted with an HTML parser. The tag will look like:
+By default the build date cannot be seen in our template even when the `html_last_updated_fmt <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt>`__ is set. Instead the theme adds a ``meta`` tag in the HTML head that specifies the build date, which can be inspected by viewing the page source or extracted with an HTML parser. The tag will look like:
 
 .. code-block:: html
 
@@ -581,4 +581,4 @@ The tag's ``content`` attribute will follow the format specified in the ``html_l
 
 .. note::
 
-    If a special component to display such an information in your page is your need please see :ref:`extending-build-date`.
+    If a special component to display such an information in your page is your need please use the built-in :code:`last-updated`.

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -577,7 +577,7 @@ By design the build date cannot be seen in our template even when the `html_last
 
     <meta name="docbuild:last-update" content="Aug 15, 2023">
 
-The content will be respecting the format specified in the ``html_last_updated_fmt`` conf variable.
+The tag's ``content`` attribute will follow the format specified in the ``html_last_updated_fmt`` configuration variable.
 
 .. note::
 

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -567,3 +567,18 @@ could do so with the following steps:
       "navbar_start": ["navbar-logo", "version"],
       # ...
       }
+
+Build date
+==========
+
+By design the build date cannot be seen in our template even when the `html_last_updated_fmt <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt>`__ is set. Instead the theme is adding a ``meta`` tag in the html head that can be read by html parser.
+
+.. code-block:: html
+
+    <meta name="docbuild:last-update" content="Aug 15, 2023">
+
+The content will be respecting the format specified in the ``html_last_updated_fmt`` conf variable.
+
+.. note::
+
+    If a special component to display such an information in your page is your need please see :ref:`_extending-build-date`.

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -571,7 +571,7 @@ could do so with the following steps:
 Build date
 ==========
 
-By design the build date cannot be seen in our template even when the `html_last_updated_fmt <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt>`__ is set. Instead the theme is adding a ``meta`` tag in the html head that can be read by html parser.
+By design the build date cannot be seen in our template even when the `html_last_updated_fmt <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_last_updated_fmt>`__ is set. Instead the theme adds a ``meta`` tag in the HTML head that specifies the build date, which can be inspected by viewing the page source or extracted with an HTML parser. The tag will look like:
 
 .. code-block:: html
 

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -581,4 +581,4 @@ The content will be respecting the format specified in the ``html_last_updated_f
 
 .. note::
 
-    If a special component to display such an information in your page is your need please see :ref:`_extending-build-date`.
+    If a special component to display such an information in your page is your need please see :ref:`extending-build-date`.

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -39,6 +39,9 @@ or not theme_secondary_sidebar_items %}
 {%- block extrahead %}
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="docsearch:language" content="{{ language }}"/>
+  {%- if last_updated %}
+    <meta name="docbuild:last-update" content="{{ last_updated | e }}"/>
+  {%- endif %}
 {%- endblock extrahead %}
 {% block body_tag %}
   {# set up with scrollspy to update the toc as we scroll #}

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -10,7 +10,7 @@ elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
     if [[ "$1" == "doc" ]]; then
         # Until they release a new version that undoes the max sphinx pin...
-        DEP_EXTRA="git+https://github.com/executablebooks/MyST-NB git+https://github.com/larsoner/sphinx-sitemap.git@path"
+        DEP_EXTRA="git+https://github.com/executablebooks/MyST-NB"
     fi
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
     SPHINX_INSTALL="sphinx==5.0"


### PR DESCRIPTION
Fix #1382 

Hide the last-updated date in the meta of each page. 

It is displayed as: 
```
<meta name="docbuild:last-update" content="Aug 15, 2023">
```

Int he header of the associated PR documentation: https://pydata-sphinx-theme--1409.org.readthedocs.build/en/1409/