### PR TITLE
kill the docs-live infinite loop (yet again)

### DIFF
--- a/docs/examples/pydata.ipynb
+++ b/docs/examples/pydata.ipynb
@@ -24,7 +24,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
-    "rng = np.random.default_rng()\n",
+    "rng = np.random.default_rng(seed=15485863)\n",
     "data = rng.standard_normal((100, 26))\n",
     "df = pd.DataFrame(data, columns=list(string.ascii_lowercase))\n",
     "df"

--- a/noxfile.py
+++ b/noxfile.py
@@ -91,7 +91,9 @@ def docs_live(session: nox.Session) -> None:
         session.install(
             "sphinx-theme-builder[cli]@git+https://github.com/pradyunsg/sphinx-theme-builder#egg=d9f620b"
         )
-    session.run("stb", "serve", "docs", "--open-browser", "--re-ignore=locale|api")
+    session.run(
+        "stb", "serve", "docs", "--open-browser", "--re-ignore=locale|api|_build"
+    )
 
 
 @nox.session()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["sphinx-theme-builder @ https://github.com/pradyunsg/sphinx-theme-builder/archive/d9f620b1a73839728c95b596343595d3952ec8bf.zip"]
+requires = ["sphinx-theme-builder @ https://github.com/pradyunsg/sphinx-theme-builder/archive/87214d0671c943992c05e3db01dca997e156e8d6.zip"]
 build-backend = "sphinx_theme_builder"
 
 [tool.sphinx-theme-builder]


### PR DESCRIPTION
this avoids the `nox -s docs-live` infinite loop (which has resurfaced again) by

1. ignoring the `_build` folder (why it is among the watched files list to begin with baffles me; cf. https://github.com/executablebooks/sphinx-autobuild/issues/124#issuecomment-1429429460)
2. making the notebook use a random seed so that its generated images don't change on each rebuild
3. bumping the version of sphinx-theme-builder so that the `re_ignore` CLI option actually works (i'd been running off my PR branch, nowadays the PR is merged)