### PR TITLE
fix: set the same background for dark/light

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -139,9 +139,9 @@
   border-radius: 1.5em;
   color: var(--pst-color-text-muted);
   padding: 0.5em;
+  background-color: var(--pst-color-surface);
 
   &:hover {
-    background-color: var(--pst-color-surface);
     border: 2px solid var(--pst-color-link-hover);
   }
   &:focus-visible {

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -52,12 +52,13 @@
 }
 
 .form-control {
+  background-color: var(--pst-color-background);
+
   &:focus,
   &:focus-visible {
     border: none;
     box-shadow: none;
     outline: 3px solid var(--pst-color-accent);
-    background-color: var(--pst-color-background);
     color: var(--pst-color-text-muted);
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -59,7 +59,7 @@
     border: none;
     box-shadow: none;
     outline: 3px solid var(--pst-color-accent);
-    backgroun-color: var(--pst-color-background);
+    background-color: var(--pst-color-background);
     color: var(--pst-color-text-muted);
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -59,6 +59,7 @@
     border: none;
     box-shadow: none;
     outline: 3px solid var(--pst-color-accent);
+    backgroun-color: var(--pst-color-background);
     color: var(--pst-color-text-muted);
   }
 }


### PR DESCRIPTION
Set the same background color for all state of the search field. It is currently only applied when hovered.

Fix #1437 