### PR TITLE
fix: don't display the warning bar if there is an issue

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -425,9 +425,10 @@ function showVersionWarningBanner(data) {
   var preferredEntries = data.filter((entry) => entry.preferred);
   if (preferredEntries.length !== 1) {
     const howMany = preferredEntries.length == 0 ? "No" : "Multiple";
-    throw new Error(
-      `[PST] ${howMany} versions marked "preferred" found in versions JSON`
+    console.log(
+      `[PST] ${howMany} versions marked "preferred" found in versions JSON, ignoring.`
     );
+    return;
   }
   const preferredVersion = preferredEntries[0].version;
   const preferredURL = preferredEntries[0].url;


### PR DESCRIPTION
related to #1416 

I'm not solving the initial issue itself but I prevent it from blocking the build of the injected code, I would say it's sufficient at the moment to make a release (which would be the first one with the new colors) while we continue working on it.  