### PR TITLE
fix: avoid matplotlib warnings

### DIFF
--- a/docs/examples/pydata.ipynb
+++ b/docs/examples/pydata.ipynb
@@ -59,6 +59,8 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "\n",
+    "matplotlib.set_loglevel(\"critical\")\n",
+    "\n",
     "fig, ax = plt.subplots()\n",
     "ax.scatter(df[\"a\"], df[\"b\"], c=df[\"b\"], s=3)"
    ]


### PR DESCRIPTION
Fix #1514 

