### PR TITLE
refactor: remove extention on component set-up

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,19 +165,19 @@ html_theme_options = {
     "use_edit_page_button": True,
     "show_toc_level": 1,
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
-    "navbar_center": ["version-switcher", "navbar-nav"],
+    # "show_nav_level": 2,
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
     "show_version_warning_banner": True,
-    # "show_nav_level": 2,
+    "navbar_center": ["version-switcher", "navbar-nav"],
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],
     # "navbar_persistent": ["search-button"],
-    # "primary_sidebar_end": ["custom-template.html", "sidebar-ethical-ads.html"],
-    # "article_footer_items": ["test.html", "test.html"],
-    # "content_footer_items": ["test.html", "test.html"],
-    "footer_start": ["copyright.html"],
-    "footer_center": ["sphinx-version.html"],
-    # "secondary_sidebar_items": ["page-toc.html"],  # Remove the source buttons
+    # "primary_sidebar_end": ["custom-template", "sidebar-ethical-ads"],
+    # "article_footer_items": ["test", "test"],
+    # "content_footer_items": ["test", "test"],
+    "footer_start": ["copyright"],
+    "footer_center": ["sphinx-version"],
+    # "secondary_sidebar_items": ["page-toc"],  # Remove the source buttons
     "switcher": {
         "json_url": json_url,
         "version_match": version_match,

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -38,19 +38,19 @@ pygment_dark_style = a11y-high-contrast-dark
 logo =
 
 # Template placement in theme layouts
-navbar_start = navbar-logo.html
-navbar_center = navbar-nav.html
-navbar_end = theme-switcher.html, navbar-icon-links.html
-navbar_persistent = search-button-field.html
-article_header_start = breadcrumbs.html
+navbar_start = navbar-logo
+navbar_center = navbar-nav
+navbar_end = theme-switcher, navbar-icon-links
+navbar_persistent = search-button-field
+article_header_start = breadcrumbs
 article_header_end =
 article_footer_items =
 content_footer_items =
-primary_sidebar_end = sidebar-ethical-ads.html
-footer_start = copyright.html, sphinx-version.html
+primary_sidebar_end = sidebar-ethical-ads
+footer_start = copyright, sphinx-version
 footer_center =
-footer_end = theme-version.html
-secondary_sidebar_items = page-toc.html, edit-this-page.html, sourcelink.html
+footer_end = theme-version
+secondary_sidebar_items = page-toc, edit-this-page, sourcelink
 show_version_warning_banner = False
 announcement =
 


### PR DESCRIPTION
I was working on https://github.com/pydata/pydata-sphinx-theme/pull/1485 and I realized that some things could be improved in the conf.py file. By design the component can be set without the .html extention. Why don't we use this nice feature in our example and default values to reduce the visual burden ? 

- I reorder the options in conf.py to group the layout slots together
- I remove all .html extention from conf.py 
- I removed all .html extention from the default theme.conf values.

Open question: 
As the full parameter reference will be exposed after #1485 is merged, I think we should remove never used parameter in our doc conf.py. what do you think ? 