### PR TITLE
Add Brightway to Featured Example Gallery Grid

### DIFF
--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -11,6 +11,9 @@
 - title: Bokeh
   link: https://docs.bokeh.org/en/latest/
   img-bottom: ../_static/gallery/bokeh.png
+- title: Brightway
+  link: https://docs.brightway.dev/en/latest/
+  img-bottom: ../_static/gallery/brightway.png
 - title: Jupyter
   link: https://docs.jupyter.org/en/latest/
   img-bottom: ../_static/gallery/jupyter.png

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -25,8 +25,6 @@ Thanks for your support!
 
 - title: Binder
   link: https://mybinder.readthedocs.io/en/latest/index.html
-- title: Brightway
-  link: https://docs.brightway.dev/en/latest/
 - title: cashocs
   link: https://cashocs.readthedocs.io/en/stable/
 - title: CuPy

--- a/tests/warning_list.txt
+++ b/tests/warning_list.txt
@@ -9,6 +9,7 @@ WARNING: image file not readable: _static/gallery/jupyter.png
 WARNING: image file not readable: _static/gallery/arviz.png
 WARNING: image file not readable: _static/gallery/sepal.png
 WARNING: image file not readable: _static/gallery/matplotlib.png
+WARNING: image file not readable: _static/gallery/brightway.png
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.count'. Check your autosummary_generate setting.
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.index'. Check your autosummary_generate setting.
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResultBytes.count'. Check your autosummary_generate setting.


### PR DESCRIPTION
Hello again, dear `pydata-sphinx-theme` devs - again many thanks for your hard work on this fantastic theme!

In these two PRs:

 - https://github.com/pydata/pydata-sphinx-theme/pull/1119
 - https://github.com/pydata/pydata-sphinx-theme/pull/1232

I had a discussion with @12rambau on adding our documentation [`brightway-documentation`](https://github.com/brightway-lca/brightway-documentation) to the featured example gallery. 

At the time, @12rambau [suggested](https://github.com/pydata/pydata-sphinx-theme/pull/1232#pullrequestreview-1556597708) that I add our project to the ["Other projects using this theme"](https://github.com/pydata/pydata-sphinx-theme/blob/370db00c79ab1ed957c939fcbae5910e8b3e312a/docs/examples/gallery.md?plain=1#L17) section, [while remaining open](https://github.com/pydata/pydata-sphinx-theme/pull/1232#issuecomment-1456354472) for moving to the featured example gallery later.

We have since completed our second revision of our documentation pages.

From what I can see in the other examples, ours is still the only project using git submodules (+GitHub Actions for updating) extensively. It took quite a while to set up, but we now have a rather neat setup, which is [explained in detail in the readme](https://github.com/brightway-lca/brightway-documentation#github-actions)

I am certain this would be useful to projects looking to include docstrings from multiple repos in their API documentation. Despite the obvious advantages of a monorepo, some communities won't be able to give up distributed repos anytime soon.

With the extensive technical description in our readme, we feel that our page provides real benefit for potential (first-time) users of the theme that want to use submodules or GH actions in their documentation.

Let us know what you think. Thanks!