### PR TITLE
Do not animate the version admonitions colors.

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -9,7 +9,6 @@ div.deprecated {
   border-left: 0.2rem solid;
   border-color: var(--pst-color-info);
   border-radius: $admonition-border-radius;
-  transition: color 250ms, background-color 250ms, border-color 250ms;
   background-color: var(--pst-color-on-background);
   @include box-shadow();
   position: relative;


### PR DESCRIPTION
Otherwise a delay has to be added to the accessibility color contrast checks, to wait for the colors to fully transition.

None of the [other admonitions](https://pydata-sphinx-theme.readthedocs.io/en/stable/examples/kitchen-sink/admonitions.html) animate as the theme toggles between light and dark. 