### PR TITLE
deps: drop support for Sphinx 5

### DIFF
--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -9,7 +9,7 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
-    SPHINX_INSTALL="sphinx==5.0"
+    SPHINX_INSTALL="sphinx==6.1.0"
 else  # not used currently but easy enough
     SPHINX_INSTALL="sphinx==$SPHINX_VERSION"
 fi

--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -8,10 +8,6 @@ if [[ "$SPHINX_VERSION" == "" ]]; then
     SPHINX_INSTALL=""
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
     SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
-    if [[ "$1" == "doc" ]]; then
-        # Until they release a new version that undoes the max sphinx pin...
-        DEP_EXTRA="git+https://github.com/executablebooks/MyST-NB"
-    fi
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
     SPHINX_INSTALL="sphinx==5.0"
 else  # not used currently but easy enough


### PR DESCRIPTION
Dropping support for Sphinx 5 as it as already been deprecated by autoapi, myst and other extentions we use to build our site. 
Using the 6.1.0 as minimal version to remain compatible with autoapi. 

Fix #1515 