### PR TITLE
BUG: JS failing to detect "preferred" docs version

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -445,6 +445,8 @@ function populateVersionSwitcher(data, versionSwitcherBtns) {
  * @param {Array} data The version data used to populate the switcher menu.
  */
 function showVersionWarningBanner(data) {
+  console.log("XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX");
+  console.log(data);
   var version = DOCUMENTATION_OPTIONS.VERSION;
   // figure out what latest stable version is
   var preferredEntries = data.filter((entry) => entry.preferred);

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -408,6 +408,9 @@ function populateVersionSwitcher(data, versionSwitcherBtns) {
     let matchesAndIsPreferred = hasMatchingPreferredEntry && entry.preferred;
     let matchesAndIsFirst =
       !hasMatchingPreferredEntry && !foundMatch && entry.match;
+    console.log(anchor);
+    console.log(`matches&preferred ${matchesAndIsPreferred}`);
+    console.log(`matches&first ${matchesAndIsFirst}`);
     if (matchesAndIsPreferred || matchesAndIsFirst) {
       anchor.classList.add("active");
       versionSwitcherBtns.forEach((btn) => {


### PR DESCRIPTION
our dev docs have a JS console error about not detecting any "preferred" version of the docs. This PR will try to fix it, but first need to do a bit of debugging. It's severe in that it results in none of the "on page load" JS getting executed (e.g., making our searchbar not work)