### PR TITLE
fix: use 12rambau fork until it's merged with nikeee repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,7 +137,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: nikeee/setup-pandoc@v1
+      # waiting for https://github.com/nikeee/setup-pandoc/pull/8
+      # using 12rambau fork until then
+      - uses: 12rambau/setup-pandoc@test
       - name: Setup Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
related to #1513 

The macOs build now works and it didn't changed anything for the other ones. 