### PR TITLE
Resolve current sidebar link notch and focus ring

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -123,6 +123,12 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
   &:active {
     color: var(--pst-color-link-hover);
   }
+
+  &:focus-visible {
+    border-radius: 0.125rem; // 2px at 100% zoom and 16px base font
+    box-shadow: $focus-ring-box-shadow;
+    outline: none;
+  }
 }
 
 // Sidebar current page link styles
@@ -135,9 +141,16 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
   font-weight: 600;
   color: var(--pst-color-primary);
   @if $link-hover-decoration-thickness {
-    border-left: $link-hover-decoration-thickness
-      solid
+    $notch-shadow: inset
+      $link-hover-decoration-thickness
+      0px
+      0px
       var(--pst-color-primary);
+    box-shadow: $notch-shadow;
+    &:focus-visible {
+      box-shadow: $notch-shadow, $focus-ring-box-shadow;
+      outline: none;
+    }
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -125,7 +125,6 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
   }
 
   &:focus-visible {
-    border-radius: 0.125rem; // 2px at 100% zoom and 16px base font
     box-shadow: $focus-ring-box-shadow;
     outline: none;
   }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -127,6 +127,7 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
   &:focus-visible {
     box-shadow: $focus-ring-box-shadow;
     outline: none;
+    z-index: 10; // keep focus ring on top (prevent the link-sidebar-current notch from lying on top of the ring)
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -182,9 +182,9 @@ pre {
 
 // Focus ring
 //
-// Note: The Bootstrap stylesheet provides the focus ring (customized via Sass
-// variables in _bootstrap.scss) in some cases. This rules covers all other
-// cases.
+// Note: The Bootstrap stylesheet provides the focus ring (customized by this
+// theme via Sass variables in _bootstrap.scss) in some cases. This rule covers
+// all other cases.
 :focus-visible {
   outline: $focus-ring-outline;
   box-shadow: none; // override Bootstrap

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -45,6 +45,9 @@ button.btn.version-switcher__button {
         top: 0;
       }
     }
+    &:focus-visible {
+      z-index: 10; // keep focus ring on top (prevent the hover background of the next dropdown item from covering the ring)
+    }
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
@@ -48,8 +48,4 @@ nav.page-toc {
       }
     }
   }
-
-  :focus-visible {
-    border-radius: 0.125rem;
-  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
@@ -47,5 +47,9 @@ nav.page-toc {
         color: var(--pst-color-link-hover);
       }
     }
+
+    &:focus-visible {
+      border-radius: $focus-ring-radius;
+    }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -29,7 +29,7 @@
   }
 
   :focus-visible {
-    border-radius: 0.125rem;
+    border-radius: $focus-ring-radius;
   }
 
   // These items will define the height of the header

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -123,6 +123,10 @@
           &:focus:not(:hover):not(:active) {
             background-color: inherit;
           }
+
+          &:focus-visible {
+            z-index: 10; // keep focus ring on top (prevent the hover background of the next dropdown item from covering the ring)
+          }
         }
 
         // Hide the menu unless show has been clicked

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -23,7 +23,6 @@
     font-size: var(--pst-sidebar-font-size);
   }
 
-  // Focus styles
   :focus-visible {
     border-radius: 0.125rem;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -24,7 +24,7 @@
   }
 
   :focus-visible {
-    border-radius: 0.125rem;
+    border-radius: $focus-ring-radius;
   }
 
   // override bootstrap when navlink are displayed in the sidebar

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -31,3 +31,7 @@ $animation-time: 200ms;
 * UI shaping and padding
 */
 $admonition-border-radius: 0.25rem;
+
+// In this theme, some focus rings have rounded corners while others do not.
+// This variable sets the border radius for the rounded focus rings.
+$focus-ring-radius: 0.125rem; // 2px at 100% zoom and 16px base font.


### PR DESCRIPTION
### Feature branch PR

Note: this PR is against `feature-focus` branch **not** `main`. Style fixes related to interaction state (focus, hover, current) will be collected in small increments into `feature-focus` before being merged into `main`.

### Changes

This PR is a follow-up to #1549. It does three things:

1. Modifies the `link-sidebar-current` mixin so that it when a sidebar link is "current" the mixin applies two box-shadows: one for the notch and one for the focus ring.
2. Replaces scattered 0.125rem values with a new Sass variable, `$focus-ring-radius`
3. Sets the z-index in a few places to prevent the focus ring from being partially covered by adjacent elements

### Backstory

@jorisvandenbossche noted that my change to the `link-sidebar-current` mixin caused a [glitch](https://github.com/pydata/pydata-sphinx-theme/pull/1549/files#r1388648863). The mixin puts a kind of notch on the left side of a sidebar link if the user is at that link. It achieved this effect with an inset box-shadow, which unfortunately overrides Bootstrap's focus ring styling for `.nav-link`s:

```scss
.nav-link {
  // ...
  &:focus-visible {
    outline: 0;
    box-shadow: $nav-link-focus-box-shadow;
  }
```

So this PR modifies the mixin so that when a sidebar link is "current" the mixin applies two box-shadows: one for the notch and one for the focus ring.