### PR TITLE
Obviate background-from-color-variable

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -7,14 +7,12 @@
 div.admonition.admonition-olive {
   border-color: hsl(60, 100%, 25%);
 }
-div.admonition.admonition-olive > .admonition-title:before {
+div.admonition.admonition-olive > .admonition-title {
   background-color: hsl(60, 100%, 14%);
+  color: white;
 }
 div.admonition.admonition-olive > .admonition-title:after {
   color: hsl(60, 100%, 25%);
-}
-div.admonition.admonition-olive > .admonition-title {
-  color: white;
 }
 /* end-custom-color */
 
@@ -30,15 +28,13 @@ div.admonition.admonition-icon > .admonition-title:after {
 div.admonition.admonition-youtube {
   border-color: hsl(0, 100%, 50%); /* YouTube red */
 }
-div.admonition.admonition-youtube > .admonition-title:before {
+div.admonition.admonition-youtube > .admonition-title {
   background-color: hsl(0, 99%, 18%);
+  color: white;
 }
 div.admonition.admonition-youtube > .admonition-title:after {
   color: hsl(0, 100%, 50%);
   content: "\f26c"; /* fa-solid fa-tv */
-}
-div.admonition.admonition-youtube > .admonition-title {
-  color: white;
 }
 /* end-custom-youtube */
 

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_color.scss
@@ -5,25 +5,6 @@
 // loading the math module
 @use "sass:math";
 
-// Set background color from a color variable
-//
-@mixin background-from-color-variable($color-variable) {
-  &:before {
-    content: "";
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    left: 0;
-    top: 0;
-    background-color: var(#{$color-variable});
-    z-index: -1;
-    // So that hovering over the text within background is still possible.
-    // Otherwise the background overlays the text and you cannot click or select easily.
-    // ref: https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events
-    pointer-events: none;
-  }
-}
-
 /**
 * Function to get items from nested maps
 */

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_color.scss
@@ -5,6 +5,24 @@
 // loading the math module
 @use "sass:math";
 
+// We must add ::before pseudo-element to some theme components (such as admonitions)
+// because users were instructed to customize the background color this way.
+@mixin legacy-backdrop-placeholder {
+  &:before {
+    content: "";
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    left: 0;
+    top: 0;
+    z-index: -1;
+    // So that hovering over the text within background is still possible.
+    // Otherwise the background overlays the text and you cannot click or select easily.
+    // ref: https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events
+    pointer-events: none;
+  }
+}
+
 /**
 * Function to get items from nested maps
 */

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -38,7 +38,7 @@ div.admonition,
     padding: 0.4rem 0.6rem 0.4rem 2rem;
     font-weight: var(--pst-admonition-font-weight-heading);
     position: relative;
-    @include background-from-color-variable(--pst-color-info-bg);
+    background-color: var(--pst-color-info-bg);
     // now that we use solid colors we want the title on top
     z-index: 1;
 
@@ -63,9 +63,7 @@ div.admonition,
   &.attention {
     border-color: var(--pst-color-attention);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-attention-bg);
-      }
+      background-color: var(--pst-color-attention-bg);
 
       &:after {
         color: var(--pst-color-attention);
@@ -77,9 +75,7 @@ div.admonition,
   &.caution {
     border-color: var(--pst-color-warning);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-warning-bg);
-      }
+      background-color: var(--pst-color-warning-bg);
 
       &:after {
         color: var(--pst-color-warning);
@@ -91,9 +87,7 @@ div.admonition,
   &.warning {
     border-color: var(--pst-color-warning);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-warning-bg);
-      }
+      background-color: var(--pst-color-warning-bg);
 
       &:after {
         color: var(--pst-color-warning);
@@ -105,9 +99,7 @@ div.admonition,
   &.danger {
     border-color: var(--pst-color-danger);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-danger-bg);
-      }
+      background-color: var(--pst-color-danger-bg);
 
       &:after {
         color: var(--pst-color-danger);
@@ -119,9 +111,7 @@ div.admonition,
   &.error {
     border-color: var(--pst-color-danger);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-danger-bg);
-      }
+      background-color: var(--pst-color-danger-bg);
 
       &:after {
         color: var(--pst-color-danger);
@@ -133,9 +123,7 @@ div.admonition,
   &.hint {
     border-color: var(--pst-color-success);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-success-bg);
-      }
+      background-color: var(--pst-color-success-bg);
 
       &:after {
         color: var(--pst-color-success);
@@ -147,9 +135,7 @@ div.admonition,
   &.tip {
     border-color: var(--pst-color-success);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-success-bg);
-      }
+      background-color: var(--pst-color-success-bg);
 
       &:after {
         color: var(--pst-color-success);
@@ -161,9 +147,7 @@ div.admonition,
   &.important {
     border-color: var(--pst-color-attention);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-attention-bg);
-      }
+      background-color: var(--pst-color-attention-bg);
 
       &:after {
         color: var(--pst-color-attention);
@@ -175,9 +159,7 @@ div.admonition,
   &.note {
     border-color: var(--pst-color-info);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-info-bg);
-      }
+      background-color: var(--pst-color-info-bg);
 
       &:after {
         color: var(--pst-color-info);
@@ -189,9 +171,7 @@ div.admonition,
   &.seealso {
     border-color: var(--pst-color-success);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-success-bg);
-      }
+      background-color: var(--pst-color-success-bg);
 
       &:after {
         color: var(--pst-color-success);
@@ -203,9 +183,7 @@ div.admonition,
   &.admonition-todo {
     border-color: var(--pst-color-secondary);
     > .admonition-title {
-      &:before {
-        background-color: var(--pst-color-secondary-bg);
-      }
+      background-color: var(--pst-color-secondary-bg);
 
       &:after {
         color: var(--pst-color-secondary);

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -38,6 +38,7 @@ div.admonition,
     padding: 0.4rem 0.6rem 0.4rem 2rem;
     font-weight: var(--pst-admonition-font-weight-heading);
     position: relative;
+    @include legacy-backdrop-placeholder;
     background-color: var(--pst-color-info-bg);
     // now that we use solid colors we want the title on top
     z-index: 1;

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -20,7 +20,7 @@ blockquote {
     margin-bottom: 0;
   }
 
-  @include background-from-color-variable(--pst-color-on-background);
+  background-color: var(--pst-color-surface);
 
   //hack to make the text in the blockquote selectable
   &:before {

--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -20,6 +20,7 @@ blockquote {
     margin-bottom: 0;
   }
 
+  @include legacy-backdrop-placeholder;
   background-color: var(--pst-color-surface);
 
   //hack to make the text in the blockquote selectable

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -11,6 +11,7 @@ span.guilabel {
   padding: 2.4px 6px;
   margin: auto 2px;
   position: relative;
+  @include legacy-backdrop-placeholder;
   background-color: var(--pst-color-info-bg);
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -11,8 +11,7 @@ span.guilabel {
   padding: 2.4px 6px;
   margin: auto 2px;
   position: relative;
-
-  @include background-from-color-variable(--pst-color-info-bg);
+  background-color: var(--pst-color-info-bg);
 }
 
 a.reference.download:before {

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -231,6 +231,7 @@ details.sd-dropdown {
       }
     }
 
+    @include legacy-backdrop-placeholder;
     background-color: var(--pst-sd-dropdown-bg-color) !important;
 
     // Add a left border with the same structure as our admonitions

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -231,9 +231,7 @@ details.sd-dropdown {
       }
     }
 
-    // Background color and border are grey by default
-    background-color: unset !important;
-    @include background-from-color-variable(--pst-sd-dropdown-bg-color);
+    background-color: var(--pst-sd-dropdown-bg-color) !important;
 
     // Add a left border with the same structure as our admonitions
     border-left: 0.2rem solid var(--pst-sd-dropdown-color) !important;


### PR DESCRIPTION
As far as I can tell, the `background-from-color-variable` mixin is no longer needed. It was used in four different Sass files. I think all of those styles show up on the following pages, so one way to check this PR is to compare the preview build URL against production. (In the following list, I've linked to the pages in production.)

- [Admonitions](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/admonitions.html): /examples/kitchen-sink/admonitions.html
- [Collapsible admonitions](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/web-components.html#dropdowns): /user_guide/web-components.html#dropdowns
- [Blocks](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/blocks.html): /examples/kitchen-sink/blocks.html
- [GUI labels](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/generic.html#gui-labels): /examples/kitchen-sink/generic.html#gui-labels

### Backstory

While reviewing the changes in #1549 against [collapsible admonitions](https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/web-components.html#dropdowns), @smeragoel noticed that there were tiny sharp sideways rabbit ears pointing out from the top and bottom right corners:

![](https://github.com/pydata/pydata-sphinx-theme/assets/317883/e6d09ae8-0048-4c3c-809e-3b240698f268)

Looking into it, I traced the issue to the `background-from-color-variable` Sass mixin. When applied to an element, it adds a background via the `::before` pseudo-element. But because it was not setting the border radius of the background to the same border radius as the foreground element, this was causing the right-side corners of the background box to poke out from behind. 

The mixin was introduced in #743. I think that its purpose was to provide a way to set opacity on a background color, since CSS doesn't define a property like background-color-opacity. (That said, I'm not sure why one of the [Sass color functions](https://sass-lang.com/documentation/modules/color/#change) wasn't used since I think they've been around [since 2019](https://github.com/sass/dart-sass/releases/tag/1.23.0).)

However, the mixin's opacity property was removed in #1174, which removed the main reason for the mixin to even exist, as far as I can tell. This meant that in every place it was being used, it could be replaced with a simple `background-color` rule instead.



