### PR TITLE
Fix landmarks

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -481,7 +481,7 @@ function showVersionWarningBanner(data) {
   inner.appendChild(bold);
   inner.appendChild(document.createTextNode("."));
   inner.appendChild(button);
-  document.body.prepend(outer);
+  (documment.querySelector("header") || document.body).prepend(outer);
 }
 
 /*******************************************************************************

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html
@@ -1,5 +1,5 @@
-<nav class="sidebar-indices-items">
-  <p class="sidebar-indices-items__title" role="heading" aria-level="1">{{ _("Indices") }}</p>
+<nav class="sidebar-indices-items" aria-labelledby="pst-indices-navigation-heading">
+  <p id="pst-indices-navigation-heading" class="sidebar-indices-items__title" role="heading" aria-level="1">{{ _("Indices") }}</p>
   <ul class="indices-link">
     {%- for rellink in rellinks %}
       {%- if rellink[0] == 'genindex' %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html
@@ -1,3 +1,4 @@
+{#- TODO use unique html id generator since components can be included in multiple places -#}
 <nav class="sidebar-indices-items" aria-labelledby="pst-indices-navigation-heading">
   <p id="pst-indices-navigation-heading" class="sidebar-indices-items__title" role="heading" aria-level="1">{{ _("Indices") }}</p>
   <ul class="indices-link">

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
@@ -1,10 +1,8 @@
-<nav class="navbar-nav">
-  <p class="sidebar-header-items__title"
+<nav class="navbar-nav" aria-labelledby="pst-site-navigation-heading">
+  <p id="pst-site-navigation-heading"
+     class="sidebar-header-items__title"
      role="heading"
-     aria-level="1"
-     aria-label="{{ _('Site Navigation') }}">
-    {{ _("Site Navigation") }}
-  </p>
+     aria-level="1">{{ _("Site") }}</p>
   <ul class="bd-navbar-elements navbar-nav">
     {{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown, dropdown_text=theme_header_dropdown_text) }}
   </ul>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html
@@ -1,8 +1,10 @@
-<nav class="navbar-nav" aria-labelledby="pst-site-navigation-heading">
-  <p id="pst-site-navigation-heading"
-     class="sidebar-header-items__title"
+<nav class="navbar-nav">
+  <p class="sidebar-header-items__title"
      role="heading"
-     aria-level="1">{{ _("Site") }}</p>
+     aria-level="1"
+     aria-label="{{ _('Site Navigation') }}">
+    {{ _("Site Navigation") }}
+  </p>
   <ul class="bd-navbar-elements navbar-nav">
     {{ generate_header_nav_html(n_links_before_dropdown=theme_header_links_before_dropdown, dropdown_text=theme_header_dropdown_text) }}
   </ul>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
@@ -1,5 +1,6 @@
 {% set page_toc = generate_toc_html() %}
 {%- if page_toc | length >= 1 %}
+{#- TODO use unique html id generator since components can be included in multiple places #}
   <div
     id="pst-page-navigation-heading"
     class="page-toc tocsection onthispage">

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
@@ -1,9 +1,11 @@
 {% set page_toc = generate_toc_html() %}
 {%- if page_toc | length >= 1 %}
-  <div class="page-toc tocsection onthispage">
+  <div
+    id="pst-page-navigation-heading"
+    class="page-toc tocsection onthispage">
     <i class="fa-solid fa-list"></i> {{ _("On this page") }}
   </div>
-  <nav class="bd-toc-nav page-toc">
+  <nav class="bd-toc-nav page-toc" aria-labelledby="pst-page-navigation-heading">
     {{ page_toc }}
   </nav>
 {%- endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
@@ -1,3 +1,4 @@
+{#- TODO use unique html id generator since components can be included in multiple places -#}
 <nav class="bd-docs-nav bd-links"
      aria-labelledby="pst-section-navigation-heading">
   <p id="pst-section-navigation-heading" class="bd-links__title" role="heading" aria-level="1">{{ _("In this section") }}</p>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
@@ -1,5 +1,5 @@
 <nav class="bd-docs-nav bd-links"
-     aria-label="{{ _('Section Navigation') }}">
-  <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
+     aria-labelledby="pst-section-navigation-heading">
+  <p id="pst-section-navigation-heading" class="bd-links__title" role="heading" aria-level="1">{{ _("In this section") }}</p>
   <div class="bd-toc-item navbar-nav">{{ sidebar_nav_html }}</div>
 </nav>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -81,6 +81,8 @@ or not theme_secondary_sidebar_items %}
     <div class="search-button__overlay"></div>
     <div class="search-button__search-container">{% include "../components/search-field.html" %}</div>
   </div>
+
+  <header>
   {%- if theme_announcement -%}
     {% include "sections/announcement.html" %}
   {%- endif %}
@@ -89,6 +91,8 @@ or not theme_secondary_sidebar_items %}
       {%- include "sections/header.html" %}
     </nav>
   {% endblock docs_navbar %}
+  </header>
+
   <div class="bd-container">
     <div class="bd-container__inner bd-page-width">
       {# Primary sidebar #}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -82,16 +82,16 @@ or not theme_secondary_sidebar_items %}
     <div class="search-button__search-container">{% include "../components/search-field.html" %}</div>
   </div>
 
-  <header>
   {%- if theme_announcement -%}
+    <aside>
     {% include "sections/announcement.html" %}
+    </aside>
   {%- endif %}
   {% block docs_navbar %}
-    <nav class="bd-header navbar navbar-expand-lg bd-navbar">
+    <header class="bd-header navbar navbar-expand-lg bd-navbar">
       {%- include "sections/header.html" %}
-    </nav>
+    </header>
   {% endblock docs_navbar %}
-  </header>
 
   <div class="bd-container">
     <div class="bd-container__inner bd-page-width">

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -111,7 +111,7 @@ or not theme_secondary_sidebar_items %}
               {% block docs_body %}
               {# This is empty and only shows up if text has been highlighted by the URL #}
                 {% include "components/searchbox.html" %}
-                <article class="bd-article" role="main">
+                <article class="bd-article">
                   {% block body %}{% endblock %}
                 </article>
               {% endblock docs_body %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -82,16 +82,16 @@ or not theme_secondary_sidebar_items %}
     <div class="search-button__search-container">{% include "../components/search-field.html" %}</div>
   </div>
 
+  <header>
   {%- if theme_announcement -%}
-    <aside>
     {% include "sections/announcement.html" %}
-    </aside>
   {%- endif %}
   {% block docs_navbar %}
-    <header class="bd-header navbar navbar-expand-lg bd-navbar">
+    <div class="bd-header navbar navbar-expand-lg bd-navbar">
       {%- include "sections/header.html" %}
-    </header>
+    </div>
   {% endblock docs_navbar %}
+  </header>
 
   <div class="bd-container">
     <div class="bd-container__inner bd-page-width">


### PR DESCRIPTION
This PR fixes some Axe errors related to landmarks (duplicate main landmark, indistinct landmarks, and some content not contained within a landmark). 

### After 

Here's how the browser "sees" the landmarks after this PR:

<img width="1728" alt="banner, navigation, main, breadcrumb navigation, in this section navigation, on this page navigation, contentinfo" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/e28dbc52-0c91-4ff3-8e7d-d28315d9bb12">

(the above screenshot was taken with the "landmarks" ad hoc tool in the [Accessibility Insights](https://accessibilityinsights.io/) browser extension)

Here's how the landmarks are shown in the VoiceOver rotor (<kbd>Caps Lock + U</kbd>):

<img width="1728" alt="banner, navigation, In this section navigation, main, Breadcrumb navigation, article, On this page navigation, footer" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/c6bf3dd5-cd83-4d61-8253-baa37e47ce48">


## Before

Here's how the browser sees landmarks before this PR

<img width="1728" alt="navigation, navigation [sic], main, breadcrumb navigation, main [sic], section navigation navigation [sic], navigation [sic], contentinfo" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/095e2400-0020-4f86-8898-786bc91bdcc1">

Landmarks in VoiceOver rotor:

<img width="1728" alt="navigation, navigation [sic], Section Navigation navigation [sic], main, Breadcrumb navigation, main, navigation, footer" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/7062658e-c3cc-4149-ac5d-4bfc7a3cd471">
