### PR TITLE
Use doc version in `showVersionWarningBanner` instead of `theme_version`

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -429,7 +429,7 @@ function populateVersionSwitcher(data, versionSwitcherBtns) {
  * @param {Array} data The version data used to populate the switcher menu.
  */
 function showVersionWarningBanner(data) {
-  const version = DOCUMENTATION_OPTIONS.theme_version;
+  const version = DOCUMENTATION_OPTIONS.VERSION;
   // figure out what latest stable version is
   var preferredEntries = data.filter((entry) => entry.preferred);
   if (preferredEntries.length !== 1) {


### PR DESCRIPTION
`DOCUMENTATION_OPTIONS.theme_version` refers to the version of the PyData theme. Instead we want to compare with the version of the currently build documentation, e.g. in my case scikit-image.
