### PR TITLE
Buttons meet WCAG criteria

### DIFF
--- a/docs/user_guide/styling.rst
+++ b/docs/user_guide/styling.rst
@@ -117,18 +117,18 @@ Here is an overview of the colors available in the theme (change theme mode to s
     </style>
 
     <p>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-primary sd-bg-text-primary">primary</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-secondary sd-bg-text-secondary">secondary</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-accent sd-bg-text-secondary">accent</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-success sd-bg-text-success">success</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-info sd-bg-text-info">info</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-warning sd-bg-text-warning">warning</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-danger sd-bg-text-danger">danger</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-background">background</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-on-background">on-background</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-surface">surface</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-on-surface sd-bg-text-primary">on-surface</span>
-      <span class="sd-sphinx-override sd-badge pst-badge pst-target">target</span>
+      <span class="sd-badge pst-badge pst-primary sd-bg-text-primary">primary</span>
+      <span class="sd-badge pst-badge pst-secondary sd-bg-text-secondary">secondary</span>
+      <span class="sd-badge pst-badge pst-accent sd-bg-text-secondary">accent</span>
+      <span class="sd-badge pst-badge pst-success sd-bg-text-success">success</span>
+      <span class="sd-badge pst-badge pst-info sd-bg-text-info">info</span>
+      <span class="sd-badge pst-badge pst-warning sd-bg-text-warning">warning</span>
+      <span class="sd-badge pst-badge pst-danger sd-bg-text-danger">danger</span>
+      <span class="sd-badge pst-badge pst-background">background</span>
+      <span class="sd-badge pst-badge pst-on-background">on-background</span>
+      <span class="sd-badge pst-badge pst-surface">surface</span>
+      <span class="sd-badge pst-badge pst-on-surface sd-bg-text-primary">on-surface</span>
+      <span class="sd-badge pst-badge pst-target">target</span>
     </p>
 
 

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -179,6 +179,19 @@ pre {
   background-color: var(--pst-color-secondary);
   border: none;
 
+  .fa-arrow-up {
+    // Using margin instead of a space character prevents the space between the
+    // icon and the text from being underlined when the button is hovered.
+    margin-inline-end: 0.5em;
+  }
+
+  @include link-style-hover;
+  &:hover {
+    text-decoration-thickness: 1px;
+    background-color: var(--pst-violet-600);
+    color: var(--pst-color-secondary-text);
+  }
+
   &:focus-visible {
     box-shadow: none;
     outline: $focus-ring-outline;

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -178,6 +178,13 @@ pre {
   color: var(--pst-color-secondary-text);
   background-color: var(--pst-color-secondary);
   border: none;
+
+  &:focus-visible {
+    box-shadow: none;
+    outline: $focus-ring-outline;
+    outline-color: var(--pst-color-secondary);
+    outline-offset: $focus-ring-width;
+  }
 }
 
 // Focus ring

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -312,7 +312,7 @@ details.sd-dropdown {
 html {
   .sd-btn {
     min-width: 2.25rem;
-    padding: 0.3125rem 0.75rem 0.4375rem;
+    padding: 0.3125rem 0.75rem 0.4375rem; // 5px 12px 7px
 
     @include link-style-hover; // override Sphinx Design
     &:hover {
@@ -321,7 +321,8 @@ html {
   }
 
   @each $name in $sd-semantic-color-names {
-    .sd-btn-#{$name} {
+    .sd-btn-#{$name},
+    .sd-btn-outline-#{$name} {
       &:focus-visible {
         // Override Sphinx Design's use of -highlight colors. The -highlight
         // colors are 15% darker, so this would create the effect of darkening

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -309,6 +309,13 @@ details.sd-dropdown {
 * Buttons (which in Sphinx Design are actually links that look like buttons)
 */
 html {
+  .sd-btn {
+    @include link-style-hover; // override Sphinx Design
+    &:hover {
+      text-decoration-thickness: 1px;
+    }
+  }
+
   @each $name in $sd-semantic-color-names {
     .sd-btn-#{$name} {
       &:focus-visible {

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -304,3 +304,23 @@ details.sd-dropdown {
     }
   }
 }
+
+/*******************************************************************************
+* Buttons (which in Sphinx Design are actually links that look like buttons)
+*/
+.bd-content {
+  @each $name in $sd-semantic-color-names {
+    .sd-btn-#{$name} {
+      &:focus-visible {
+        // Override Sphinx Design's use of -highlight colors. The -highlight
+        // colors are 15% darker, so this would create the effect of darkening
+        // the button when focused but we just want the button to have a focus
+        // ring of the same (non-highlight) color.
+        background-color: var(--sd-color-#{$name}) !important;
+        border-color: var(--sd-color-#{$name}) !important;
+        outline: var(--sd-color-#{$name}) solid $focus-ring-width;
+        outline-offset: $focus-ring-width;
+      }
+    }
+  }
+}

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -310,6 +310,9 @@ details.sd-dropdown {
 */
 html {
   .sd-btn {
+    min-width: 2.25rem;
+    padding: 0.3125rem 0.75rem 0.4375rem;
+
     @include link-style-hover; // override Sphinx Design
     &:hover {
       text-decoration-thickness: 1px;

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -307,6 +307,7 @@ details.sd-dropdown {
 
 /*******************************************************************************
 * Buttons (which in Sphinx Design are actually links that look like buttons)
+* ref: https://sphinx-design.readthedocs.io/en/pydata-theme/badges_buttons.html#buttons
 */
 html {
   .sd-btn {

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -308,7 +308,7 @@ details.sd-dropdown {
 /*******************************************************************************
 * Buttons (which in Sphinx Design are actually links that look like buttons)
 */
-.bd-content {
+html {
   @each $name in $sd-semantic-color-names {
     .sd-btn-#{$name} {
       &:focus-visible {

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -61,7 +61,7 @@ or not theme_secondary_sidebar_items %}
   {# the scroll to top button #}
   <button type="button" class="btn rounded-pill" id="pst-back-to-top">
     <i class="fa-solid fa-arrow-up"></i>
-    {{ _("Back to top") }}
+    {{- _("Back to top") -}}
   </button>
 
   {# checkbox to toggle primary sidebar #}


### PR DESCRIPTION
**IMPORTANT: this PR is against `feature-focus` branch not `main`.** Style fixes related to interaction state (focus, hover, current) will be collected in small increments into `feature-focus` before being merged into `main`.

This PR is to make the buttons throughout the Pydata Sphinx Theme meet the specification in the [Figma Buttons page](https://www.figma.com/file/BHkBFxg1Qg0h5RApUw1ZrR/PyData-Design-system---Ongoing?type=design&node-id=1228-2373&mode=design&t=W4YKRZXBJ30eIgh3-0). Image below taken from Figma for those who don't have access.

Take a look at the effects of this PR on the buttons at the following preview build URL: 

- https://pydata-sphinx-theme--1589.org.readthedocs.build/en/1589/user_guide/web-components.html#badges-and-button-links

![visual guide for buttons in default, hover and focus states](https://github.com/pydata/pydata-sphinx-theme/assets/317883/f5f3e3e1-8c54-425b-94e0-90a2925af58b)

Cross-reference: https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/36
