### PR TITLE
add css class dropdown-item to version switcher

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -364,7 +364,10 @@ function populateVersionSwitcher(data, versionSwitcherBtns) {
   data.forEach((entry) => {
     // create the node
     const anchor = document.createElement("a");
-    anchor.setAttribute("class", "list-group-item list-group-item-action py-1");
+    anchor.setAttribute(
+      "class",
+      "dropdown-item list-group-item list-group-item-action py-1"
+    );
     anchor.setAttribute("href", `${entry.url}${currentFilePath}`);
     anchor.setAttribute("role", "option");
     const span = document.createElement("span");


### PR DESCRIPTION
This may be the only thing needed to close https://github.com/pydata/pydata-sphinx-theme/issues/1358.

Is there some reason we weren't applying the `dropdown-item` class (per [Bootstrap docs](https://getbootstrap.com/docs/5.2/components/dropdowns/)) to items in the version switcher dropdown? This will automatically add the ability to select items in the dropdown using the arrow and enter keys.