### PR TITLE
Up/down chevrons and "expand"/"collapse" for Sphinx-togglebutton

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,4 +1,5 @@
-# See https://github.com/sphinx-doc/sphinx/blob/6.1.x/babel.cfg
+# See https://github.com/python-babel/babel/blob/2a1709a7768f6f07c3d2dbfdb03d3c8a6bd80aef/docs/messages.rst#extraction-method-mapping-and-configuration
+[python: **.py]
 [jinja2: **.html]
 encoding = utf-8
 ignore_tags = script,style

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ from typing import Any, Dict
 
 import pydata_sphinx_theme
 from sphinx.application import Sphinx
+from sphinx.locale import _
 
 sys.path.append(str(Path(".").resolve()))
 
@@ -88,6 +89,11 @@ blog_authors = {
     "pydata": ("PyData", "https://pydata.org"),
     "jupyter": ("Jupyter", "https://jupyter.org"),
 }
+
+# -- sphinx_togglebutton options ---------------------------------------------
+togglebutton_hint = str(_("Click to expand"))
+togglebutton_hint_hide = str(_("Click to collapse"))
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_togglebutton.scss
@@ -3,10 +3,32 @@
  */
 
 .bd-content {
+  @mixin chevron-down {
+    .toggle-chevron-right {
+      transform: rotate(90deg); // point chevron down
+      transition: none; // match non-animated behavior of other chevrons on site
+    }
+  }
+
+  @mixin chevron-up {
+    .toggle-chevron-right {
+      transform: rotate(-90deg); // point chevron down
+      transition: none; // match non-animated behavior of other chevrons on site
+    }
+  }
+
   // Admonition toggles
   .admonition {
     button.toggle-button {
       color: inherit;
+
+      // When disclosure widget is closed
+      &.toggle-button-hidden {
+        @include chevron-down;
+      }
+
+      // When open
+      @include chevron-up;
     }
 
     // Focus ring
@@ -52,12 +74,18 @@
     // Over-ride border color to re-use our primary color
     summary {
       border-left: 3px solid var(--pst-color-primary);
+
+      @include chevron-down;
     }
 
     // When expanded, sharpen the bottom left and right corners of the focus ring
-    &[open] :focus-visible {
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
+    &[open] {
+      @include chevron-up;
+
+      :focus-visible {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+      }
     }
   }
 }

--- a/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
@@ -1,30 +1,45 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Oriol Abril-Pla <oriol.abril.pla@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 08:09-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Oriol Abril-Pla <oriol.abril.pla@gmail.com>, 2023\n"
-"Language-Team: Catalan (https://app.transifex.com/12rambau/teams/166811/ca/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: ca\n"
+"Language-Team: Catalan "
+"(https://app.transifex.com/12rambau/teams/166811/ca/)\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: docs/conf.py:94
+msgid "Click to expand"
+msgstr ""
+
+#: docs/conf.py:95
+msgid "Click to collapse"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Salta al contingut principal"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -38,93 +53,89 @@ msgstr "Error"
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr "Activeu JavaScript per habilitar la funcionalitat de cerca."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Rutes de navegació"
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Ruta de navegació"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Inici"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Copyright %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Edita a %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Edita"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr "Índexs"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Índex general"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Índex Global de Mòduls"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Índex de Mòduls Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Última actualització el %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Navegació del lloc"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "Continguts de la pàgina"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "pàgina anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "pàgina següent"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "següent"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "Navegació de la Secció"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Mostra el fitxer d'origen"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -137,7 +148,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "clar/fosc"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -148,18 +159,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\">Tema PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "pàgina anterior"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Rutes de navegació"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "anterior"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "pàgina següent"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "següent"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
@@ -1,12 +1,13 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 08:09-0700\n"
 "PO-Revision-Date: 2023-02-16 13:19-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -15,13 +16,27 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: docs/conf.py:94
+msgid "Click to expand"
+msgstr ""
+
+#: docs/conf.py:95
+msgid "Click to collapse"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -35,93 +50,89 @@ msgstr ""
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr ""
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr ""
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -132,7 +143,7 @@ msgstr ""
 msgid "light/dark"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -140,18 +151,18 @@ msgid ""
 "%(theme_version)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr ""
+#~ msgid "Breadcrumbs"
+#~ msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr ""
+#~ msgid "GitHub"
+#~ msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr ""
+#~ msgid "GitLab"
+#~ msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr ""
+#~ msgid "Bitbucket"
+#~ msgstr ""
+
+#~ msgid "Twitter"
+#~ msgstr ""
+

--- a/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
@@ -1,30 +1,46 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 08:09-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
-"Language-Team: Spanish (https://app.transifex.com/12rambau/teams/166811/es/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Language-Team: Spanish "
+"(https://app.transifex.com/12rambau/teams/166811/es/)\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 "
+"? 1 : 2;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: docs/conf.py:94
+msgid "Click to expand"
+msgstr ""
+
+#: docs/conf.py:95
+msgid "Click to collapse"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Saltar al contenido principal"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -36,96 +52,91 @@ msgstr "Error"
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:9
 msgid "Please activate JavaScript to enable the search functionality."
-msgstr ""
-"Por favor, active JavaScript para habilitar la funcionalidad de búsqueda."
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Migas de pan"
+msgstr "Por favor, active JavaScript para habilitar la funcionalidad de búsqueda."
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Miga de pan"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Inicio"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Copyright %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Editar en %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Editar"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr "Índices"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Índice General"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Índice Global de Módulos"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Índice de Módulos Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Actualizado por última vez en %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Navegación del sitio"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "En esta página"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "página anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "siguiente página"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "siguiente"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "Navegación del sección"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Mostrar el código"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -138,7 +149,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "claro/oscuro"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -149,18 +160,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\">Tema PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "página anterior"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Migas de pan"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "anterior"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "siguiente página"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "siguiente"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
@@ -1,30 +1,46 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 08:09-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
-"Language-Team: French (https://app.transifex.com/12rambau/teams/166811/fr/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Language-Team: French "
+"(https://app.transifex.com/12rambau/teams/166811/fr/)\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: docs/conf.py:94
+msgid "Click to expand"
+msgstr ""
+
+#: docs/conf.py:95
+msgid "Click to collapse"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Passer au contenu principal"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -38,93 +54,89 @@ msgstr "Erreur"
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr "Veuillez activer le JavaScript pour que la recherche fonctionne."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Fils d'Ariane"
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Fil d'Ariane"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Accueil"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Copyright %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Modifier sur %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Modifier"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr "Indices"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Index général"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Index général des modules"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Index des modules Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Mis à jour le %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Navigation du site"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "Sur cette page"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "page précédente"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "précédente"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "page suivante"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "suivante"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "Navigation de la section"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Montrer le code source"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -137,7 +149,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "clair/sombre"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -148,18 +160,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\">Thème PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "page précédente"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Fils d'Ariane"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "précédente"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "page suivante"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "suivante"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
@@ -1,30 +1,47 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 08:09-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
-"Language-Team: Russian (https://app.transifex.com/12rambau/teams/166811/ru/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Language-Team: Russian "
+"(https://app.transifex.com/12rambau/teams/166811/ru/)\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) "
+"|| (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: docs/conf.py:94
+msgid "Click to expand"
+msgstr ""
+
+#: docs/conf.py:95
+msgid "Click to collapse"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Перейти к основному содержанию"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -38,93 +55,89 @@ msgstr "Ошибка"
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr "Активируйте JavaScript, чтобы включить функцию поиска."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Навигационная цепочка"
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Хлебная крошка"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Главная"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\\\"%(path)s\\\">Копирайт</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Копирайт %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Редактировать на %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Редактировать"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Общий указатель"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Глобальный индекс модулей"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Индекс модулей Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Последнее обновление %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Навигация по сайту"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "На этой странице"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "предыдущая страница"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "назад"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "следующая страница"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "далее"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "В этом разделе"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Просмотр исходного кода"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -137,7 +150,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "светлая/темная"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -148,18 +161,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\\\">PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "предыдущая страница"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Навигационная цепочка"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "назад"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "следующая страница"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "далее"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/sphinx.pot
+++ b/src/pydata_sphinx_theme/locale/sphinx.pot
@@ -8,20 +8,34 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 08:09-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: docs/conf.py:94
+msgid "Click to expand"
+msgstr ""
+
+#: docs/conf.py:95
+msgid "Click to collapse"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -35,93 +49,89 @@ msgstr ""
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr ""
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr ""
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -132,7 +142,7 @@ msgstr ""
 msgid "light/dark"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -140,18 +150,3 @@ msgid ""
 "%(theme_version)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr ""


### PR DESCRIPTION
**IMPORTANT: this PR is against `feature-focus` branch not `main`.** Style fixes related to interaction state (focus, hover, current) will be collected in small increments into `feature-focus` before being merged into `main`.

This PR attempts to make the Sphinx-togglebuttons in the theme match the design. Toggle icon chevrons should only point up and down not to the right, and the toggle text should say "Click to expand" and "Click to collapse" instead of "Click to show" and "Click to hide":

![](https://github.com/pydata/pydata-sphinx-theme/assets/317883/555eb4e5-9b5f-4dd1-b6e9-0040d4432ae8)

For admonitions, "Click to collapse" will not show unless an upstream PR to sphinx-togglebutton is accepted: https://github.com/executablebooks/sphinx-togglebutton/pull/59


🔗 PR preview link: https://github.com/pydata/pydata-sphinx-theme/pull/1606