### PR TITLE
Remove redundant ARIA in breadcrumb navigation

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html
@@ -9,8 +9,8 @@
 
 {#- Hide breadcrumbs on the home page #}
 {% if title and pagename != root_doc %}
-<nav aria-label="{{ _('Breadcrumbs') }}">
-  <ul class="bd-breadcrumbs" role="navigation" aria-label="{{ _('Breadcrumb') }}">
+<nav aria-label="{{ _('Breadcrumb') }}">
+  <ul class="bd-breadcrumbs">
     {# Home icon #}
     <li class="breadcrumb-item breadcrumb-home">
       <a href="{{ pathto(root_doc) }}" class="nav-link" aria-label="{{ _('Home') }}">


### PR DESCRIPTION
I think the intention behind https://github.com/pydata/pydata-sphinx-theme/pull/1142#discussion_r1099154331 was to follow the [ARIA APG breadcrumb example](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/), but I think something got lost in translation.

The markup before this PR was causing the site to fail accessibility checks (Axe).