### PR TITLE
temporarily pin sphinxcontrib-youtube

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ doc = [
   "sphinx-design",
   "sphinx-togglebutton",
   "jupyterlite-sphinx",
-  "sphinxcontrib-youtube",
+  "sphinxcontrib-youtube<1.4",
   "sphinx-favicon>=1.0.1",
   # Install nbsphinx in case we want to test it locally even though we can't load
   # it at the same time as MyST-NB.


### PR DESCRIPTION
... so that our CIs will keep running. When we can bump to using Sphinx > 5.x in the CIs we should remove this pin.

xref #1441 and https://github.com/executablebooks/MyST-NB/issues/543