### PR TITLE
fix: truncate title in breadcrumbs

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html
@@ -24,7 +24,7 @@
     <li class="breadcrumb-item">{{ doc.title }}</li>
     {% endif %}
     {%- endfor %}
-    <li class="breadcrumb-item active" aria-current="page">{{ title|truncate(10, False) }}</li>
+    <li class="breadcrumb-item active" aria-current="page">{{ title|truncate(15, False) }}</li>
   </ul>
 </nav>
 {% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html
@@ -24,7 +24,7 @@
     <li class="breadcrumb-item">{{ doc.title }}</li>
     {% endif %}
     {%- endfor %}
-    <li class="breadcrumb-item active" aria-current="page">{{ title }}</li>
+    <li class="breadcrumb-item active" aria-current="page">{{ title|truncate(10, False) }}</li>
   </ul>
 </nav>
 {% endif %}


### PR DESCRIPTION
Fix #1451 

When title is too long it becomes messy to display.

tagging @trallard  and @gabalafou to advice on length.
