### PR TITLE
fix: make table background transparent

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -43,3 +43,8 @@ td {
     text-align: center;
   }
 }
+
+// override bootstrap background colors
+.table {
+  --bs-table-bg: transparent;
+}

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -90,9 +90,6 @@ $color-palette: (
       --pst-#{$group-color}-#{$color-name}: #{$definition};
     }
   }
-
-  // override some bootstrap colors if necessary
-  --bs-table-bg: transparent;
 }
 
 // Static SCSS variables used thoroughout the theme

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -90,6 +90,9 @@ $color-palette: (
       --pst-#{$group-color}-#{$color-name}: #{$definition};
     }
   }
+
+  // override some bootstrap colors if necessary
+  --bs-table-bg: transparent;
 }
 
 // Static SCSS variables used thoroughout the theme


### PR DESCRIPTION
Fix #1543 

The background color of the table has changed from transparent to white in bootstrap. In this PR I override the bootstrap color to make it consistent with the previous version. 

The alternative would have been to override the colors of all table selectors which seems like an overkill.