### PR TITLE
Fix tabbed panel colors

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -179,7 +179,7 @@ html[data-theme="light"] {
         transparent; // top LR bottom
       border-width: 0.125rem 0.125rem 0;
       border-radius: 0.125rem 0.125rem 0 0;
-      background-color: var(--pst-color-background);
+      background-color: var(--pst-color-on-background);
       transform: translateY(0.125rem);
       color: var(--pst-color-primary);
     }
@@ -207,6 +207,10 @@ html[data-theme="light"] {
     padding: 0 0.75em;
     margin-inline-end: 0.25rem;
     line-height: 1.95;
+
+    html[data-theme="dark"] & {
+      background-color: var(--pst-color-on-background);
+    }
   }
 
   // panel
@@ -215,6 +219,7 @@ html[data-theme="light"] {
     border-radius: 0.1875rem;
     box-shadow: unset;
     padding: 0.625rem;
+    background-color: var(--pst-color-on-background);
   }
 }
 


### PR DESCRIPTION
### Feature branch PR

Note: this PR is against `feature-focus` branch **not** `main`. Style fixes related to interaction state (focus, hover, current) will be collected in small increments into `feature-focus` before being merged into `main`.

### Figma mismatches this PR corrects 

Upon re-examining the design in Figma, I realized that I got the colors for the tabbed panel slightly wrong. This PR corrects them. cc @smeragoel

The Figma specifies that the tabbed panel background color should be set to `on-background` (in light mode, this color is the same white as `background`, but in dark mode `on-background` is lighter than `background`). Also the inactive tabs cannot share the same background color variable for both light and dark mode. In light mode, the background color for the inactive tabs should be `surface`, but in dark mode, it should be `on-background`, as the following screenshot shows:

<img width="620" alt="" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/b5a5e699-046f-4b4e-b0cb-5a21d59c3f3a">
