### PR TITLE
Fix More dropdown (html, aria, bootstrap classes)

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -38,6 +38,15 @@ function setTheme(mode) {
   document.documentElement.dataset.mode = mode;
   var theme = mode == "auto" ? colorScheme : mode;
   document.documentElement.dataset.theme = theme;
+  // TODO: remove this line after Bootstrap upgrade
+  // v5.3 has a colors mode: https://getbootstrap.com/docs/5.3/customize/color-modes/
+  document.querySelectorAll(".dropdown-menu").forEach((el) => {
+    if (theme === "dark") {
+      el.classList.add("dropdown-menu-dark");
+    } else {
+      el.classList.remove("dropdown-menu-dark");
+    }
+  });
 
   // save mode and theme
   localStorage.setItem("mode", mode);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -112,7 +112,19 @@
         min-width: 20rem;
 
         .dropdown-item {
+          // Give the items in the dropdown some breathing room but let the hit
+          // and hover area of the items extend to the edges of the menu
           padding: 0.25rem 1.5rem;
+
+          // Override Bootstrap
+          &:focus:not(:hover):not(:active) {
+            background-color: inherit;
+          }
+        }
+
+        // Override Bootstrap
+        .nav-link {
+          transition: none;
         }
 
         // Hide the menu unless show has been clicked

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -122,11 +122,6 @@
           }
         }
 
-        // Override Bootstrap
-        .nav-link {
-          transition: none;
-        }
-
         // Hide the menu unless show has been clicked
         &:not(.show) {
           display: none;
@@ -145,6 +140,9 @@
 
 .nav-link {
   @include link-style-hover;
+
+  // Override Bootstrap
+  transition: none;
 
   &.nav-external:after {
     font: var(--fa-font-solid);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -107,9 +107,13 @@
         border: 1px solid var(--pst-color-border);
         box-shadow: 0 0 0.3rem 0.1rem var(--pst-color-shadow);
         background-color: var(--pst-color-on-background);
-        padding: 0.5rem 1rem;
+        padding: 0.5rem 0;
         margin: 0.5rem 0;
         min-width: 20rem;
+
+        .dropdown-item {
+          padding: 0.25rem 1.5rem;
+        }
 
         // Hide the menu unless show has been clicked
         &:not(.show) {

--- a/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
@@ -15,3 +15,10 @@ $grid-breakpoints: (
   lg: 960px,
   xl: 1200px,
 );
+
+$dropdown-link-hover-bg: var(--pst-color-surface);
+// --pst-color-surface can also be assigned to the dark variant because it is
+// scoped to different values depending on light/dark theme
+$dropdown-dark-link-hover-bg: var(--pst-color-surface);
+$dropdown-link-active-bg: var(--pst-color-surface);
+$dropdown-dark-link-active-bg: var(--pst-color-surface);

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -138,6 +138,8 @@ def add_toctree_functions(
 
         # Wrap the final few header items in a "more" dropdown
         links_dropdown = [
+            # 🐲 brittle code, relies on the assumption that the code above
+            # gives each link in the nav a `nav-link` CSS class        
             html.replace("nav-link", "nav-link dropdown-item")
             for html in links_html[n_links_before_dropdown:]
         ]

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -139,7 +139,7 @@ def add_toctree_functions(
         # Wrap the final few header items in a "more" dropdown
         links_dropdown = [
             # 🐲 brittle code, relies on the assumption that the code above
-            # gives each link in the nav a `nav-link` CSS class        
+            # gives each link in the nav a `nav-link` CSS class
             html.replace("nav-link", "nav-link dropdown-item")
             for html in links_html[n_links_before_dropdown:]
         ]

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -137,18 +137,22 @@ def add_toctree_functions(
         out = "\n".join(links_solo)
 
         # Wrap the final few header items in a "more" dropdown
-        links_dropdown = links_html[n_links_before_dropdown:]
+        links_dropdown = [
+            html.replace("nav-link", "nav-link dropdown-item")
+            for html in links_html[n_links_before_dropdown:]
+        ]
+
         if links_dropdown:
             links_dropdown_html = "\n".join(links_dropdown)
             out += f"""
-            <div class="nav-item dropdown">
-                <button class="btn dropdown-toggle nav-item" type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <li class="nav-item dropdown">
+                <button class="btn dropdown-toggle nav-item" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-controls="pst-header-nav-more-links">
                     More
                 </button>
-                <div class="dropdown-menu">
+                <ul id="pst-header-nav-more-links" class="dropdown-menu">
                     {links_dropdown_html}
-                </div>
-            </div>
+                </ul>
+            </li>
             """
 
         return out

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -322,19 +322,19 @@ def test_navbar_header_dropdown(sphinx_build_factory, n_links) -> None:
     navbar = index_html.select("ul.bd-navbar-elements")[0]
     if n_links == 0:
         # There should be *only* a dropdown and no standalone links
-        assert navbar.select("div.dropdown") and not navbar.select(
-            ".navbar-nav > li.nav-item"
+        assert navbar.select("li.dropdown") and not navbar.select(
+            ".navbar-nav > li.nav-item:not(.dropdown)"
         )
     if n_links == 4:
         # There should be at least one standalone link, and a dropdown
-        assert navbar.select(".navbar-nav > li.nav-item") and navbar.select(
-            "div.dropdown"
-        )
+        assert navbar.select(
+            ".navbar-nav > li.nav-item:not(.dropdown)"
+        ) and navbar.select("li.dropdown")
     if n_links == 8:
         # There should be no dropdown and only standalone links
-        assert navbar.select(".navbar-nav > li.nav-item") and not navbar.select(
-            "div.dropdown"
-        )
+        assert navbar.select(
+            ".navbar-nav > li.nav-item:not(.dropdown)"
+        ) and not navbar.select("li.dropdown")
 
 
 def test_sidebars_captions(sphinx_build_factory, file_regression) -> None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -320,21 +320,17 @@ def test_navbar_header_dropdown(sphinx_build_factory, n_links) -> None:
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     index_html = sphinx_build.html_tree("index.html")
     navbar = index_html.select("ul.bd-navbar-elements")[0]
+    dropdowns = navbar.select("li.dropdown")
+    standalone_links = navbar.select(".navbar-nav > li.nav-item:not(.dropdown)")
     if n_links == 0:
         # There should be *only* a dropdown and no standalone links
-        assert navbar.select("li.dropdown") and not navbar.select(
-            ".navbar-nav > li.nav-item:not(.dropdown)"
-        )
+        assert len(dropdowns) == 1 and not standalone_links
     if n_links == 4:
-        # There should be at least one standalone link, and a dropdown
-        assert navbar.select(
-            ".navbar-nav > li.nav-item:not(.dropdown)"
-        ) and navbar.select("li.dropdown")
+        # There should be `n_links` standalone links, and a dropdown
+        assert len(standalone_links) == n_links and len(dropdowns) == 1
     if n_links == 8:
         # There should be no dropdown and only standalone links
-        assert navbar.select(
-            ".navbar-nav > li.nav-item:not(.dropdown)"
-        ) and not navbar.select("li.dropdown")
+        assert standalone_links and not dropdowns
 
 
 def test_sidebars_captions(sphinx_build_factory, file_regression) -> None:


### PR DESCRIPTION
Fixes #1363.

Note that this PR specifically does not use the combobox role or pattern because a dropdown in a nav bar is not, semantically speaking, a select-only combobox. Accessibility expert Adrian Roselli advises against using such patterns for navigation, and proposes a [disclosure widget navigation](https://adrianroselli.com/2019/06/link-disclosure-widget-navigation.html) pattern instead. 

The ARIA APG Patterns site also has an example of the [disclosure pattern in navigation](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/), which this PR uses as a reference for the HTML markup. Essentially this meant replacing `aria-haspopup` with `aria-controls`.