### PR TITLE
Fix redundant logo alt

### DIFF
--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -109,7 +109,7 @@ This title will appear next to the logo image if set.
        }
    }
 
-.. note:: If you specify ``text`` then the theme sets the value of logo ``alt_text`` to an empty string to avoid screen reader noise.
+.. note:: If you specify ``text`` then the theme sets the logo alt text to an empty string to avoid screen reader noise.
 
 .. note:: If you provide neither a logo image nor logo text, the theme will use ``html_title``.
 

--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -91,7 +91,7 @@ To do so, customize the ``html_theme_options["logo"]["alt_text"]`` configuration
    html_theme_options = {
        "logo": {
            # Because the logo is also a homepage link, including "home" in the alt text is good practice
-           "alt_text": "My Project Name",
+           "alt_text": "My Project Name - Home",
        }
    }
 

--- a/docs/user_guide/branding.rst
+++ b/docs/user_guide/branding.rst
@@ -91,7 +91,7 @@ To do so, customize the ``html_theme_options["logo"]["alt_text"]`` configuration
    html_theme_options = {
        "logo": {
            # Because the logo is also a homepage link, including "home" in the alt text is good practice
-           "alt_text": "My Project Name - Home",
+           "alt_text": "My Project Name",
        }
    }
 
@@ -109,7 +109,9 @@ This title will appear next to the logo image if set.
        }
    }
 
-.. note:: The ``html_title`` field will work as well if no logo images are specified.
+.. note:: If you specify ``text`` then the theme sets the value of logo ``alt_text`` to an empty string to avoid screen reader noise.
+
+.. note:: If you provide neither a logo image nor logo text, the theme will use ``html_title``.
 
 
 Add favicons

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-logo.html
@@ -6,12 +6,11 @@
 {% else %}
   {% set href = theme_logo.get("link") %} {# external url #}
 {% endif %}
-
 {#- Logo HTML and image #}
 <a class="navbar-brand logo" href="{{ href }}">
   {# get all the brand information from html_theme_option #}
   {% set is_logo = "light" in theme_logo["image_relative"] %}
-  {% set alt = theme_logo.get("alt_text", "Logo image") %}
+  {% set alt = theme_logo.get("alt_text", "Logo image") if not theme_logo.get("text") else "" %}
   {% if is_logo %}
     {# Theme switching is only available when JavaScript is enabled.
      # Thus we should add the extra image using JavaScript, defaulting


### PR DESCRIPTION
Completes one of the tasks in #1428. 

[Alternative text of images should not be repeated as text.](https://dequeuniversity.com/rules/axe/4.7/image-redundant-alt?application=AxeChrome)

The theme allows the user to specify both logo text and alt text. This PR changes the theme so that if the user provides text, it takes precedence over alt text.

