### PR TITLE
Restyle Sphinx Design tabs

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -158,27 +158,48 @@ html[data-theme="light"] {
   > input {
     // Active tab label
     &:checked + label {
-      border-color: transparent transparent var(--pst-color-primary); // top LR bottom
+      border-style: solid solid none;
+      border-color: var(--pst-color-primary) var(--pst-color-primary)
+        transparent; // top LR bottom
+      border-width: 0.125rem 0.125rem 0;
+      border-radius: 0.125rem 0.125rem 0 0;
+      background-color: var(--pst-color-background);
+      transform: translateY(0.125rem);
+      box-shadow: 0.125rem -0.125rem 0.125rem rgba(0, 0, 0, 0.25);
+
       color: var(--pst-color-primary);
     }
 
+    &:focus-visible + label {
+      border: 0.125rem solid var(--pst-color-accent);
+      border-radius: 0.125rem;
+      background-color: var(--pst-color-accent-bg);
+      color: var(--pst-color-on-surface);
+    }
+
     // Hover label
-    &:not(:checked) + label:hover {
-      border-color: var(--pst-color-secondary);
+    &:not(:checked):not(:focus-visible) + label:hover {
+      border-color: transparent;
       color: var(--pst-color-secondary);
     }
   }
 
   // Tab label
   > label {
-    color: var(--pst-color-text-muted);
-    border-top: 0.125rem solid transparent; // so hover isn't just color change
-    padding-top: 0.5em; // same as bottom padding, so hover overline looks OK
-    // Hovered label
-    html &:hover {
-      color: var(--pst-color-secondary);
-      border-color: var(--pst-color-secondary);
-    }
+    color: var(--pst-color-on-surface);
+    border: 0.125rem solid transparent;
+    border-radius: 0.125rem 0.125rem 0px 0px;
+    background-color: var(--pst-color-surface);
+    padding: 0.5em 0.75em;
+    margin-inline-end: 0.25rem;
+  }
+
+  // panel
+  .sd-tab-content {
+    border: 0.125rem solid var(--pst-color-primary);
+    border-radius: 0.125rem;
+    box-shadow: unset;
+    padding: 0.625rem;
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -190,8 +190,9 @@ html[data-theme="light"] {
     border: 0.125rem solid transparent;
     border-radius: 0.125rem 0.125rem 0px 0px;
     background-color: var(--pst-color-surface);
-    padding: 0.5em 0.75em;
+    padding: 0 0.75em;
     margin-inline-end: 0.25rem;
+    line-height: 1.95;
   }
 
   // panel

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -165,7 +165,6 @@ html[data-theme="light"] {
       border-radius: 0.125rem 0.125rem 0 0;
       background-color: var(--pst-color-background);
       transform: translateY(0.125rem);
-
       color: var(--pst-color-primary);
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -165,7 +165,7 @@ html[data-theme="light"] {
       border-radius: 0.125rem 0.125rem 0 0;
       background-color: var(--pst-color-background);
       transform: translateY(0.125rem);
-      box-shadow: 0.125rem -0.125rem 0.125rem rgba(0, 0, 0, 0.25);
+      box-shadow: 0.125rem -0.125rem 0.125rem var(--pst-color-shadow);
 
       color: var(--pst-color-primary);
     }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -197,7 +197,7 @@ html[data-theme="light"] {
   // panel
   .sd-tab-content {
     border: 0.125rem solid var(--pst-color-primary);
-    border-radius: 0.125rem;
+    border-radius: 0.1875rem;
     box-shadow: unset;
     padding: 0.625rem;
   }

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -165,7 +165,6 @@ html[data-theme="light"] {
       border-radius: 0.125rem 0.125rem 0 0;
       background-color: var(--pst-color-background);
       transform: translateY(0.125rem);
-      box-shadow: 0.125rem -0.125rem 0.125rem var(--pst-color-shadow);
 
       color: var(--pst-color-primary);
     }


### PR DESCRIPTION
Note: this PR is against `feature-focus` branch **not** `main`. Style fixes related to interaction state (focus, hover, current) will be collected in small increments into `feature-focus` before being merged into `main`.

This PR implements @smeragoel's designs for the tab interface, which this theme inherits from [Sphinx Design](https://sphinx-design.readthedocs.io/en/pydata-theme/).

If you have access, see [Figma - Header Nav Tab](https://www.figma.com/file/BHkBFxg1Qg0h5RApUw1ZrR/PyData-Design-system---Ongoing?node-id=2123%3A1013&mode=dev). Otherwise, check the Read the Docs preview build in the GitHub checks below.