### PR TITLE
fix: change the z-index of the dropdown

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -53,6 +53,7 @@ button.btn.version-switcher__button {
 button.version-switcher__button,
 .version-switcher__menu {
   font-size: 1.1em; // A bit smaller than other menu font
+  z-index: $zindex-modal; // higher than the sidebars
   @include media-breakpoint-up($breakpoint-sidebar-primary) {
     font-size: unset;
   }


### PR DESCRIPTION
In order to be on top of the primary sidebar on small screens.

FIx #1434 