### PR TITLE
docs: link back to GitHub from PyPI metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 
+[project.urls]
+"Source" = "https://github.com/pydata/pydata-sphinx-theme"
+
 [project.optional-dependencies]
 doc = [
   "numpydoc",


### PR DESCRIPTION
This will add a "Source" link in the PyPI page.