### PR TITLE
MAINT: Test old and new Sphinx versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
             sphinx-version: ""
           - os: ubuntu-latest
             python-version: "3.8"
-            sphinx-version: "4.2"
+            sphinx-version: "5.0"
           # dev Sphinx test
           - os: ubuntu-latest
             python-version: "3.11"
@@ -129,7 +129,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.8"
-            sphinx-version: "4.2"
+            sphinx-version: "5.0"
           - os: ubuntu-latest
             python-version: "3.10" # use different ver here to ensure separate run
             sphinx-version: "dev"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        sphinx-version: [""]
         include:
           # macos test
           - os: macos-latest
@@ -58,14 +59,8 @@ jobs:
           # old Sphinx test
           - os: ubuntu-latest
             python-version: "3.8"
-            sphinx-version: ""
-          - os: ubuntu-latest
-            python-version: "3.8"
             sphinx-version: "old"
           # dev Sphinx test
-          - os: ubuntu-latest
-            python-version: "3.11"
-            sphinx-version: ""
           - os: ubuntu-latest
             python-version: "3.11"
             sphinx-version: "dev"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
             sphinx-version: ""
           - os: ubuntu-latest
             python-version: "3.8"
-            sphinx-version: "5.0"
+            sphinx-version: "old"
           # dev Sphinx test
           - os: ubuntu-latest
             python-version: "3.11"
@@ -129,7 +129,7 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.8"
-            sphinx-version: "5.0"
+            sphinx-version: "old"
           - os: ubuntu-latest
             python-version: "3.10" # use different ver here to ensure separate run
             sphinx-version: "dev"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,10 +131,9 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.8"
             sphinx-version: "old"
-          # TODO: Can't build on dev because of dependency resolution :(
-          # - os: ubuntu-latest
-          #   python-version: "3.11"
-          #   sphinx-version: "dev"
+          - os: ubuntu-latest
+            python-version: "3.11"
+            sphinx-version: "dev"
     env:
       SPHINX_VERSION: ${{ matrix.sphinx-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,13 +124,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11"]
+        sphinx-version: [""]
         include:
+          # TODO: Cant build on oldest version (4.2) because of ablog,
+          # so we test on 5.0 in github_actions_install.sh
           - os: ubuntu-latest
             python-version: "3.8"
             sphinx-version: "old"
-          - os: ubuntu-latest
-            python-version: "3.10" # use different ver here to ensure separate run
-            sphinx-version: "dev"
+          # TODO: Can't build on dev because of dependency resolution :(
+          # - os: ubuntu-latest
+          #   python-version: "3.11"
+          #   sphinx-version: "dev"
     env:
       SPHINX_VERSION: ${{ matrix.sphinx-version }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,7 @@
 name: continuous-integration
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 # README
 # ======

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,8 +126,6 @@ jobs:
         python-version: ["3.11"]
         sphinx-version: [""]
         include:
-          # TODO: Cant build on oldest version (4.2) because of ablog,
-          # so we test on 5.0 in github_actions_install.sh
           - os: ubuntu-latest
             python-version: "3.8"
             sphinx-version: "old"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,9 +52,18 @@ jobs:
           # windows test
           - os: windows-latest
             python-version: "3.11"
+          # old Sphinx test
+          - os: ubuntu-latest
+            python-version: "3.8"
+            sphinx-version: "4.2"
+          # dev Sphinx test
+          - os: ubuntu-latest
+            python-version: "3.11"
+            sphinx-version: "dev"
     # needed to cache the browsers for the accessibility tests
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/pw-browsers
+      SPHINX_VERSION: ${{ matrix.sphinx-version }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -67,21 +76,10 @@ jobs:
       - name: Install dependencies
         # if Sphinx version not specified in matrix, the constraints in the
         # pyproject.toml file determine Sphinx version
-        if: false == matrix.sphinx-version
         shell: bash
         # setting shell to BASH and using PYTHONUTF8 env var makes the editable
         # install work on Windows even though there are emoji in our README
-        run: |
-          export PYTHONUTF8=1
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install -e .[test]
-      - name: Install dependencies (legacy Sphinx)
-        # here we override the pyproject.toml constraints to get a specific
-        # Sphinx version.
-        if: matrix.sphinx-version
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install -e .[test] sphinx==${{ matrix.sphinx-version }}
+        run: tools/github_actions_install.sh test
       - name: Show installed versions
         run: python -m pip list
       - name: Compile MO files
@@ -122,6 +120,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.11"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8"
+            sphinx-version: "4.2"
+          - os: ubuntu-latest
+            python-version: "3.10"  # use different ver here to ensure separate run
+            sphinx-version: "dev"
+    env:
+      SPHINX_VERSION: ${{ matrix.sphinx-version }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -132,9 +139,8 @@ jobs:
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install -e .[doc]
+        shell: bash
+        run: ./tools/github_actions_install.sh doc
       - name: Show installed versions
         run: python -m pip list
       - name: Build docs
@@ -159,9 +165,8 @@ jobs:
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel setuptools
-          python -m pip install -e .[doc]
+        run: ./tools/github_actions_install.sh doc
+        shell: bash
       - name: Show installed versions
         run: python -m pip list
       # We want to run the audit on a simplified documentation build so that
@@ -203,9 +208,8 @@ jobs:
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel setuptools nox
-          python -m pip install -e .[test]
+        run: ./tools/github_actions_install.sh test nox
+        shell: bash
       - name: Show installed versions
         run: python -m pip list
       - name: Generate a profile

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,8 +55,14 @@ jobs:
           # old Sphinx test
           - os: ubuntu-latest
             python-version: "3.8"
+            sphinx-version: ""
+          - os: ubuntu-latest
+            python-version: "3.8"
             sphinx-version: "4.2"
           # dev Sphinx test
+          - os: ubuntu-latest
+            python-version: "3.11"
+            sphinx-version: ""
           - os: ubuntu-latest
             python-version: "3.11"
             sphinx-version: "dev"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
             python-version: "3.8"
             sphinx-version: "4.2"
           - os: ubuntu-latest
-            python-version: "3.10"  # use different ver here to ensure separate run
+            python-version: "3.10" # use different ver here to ensure separate run
             sphinx-version: "dev"
     env:
       SPHINX_VERSION: ${{ matrix.sphinx-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "sphinx>=4.2",
+  "sphinx>=5.0",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-  "sphinx>=5.0",
+  "sphinx>=4.2",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "packaging",

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -8,7 +8,9 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
     SPHINX_INSTALL=""
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
-else
+elif [[ "$SPHINX_VERSION" == "old" ]]; then
+    SPHINX_INSTALL="sphinx==5.0"
+else  # not used currently but easy enough
     SPHINX_INSTALL="sphinx==$SPHINX_VERSION"
 fi
 set -x  # print commands

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -9,15 +9,11 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
     if [[ "$1" == "doc" ]]; then
-        DEP_EXTRA="jupyterlite-sphinx==0.9.1 myst-nb==0.17.2 jupyter-sphinx==0.4.0"
+        # Until they release a new version that undoes the max sphinx pin...
+        DEP_EXTRA="git+https://github.com/executablebooks/MyST-NB"
     fi
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
-    # ablog requires 5.0 so we have to triage based on install type
-    if [[ "$1" == "doc" ]]; then
-        SPHINX_INSTALL="sphinx==5.0"
-    else
-        SPHINX_INSTALL="sphinx==4.2"
-    fi
+    SPHINX_INSTALL="sphinx==5.0"
 else  # not used currently but easy enough
     SPHINX_INSTALL="sphinx==$SPHINX_VERSION"
 fi

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -9,7 +9,12 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
-    SPHINX_INSTALL="sphinx==5.0"
+    # ablog requires 5.0 so we have to triage based on install type
+    if [[ "$1" == "doc" ]]; then
+        SPHINX_INSTALL="sphinx==5.0"
+    else
+        SPHINX_INSTALL="sphinx==4.2"
+    fi
 else  # not used currently but easy enough
     SPHINX_INSTALL="sphinx==$SPHINX_VERSION"
 fi

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -8,6 +8,9 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
     SPHINX_INSTALL=""
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
+    if [[ "$1" == "doc" ]]; then
+        DEP_EXTRA="jupyterlite-sphinx==0.9.1"
+    fi
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
     # ablog requires 5.0 so we have to triage based on install type
     if [[ "$1" == "doc" ]]; then
@@ -20,4 +23,4 @@ else  # not used currently but easy enough
 fi
 set -x  # print commands
 python -m pip install --upgrade pip wheel setuptools
-python -m pip install -e .["$1"] ${SPHINX_INSTALL} $2
+python -m pip install -e .["$1"] ${SPHINX_INSTALL} $2 $DEP_EXTRA

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -9,7 +9,7 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
     if [[ "$1" == "doc" ]]; then
-        DEP_EXTRA="jupyterlite-sphinx==0.9.1 myst-nb==0.17.2 jupyter-sphinx=0.4.0"
+        DEP_EXTRA="jupyterlite-sphinx==0.9.1 myst-nb==0.17.2 jupyter-sphinx==0.4.0"
     fi
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
     # ablog requires 5.0 so we have to triage based on install type

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -7,7 +7,7 @@ export PYTHONUTF8=1
 if [[ "$SPHINX_VERSION" == "" ]]; then
     SPHINX_INSTALL=""
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
-    SPHINX_INSTALL="https://github.com/sphinx-doc/sphinx"
+    SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
 else
     SPHINX_INSTALL="sphinx==$SPHINX_VERSION"
 fi

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -9,7 +9,7 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
     if [[ "$1" == "doc" ]]; then
-        DEP_EXTRA="jupyterlite-sphinx==0.9.1"
+        DEP_EXTRA="jupyterlite-sphinx==0.9.1 myst-nb==0.17.2 jupyter-sphinx=0.4.0"
     fi
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
     # ablog requires 5.0 so we have to triage based on install type

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -10,7 +10,7 @@ elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
     if [[ "$1" == "doc" ]]; then
         # Until they release a new version that undoes the max sphinx pin...
-        DEP_EXTRA="git+https://github.com/executablebooks/MyST-NB"
+        DEP_EXTRA="git+https://github.com/executablebooks/MyST-NB git+https://github.com/larsoner/sphinx-sitemap.git@path"
     fi
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
     SPHINX_INSTALL="sphinx==5.0"

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# First arg ($1) is the extras_require to install, optional second arg
+# ($2) is an extra dependency (currently just nox on one run)
+set -eo pipefail
+export PYTHONUTF8=1
+if [[ "$SPHINX_VERSION" == "" ]]; then
+    SPHINX_INSTALL=""
+elif [[ "$SPHINX_VERSION" == "dev" ]]; then
+    SPHINX_INSTALL="https://github.com/sphinx-doc/sphinx"
+else
+    SPHINX_INSTALL="sphinx==$SPHINX_VERSION"
+fi
+set -x  # print commands
+python -m pip install --upgrade pip wheel setuptools
+python -m pip install -e .["$1"] ${SPHINX_INSTALL} $2


### PR DESCRIPTION
This is a proposal-by-PR:

1. Test the oldest supported sphinx in tests (I don't think it's being done currently?)
2. Test the latest sphinx dev version (should help catch stuff like #1404)
3. Refactor test install step into a script (DRY)

No idea if this has been discussed so far but it seemed quick enough to just do it and see what people thought :)

FYI we use a dev test against NumPy/SciPy/matplotlib etc. in MNE-Python and find bugs in their dev branches fairly frequently. As a maintainer it's easy enough to know when a `dev` failure can be safely ignored for the time being...