### PR TITLE
Consistent focus ring (first pass)

### DIFF
--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -35,7 +35,7 @@ Thanks for your support!
   link: https://fairlearn.org/main/about/
 - title: Feature-engine
   link: https://feature-engine.readthedocs.io/
-- title: idtracker.ai
+- title: idtracker&period;ai
   link: https://idtracker.ai/
 - title: MegEngine
   link: https://www.megengine.org.cn/doc/stable/en/index.html

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,13 +21,11 @@ A clean, Bootstrap-based Sphinx theme by and for [the PyData community](https://
 - header: "{fas}`circle-half-stroke;pst-color-primary` Light / Dark theme"
   content: "Users can toggle between light and dark themes interactively."
 - header: "{fas}`palette;pst-color-primary` Customizable UI and themes"
-  content: "Customize colors and branding with CSS variables, and build custom UIs with [Sphinx Design](user_guide/web-components)."
+  content: "Customize colors and branding with CSS variables, and build custom UIs with [Sphinx Design components](user_guide/web-components)."
 - header: "{fab}`python;pst-color-primary` Supports PyData and Jupyter"
-  content: "CSS and UI support for Jupyter extensions and PyData execution outputs."
-  link: "examples/pydata.html"
+  content: "CSS and UI support for Jupyter extensions and [PyData execution outputs](examples/pydata.ipynb)."
 - header: "{fas}`lightbulb;pst-color-primary` Example Gallery"
-  content: "See our gallery of projects that use this theme."
-  link: "examples/gallery.html"
+  content: "See [our gallery](examples/gallery.md) of projects that use this theme."
 ```
 
 ```{seealso}

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ A clean, Bootstrap-based Sphinx theme by and for [the PyData community](https://
 - header: "{fas}`palette;pst-color-primary` Customizable UI and themes"
   content: "Customize colors and branding with CSS variables, and build custom UIs with [Sphinx Design components](user_guide/web-components)."
 - header: "{fab}`python;pst-color-primary` Supports PyData and Jupyter"
-  content: "CSS and UI support for Jupyter extensions and [PyData execution outputs](examples/pydata.ipynb)."
+  content: "CSS and UI support for [Jupyter extensions](examples/execution) and [PyData execution outputs](examples/pydata.ipynb)."
 - header: "{fas}`lightbulb;pst-color-primary` Example Gallery"
   content: "See [our gallery](examples/gallery.md) of projects that use this theme."
 ```

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -171,9 +171,3 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
     }
   }
 }
-
-// Focus ring
-:focus-visible {
-  outline: 3px solid var(--pst-color-accent);
-  box-shadow: none; // override Bootstrap
-}

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -86,10 +86,6 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
       color: var(--pst-color-link-hover);
     }
   }
-
-  &:focus-visible {
-    @include focus-indicator;
-  }
 }
 
 // Text link styles
@@ -104,10 +100,6 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
     color: var(--pst-color-link-hover);
     @include link-decoration;
     @include link-decoration-hover;
-  }
-
-  &:focus-visible {
-    @include focus-indicator;
   }
 }
 
@@ -143,10 +135,8 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
   font-weight: 600;
   color: var(--pst-color-primary);
   @if $link-hover-decoration-thickness {
-    box-shadow: inset
-      $link-hover-decoration-thickness
-      0px
-      0px
+    border-left: $link-hover-decoration-thickness
+      solid
       var(--pst-color-primary);
   }
 }
@@ -182,14 +172,8 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
   }
 }
 
-// Focus indicator
-//
-// If a value of $radius: 0.125rem is passed in, it means 2px at 100% zoom
-// (0.125 * 16px base font = 2px)
-@mixin focus-indicator($radius: -1) {
+// Focus ring
+:focus-visible {
   outline: 3px solid var(--pst-color-accent);
   box-shadow: none; // override Bootstrap
-  @if $radius != -1 {
-    border-radius: $radius;
-  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -86,7 +86,10 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
       color: var(--pst-color-link-hover);
     }
   }
-  @include focus-indicator;
+
+  &:focus-visible {
+    @include focus-indicator;
+  }
 }
 
 // Text link styles
@@ -102,7 +105,10 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
     @include link-decoration;
     @include link-decoration-hover;
   }
-  @include focus-indicator;
+
+  &:focus-visible {
+    @include focus-indicator;
+  }
 }
 
 // Sidebar and TOC links
@@ -177,9 +183,13 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
 }
 
 // Focus indicator
-@mixin focus-indicator {
-  &:focus-visible {
-    outline: 3px solid var(--pst-color-accent);
-    box-shadow: none; // override Bootstrap
+//
+// If a value of $radius: 0.125rem is passed in, it means 2px at 100% zoom
+// (0.125 * 16px base font = 2px)
+@mixin focus-indicator($radius: -1) {
+  outline: 3px solid var(--pst-color-accent);
+  box-shadow: none; // override Bootstrap
+  @if $radius != -1 {
+    border-radius: $radius;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -180,5 +180,6 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
 @mixin focus-indicator {
   &:focus-visible {
     outline: 3px solid var(--pst-color-accent);
+    box-shadow: none; // override Bootstrap
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -179,6 +179,6 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
 // Focus indicator
 @mixin focus-indicator {
   &:focus-visible {
-    outline: 2px solid var(--pst-color-accent);
+    outline: 3px solid var(--pst-color-accent);
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -182,9 +182,9 @@ pre {
 
 // Focus ring
 //
-// Note: The Bootstrap stylesheet provide the focus ring for most of the site's
-// elements. This covers everything else that's focusable that Bootstrap doesn't
-// cover.
+// Note: The Bootstrap stylesheet provides the focus ring (customized via Sass
+// variables in _bootstrap.scss) in some cases. This rules covers all other
+// cases.
 :focus-visible {
   outline: $focus-ring-outline;
   box-shadow: none; // override Bootstrap

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -179,3 +179,13 @@ pre {
   background-color: var(--pst-color-secondary);
   border: none;
 }
+
+// Focus ring
+//
+// Note: The Bootstrap stylesheet provide the focus ring for most of the site's
+// elements. This covers everything else that's focusable that Bootstrap doesn't
+// cover.
+:focus-visible {
+  outline: $focus-ring-outline;
+  box-shadow: none; // override Bootstrap
+}

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -67,6 +67,28 @@
  * Search button - located in the navbar
  */
 
+// Search link icon should be a bit bigger since it is separate from icon links
+.search-button {
+  display: flex;
+  align-items: center;
+  align-content: center;
+  color: var(--pst-color-text-muted);
+  border-radius: 0;
+  border: none; // Override Bootstrap button border
+  font-size: 1rem; // Override Bootstrap button font size
+
+  // Override Bootstrap button padding-x. Whitespace in nav bar is controlled
+  // via column gap rule on the container.
+  padding-left: 0;
+  padding-right: 0;
+
+  @include icon-navbar-hover;
+
+  i {
+    font-size: 1.3rem;
+  }
+}
+
 // __search-container will only show up when we use the search pop-up bar
 .search-button__search-container,
 .search-button__overlay {

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -136,10 +136,11 @@
  * Lives at components/search-button-field.html
  */
 .search-button-field {
+  $search-button-border-radius: 1.5em;
   display: inline-flex;
   align-items: center;
   border: var(--pst-color-border) solid 1px;
-  border-radius: 1.5em;
+  border-radius: $search-button-border-radius;
   color: var(--pst-color-text-muted);
   padding: 0.5em;
   background-color: var(--pst-color-surface);
@@ -147,8 +148,10 @@
   &:hover {
     border: 2px solid var(--pst-color-link-hover);
   }
+
+  @include focus-indicator;
   &:focus-visible {
-    border: 2px solid var(--pst-color-accent);
+    border-radius: $search-button-border-radius; // set explicitly to override focus-visible border-radius set in _header.scss
   }
 
   // The keyboard shotcut text

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -57,9 +57,8 @@
 
   &:focus,
   &:focus-visible {
+    @include focus-indicator;
     border: none;
-    box-shadow: none;
-    outline: 3px solid var(--pst-color-accent);
     background-color: var(--pst-color-background);
     color: var(--pst-color-text-muted);
   }
@@ -68,23 +67,6 @@
 /**
  * Search button - located in the navbar
  */
-
-// Search link icon should be a bit bigger since it is separate from icon links
-.search-button {
-  display: flex;
-  align-items: center;
-  align-content: center;
-  color: var(--pst-color-text-muted);
-  // Needed to match other icons hover
-  padding: 0 0 0.25rem 0;
-  border-radius: 0;
-  @include icon-navbar-hover;
-  @include focus-indicator;
-
-  i {
-    font-size: 1.3rem;
-  }
-}
 
 // __search-container will only show up when we use the search pop-up bar
 .search-button__search-container,
@@ -149,9 +131,8 @@
     border: 2px solid var(--pst-color-link-hover);
   }
 
-  @include focus-indicator;
   &:focus-visible {
-    border-radius: $search-button-border-radius; // set explicitly to override focus-visible border-radius set in _header.scss
+    @include focus-indicator($radius: $search-button-border-radius);
   }
 
   // The keyboard shotcut text

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -57,7 +57,6 @@
 
   &:focus,
   &:focus-visible {
-    @include focus-indicator;
     border: none;
     background-color: var(--pst-color-background);
     color: var(--pst-color-text-muted);
@@ -132,7 +131,7 @@
   }
 
   &:focus-visible {
-    @include focus-indicator($radius: $search-button-border-radius);
+    border-radius: $search-button-border-radius;
   }
 
   // The keyboard shotcut text

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -7,8 +7,6 @@
   margin: 0 -0.5rem;
   padding: 0; // We pad the `span` not the container
   color: var(--pst-color-text-muted);
-  border-radius: 0;
-  @include focus-indicator;
 
   span {
     display: none;

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -3,16 +3,23 @@
  */
 
 .theme-switch-button {
-  // overide bootstrap settings
-  margin: 0 -0.5rem;
-  padding: 0; // We pad the `span` not the container
   color: var(--pst-color-text-muted);
+  border-radius: 0;
+  border: none; // Override Bootstrap button border
+  font-size: 1rem; // Override Bootstrap's button font size
+
+  // Override Bootstrap button padding-x. Whitespace in nav bar is controlled
+  // via column gap rule on the container.
+  padding-left: 0;
+  padding-right: 0;
+
+  &:hover {
+    @include icon-navbar-hover;
+  }
 
   span {
     display: none;
-    padding: 0.5em;
 
-    @include icon-navbar-hover;
     &:active {
       text-decoration: none;
       color: var(--pst-color-link-hover);

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -17,7 +17,7 @@ button.btn.version-switcher__button {
 
 .version-switcher__menu {
   border-color: var(--pst-color-border);
-  border-radius: var(--bs-dropdown-border-radius);
+  border-radius: 2px;
 
   a.list-group-item {
     background-color: var(--pst-color-on-background);

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -16,7 +16,7 @@ button.btn.version-switcher__button {
 
 .version-switcher__menu {
   border-color: var(--pst-color-border);
-  border-radius: 2px;
+  border-radius: var(--bs-dropdown-border-radius);
 
   a.list-group-item {
     background-color: var(--pst-color-on-background);

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -8,7 +8,6 @@ button.btn.version-switcher__button {
   }
 
   @include link-style-hover;
-  @include focus-indicator;
   &:active {
     color: var(--pst-color-text-base);
     border-color: var(--pst-color-border);

--- a/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
@@ -50,6 +50,6 @@ nav.page-toc {
   }
 
   :focus-visible {
-    @include focus-indicator($radius: 0.125rem);
+    border-radius: 0.125rem;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
@@ -48,4 +48,8 @@ nav.page-toc {
       }
     }
   }
+
+  :focus-visible {
+    @include focus-indicator($radius: 0.125rem);
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -3,13 +3,14 @@
  * Admonitions CSS originally inspired by https://squidfunk.github.io/mkdocs-material/getting-started/
  */
 $admonition-border-radius: 0.25rem;
+$admonition-left-border-width: 0.2rem;
 div.admonition,
 .admonition {
   margin: 1.5625em auto;
   padding: 0 0.6rem 0.8rem 0.6rem;
   overflow: hidden;
   page-break-inside: avoid;
-  border-left: 0.2rem solid;
+  border-left: $admonition-left-border-width solid;
   border-color: var(--pst-color-info);
   border-radius: $admonition-border-radius;
   background-color: var(--pst-color-on-background);
@@ -226,7 +227,7 @@ div.admonition,
     margin-top: 0;
 
     // Undo the .sidebar directive border
-    border-width: 0 0 0 0.2rem;
+    border-width: 0 0 0 $admonition-left-border-width;
 
     // TODO: these semantic-color-names border-color rules might no longer be
     //       needed when we drop support for Sphinx 4 / docutils 0.17

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
@@ -38,6 +38,6 @@ div.highlight button.copybtn {
   }
 
   &:focus-visible {
-    outline: $focus-ring-width solid $focus-ring-color;
+    outline: $focus-ring-outline;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
@@ -31,4 +31,13 @@ div.highlight button.copybtn {
     color: var(--pst-color-text);
     background-color: var(--pst-color-surface);
   }
+
+  &:focus {
+    // For keyboard users, make the copy button visible when focussed.
+    opacity: 1;
+  }
+
+  &:focus-visible {
+    outline: $focus-ring-width solid $focus-ring-color;
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -140,11 +140,6 @@ html[data-theme="light"] {
   .sd-card-header {
     background-color: var(--pst-color-panel-background);
     border-bottom: 1px solid var(--pst-color-border);
-
-    &:focus-visible {
-      outline: $focus-ring-outline;
-      outline-offset: -$focus-ring-width;
-    }
   }
   .sd-card-footer {
     background-color: var(--pst-color-panel-background);
@@ -153,6 +148,22 @@ html[data-theme="light"] {
 
   .sd-card-body {
     background-color: var(--pst-color-panel-background);
+  }
+
+  // Focus ring for link-cards
+  .sd-stretched-link:focus-visible {
+    // Don't put the focus ring on the <a> element (it has zero height in Sphinx Design cards)
+    outline: none;
+
+    // Put the focus ring on the <a> element's ::after pseudo-element
+    &:after {
+      outline: $focus-ring-outline;
+      border-radius: 0.25rem; // copied from Sphinx Design CSS for .sd-card
+    }
+  }
+
+  &.sd-card-hover:hover {
+    border-color: var(--pst-color-link-hover);
   }
 }
 /*******************************************************************************
@@ -260,6 +271,12 @@ details.sd-dropdown {
     .sd-summary-up,
     .sd-summary-down {
       top: 0.7rem;
+    }
+
+    // Focus ring
+    &:focus-visible {
+      outline: $focus-ring-outline;
+      outline-offset: -$focus-ring-width;
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -142,7 +142,7 @@ html[data-theme="light"] {
     border-bottom: 1px solid var(--pst-color-border);
 
     &:focus-visible {
-      outline: $focus-ring-width solid $focus-ring-color;
+      outline: $focus-ring-outline;
     }
   }
   .sd-card-footer {

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -140,6 +140,10 @@ html[data-theme="light"] {
   .sd-card-header {
     background-color: var(--pst-color-panel-background);
     border-bottom: 1px solid var(--pst-color-border);
+
+    &:focus-visible {
+      outline: $focus-ring-width solid $focus-ring-color;
+    }
   }
   .sd-card-footer {
     background-color: var(--pst-color-panel-background);

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -143,6 +143,7 @@ html[data-theme="light"] {
 
     &:focus-visible {
       outline: $focus-ring-outline;
+      outline-offset: -$focus-ring-width;
     }
   }
   .sd-card-footer {

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -9,7 +9,7 @@
       color: inherit;
 
       &:focus-visible {
-        outline: $focus-ring-width solid $focus-ring-color;
+        outline: $focus-ring-outline;
         outline-offset: $focus-ring-width;
       }
     }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -19,16 +19,23 @@
     &:focus-within {
       overflow: visible;
 
+      // The complicated focus ring styles here are a consequence of the markup
+      // and border styles for this particular admonition class. (For the other
+      // type of admonition on this site, the focus ring style is achieved with
+      // simple `outline` and `outline-offset` rules on the admonition's
+      // header.) The problem is that Sphinx-togglebutton puts the admonition's
+      // left border on the outermost container (rather than separately setting
+      // the left border on the container's children). This makes it complicated
+      // to get the focus ring to simultaneously cover the left border in the
+      // header and align perfectly on the right with the body.
       .admonition-title:focus-within:before {
         content: "";
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        right: 0;
-        left: 0;
-        width: calc(100% - $focus-ring-width);
+        transform: translateX(
+          -$admonition-left-border-width
+        ); // align left edges of admonition and ring
+        width: calc(100% + $admonition-left-border-width); // align right edges
         height: 100%;
-        outline: $focus-ring-outline;
+        border: $focus-ring-outline;
         border-radius: $focus-ring-width;
       }
 

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -7,6 +7,11 @@
   .admonition {
     button.toggle-button {
       color: inherit;
+
+      &:focus-visible {
+        outline: $focus-ring-width solid $focus-ring-color;
+        outline-offset: $focus-ring-width;
+      }
     }
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -7,10 +7,34 @@
   .admonition {
     button.toggle-button {
       color: inherit;
+    }
 
-      &:focus-visible {
+    // Focus ring
+    //
+    // Sphinx-togglebutton makes the entire admonition header clickable, but
+    // only the button within the header is focusable. We want the entire
+    // clickable area to be surrounded with a focus ring, so that's why we use
+    // the :focus-within selector, rather than a :focus-visible selector on the
+    // button.
+    &:focus-within {
+      overflow: visible;
+
+      .admonition-title:focus-within:before {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        width: calc(100% - $focus-ring-width);
+        height: 100%;
         outline: $focus-ring-outline;
-        outline-offset: $focus-ring-width;
+        border-radius: $focus-ring-width;
+      }
+
+      // When expanded, sharpen the bottom left and right corners of the focus ring
+      &:not(.toggle-hidden) .admonition-title:focus-within:before {
+        border-radius: $focus-ring-width $focus-ring-width 0 0;
       }
     }
   }
@@ -20,6 +44,11 @@
     // Over-ride border color to re-use our primary color
     summary {
       border-left: 3px solid var(--pst-color-primary);
+    }
+
+    // When expanded, sharpen the bottom left and right corners of the focus ring
+    &[open] :focus-visible {
+      border-radius: $focus-ring-width $focus-ring-width 0 0;
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -41,7 +41,8 @@
 
       // When expanded, sharpen the bottom left and right corners of the focus ring
       &:not(.toggle-hidden) .admonition-title:focus-within:before {
-        border-radius: $focus-ring-width $focus-ring-width 0 0;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
       }
     }
   }
@@ -55,7 +56,8 @@
 
     // When expanded, sharpen the bottom left and right corners of the focus ring
     &[open] :focus-visible {
-      border-radius: $focus-ring-width $focus-ring-width 0 0;
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -29,7 +29,7 @@
   }
 
   :focus-visible {
-    border-radius: 0.125rem; // 2/16
+    @include focus-indicator($radius: 0.125rem);
   }
 
   // These items will define the height of the header
@@ -103,7 +103,9 @@
         color: var(--pst-color-text-muted);
         border: none;
         @include link-style-hover;
-        @include focus-indicator;
+        &:focus-visible {
+          @include focus-indicator;
+        }
       }
 
       .dropdown-menu {
@@ -194,7 +196,9 @@
       }
     }
     @include icon-navbar-hover;
-    @include focus-indicator;
+    &:focus-visible {
+      @include focus-indicator;
+    }
   }
 
   // Hide the navbar header items on mobile because they're in the sidebar

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -28,6 +28,10 @@
     padding-right: 1rem;
   }
 
+  :focus-visible {
+    border-radius: 0.125rem; // 2/16
+  }
+
   // These items will define the height of the header
   .navbar-item {
     height: var(--pst-header-height);

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -29,7 +29,7 @@
   }
 
   :focus-visible {
-    @include focus-indicator($radius: 0.125rem);
+    border-radius: 0.125rem;
   }
 
   // These items will define the height of the header
@@ -103,9 +103,6 @@
         color: var(--pst-color-text-muted);
         border: none;
         @include link-style-hover;
-        &:focus-visible {
-          @include focus-indicator;
-        }
       }
 
       .dropdown-menu {
@@ -196,9 +193,6 @@
       }
     }
     @include icon-navbar-hover;
-    &:focus-visible {
-      @include focus-indicator;
-    }
   }
 
   // Hide the navbar header items on mobile because they're in the sidebar

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -92,7 +92,7 @@
             // In the mobile sidebar, the dropdown menu is inlined with the
             // other links, which do not have background-color changes on hover
             // and focus
-            background-color: transparent;
+            background-color: unset;
           }
         }
       }
@@ -102,7 +102,7 @@
       .nav-link {
         &:focus-visible {
           box-shadow: none; // Override Bootstrap
-          outline: $focus-ring-width solid $focus-ring-color;
+          outline: $focus-ring-outline;
           outline-offset: $focus-ring-width;
         }
       }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -85,6 +85,26 @@
         border: none;
         background-color: inherit;
         font-size: inherit;
+
+        .dropdown-item {
+          &:hover,
+          &:focus {
+            // In the mobile sidebar, the dropdown menu is inlined with the
+            // other links, which do not have background-color changes on hover
+            // and focus
+            background-color: transparent;
+          }
+        }
+      }
+    }
+
+    .bd-navbar-elements {
+      .nav-link {
+        &:focus-visible {
+          box-shadow: none; // Override Bootstrap
+          outline: $focus-ring-width solid $focus-ring-color;
+          outline-offset: $focus-ring-width;
+        }
       }
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -25,7 +25,7 @@
 
   // Focus styles
   :focus-visible {
-    @include focus-indicator($radius: 0.125rem);
+    border-radius: 0.125rem;
   }
 
   // override bootstrap when navlink are displayed in the sidebar

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -118,7 +118,7 @@
     .sidebar-header-items__end {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
+      gap: 1rem;
     }
 
     @include media-breakpoint-up($breakpoint-sidebar-primary) {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -23,6 +23,11 @@
     font-size: var(--pst-sidebar-font-size);
   }
 
+  // Focus styles
+  :focus-visible {
+    @include focus-indicator($radius: 0.125rem);
+  }
+
   // override bootstrap when navlink are displayed in the sidebar
   .nav-link {
     font-size: var(--pst-sidebar-font-size-mobile);
@@ -171,8 +176,6 @@
 
 /* Between-page links and captions */
 nav.bd-links {
-  margin-right: -1rem;
-
   @include media-breakpoint-up($breakpoint-sidebar-primary) {
     display: block;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_skip-link.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_skip-link.scss
@@ -1,6 +1,6 @@
 /***
- * Rules for the UX/UI of skip navigation link btn. 
- *It's only visible to people
+ * Rules for the UX/UI of skip navigation link btn.
+ * It's only visible to people
  * navigating with keyboard for accessibility purposes
  * ref: https://www.youtube.com/watch?v=VUR0I5mqq7I
  ***/
@@ -12,8 +12,6 @@
   right: 0;
   text-align: center;
   background-color: var(--pst-color-warning);
-  // Ensure we are using a WCAG conformant colour
-  color: var(--pst-color-warning-text) !important;
   padding: 0.5rem;
   z-index: $zindex-modal;
   border-bottom: 1px solid var(--pst-color-border);
@@ -21,9 +19,17 @@
   // This shows / hides the button
   transform: translateY(-100%);
   transition: transform 150ms ease-in-out;
-  &:focus {
+  &:focus-within {
     transform: translateY(0%);
-    // ensure this is visible
-    outline: 3px solid $foundation-black;
+  }
+
+  a {
+    // Ensure we are using a WCAG conformant colour
+    color: var(--pst-color-warning-text) !important;
+
+    &:focus-visible {
+      // use color with sufficient contrast
+      outline-color: $foundation-black;
+    }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
@@ -28,6 +28,8 @@ $focus-ring-opacity: 1;
 $focus-ring-color: var(--pst-color-accent);
 $focus-ring-blur: 0;
 $focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color;
+// outline creates the same style of focus ring, it just uses CSS outline instead of box shadow
+$focus-ring-outline: $focus-ring-color solid $focus-ring-width;
 $btn-focus-box-shadow: $focus-ring-box-shadow;
 
 .btn {

--- a/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
@@ -22,3 +22,14 @@ $dropdown-link-hover-bg: var(--pst-color-surface);
 $dropdown-dark-link-hover-bg: var(--pst-color-surface);
 $dropdown-link-active-bg: var(--pst-color-surface);
 $dropdown-dark-link-active-bg: var(--pst-color-surface);
+
+$focus-ring-width: 0.1875rem; // 3px at 100% zoom (0.1875 * 16px base font = 3px)
+$focus-ring-opacity: 1;
+$focus-ring-color: var(--pst-color-accent);
+$focus-ring-blur: 0;
+$focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color;
+$btn-focus-box-shadow: $focus-ring-box-shadow;
+
+.btn {
+  --bs-btn-focus-box-shadow: #{$btn-focus-box-shadow};
+}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -50,7 +50,7 @@ or not theme_secondary_sidebar_items %}
 
   {# A button hidden by default to help assistive devices quickly jump to main content #}
   {# ref: https://www.youtube.com/watch?v=VUR0I5mqq7I #}
-  <a class="skip-link" href="#main-content">{{ _("Skip to main content") }}</a>
+  <div class="skip-link"><a href="#main-content">{{ _("Skip to main content") }}</a></div>
 
 {%- endblock %}
 


### PR DESCRIPTION
Note: this PR is against `feature-focus` branch **not** `main`. Style fixes related to interaction state (focus, hover, current) will be collected in small increments into `feature-focus` before being merged into `main`.

This PR is a first pass at making the focus rings across the theme consistent. That means that they are all solid and 3px thick (at 100% zoom). In light mode, all focus rings should be pink-500 (#c132af), and in dark mode, pink-400 (#e47fd7). (Exception: skip link, which uses a black focus ring.)

Known TODOs (for future PRs):

- [ipyleaflet](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/pydata.html#ipyleaflet) receives focus but does not show focus ring
- Sphinx Design link cards (as seen on the home page) - focus ring is broken (squished, very narrow) due to the way the link is rendered
- Sidebar TOC dropdown "chevron" button (does not receive focus and does not work with space or enter key)
- There are too many copy buttons in [notebook outputs](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/pydata.html)
- Focus ring for [tabs](http://[::]:8000/user_guide/web-components.html#tabs) not yet implemented
- Some weird artifact for API "source" links, where a second blank focus ring appears at the end of the API method name:
  <img width="698" alt="screenshot showing the two focus rings" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/fe3722f1-97d2-46ed-a7ce-16055c71604b">
- Toggle (hamburger) button for left/primary mobile sidebar overlay (does not receive focus and does not work with space key or enter key). Open question: does it need to work with keyboard? 
- Toggle (hamburger) button for right/secondary mobile sidebar overlay (receives focus, has focus ring, but does not respond to space or enter key). Open question: does it need to work with keyboard? 
- [Button](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/web-components.html#badges-and-button-links) focus rings need to be changed to match the color of the button