### PR TITLE
Update translation files

### DIFF
--- a/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
@@ -1,30 +1,37 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Oriol Abril-Pla <oriol.abril.pla@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 07:30-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Oriol Abril-Pla <oriol.abril.pla@gmail.com>, 2023\n"
-"Language-Team: Catalan (https://app.transifex.com/12rambau/teams/166811/ca/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: ca\n"
+"Language-Team: Catalan "
+"(https://app.transifex.com/12rambau/teams/166811/ca/)\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Salta al contingut principal"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -38,93 +45,89 @@ msgstr "Error"
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr "Activeu JavaScript per habilitar la funcionalitat de cerca."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Rutes de navegació"
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Ruta de navegació"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Inici"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Copyright %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Edita a %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Edita"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr "Índexs"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Índex general"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Índex Global de Mòduls"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Índex de Mòduls Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Última actualització el %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Navegació del lloc"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "Continguts de la pàgina"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "pàgina anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "pàgina següent"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "següent"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "Navegació de la Secció"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Mostra el fitxer d'origen"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -137,7 +140,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "clar/fosc"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -148,18 +151,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\">Tema PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "pàgina anterior"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Rutes de navegació"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "anterior"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "pàgina següent"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "següent"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
@@ -1,12 +1,13 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 07:30-0700\n"
 "PO-Revision-Date: 2023-02-16 13:19-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -15,13 +16,19 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -35,93 +42,89 @@ msgstr ""
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr ""
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr ""
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -132,7 +135,7 @@ msgstr ""
 msgid "light/dark"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -140,18 +143,18 @@ msgid ""
 "%(theme_version)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr ""
+#~ msgid "Breadcrumbs"
+#~ msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr ""
+#~ msgid "GitHub"
+#~ msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr ""
+#~ msgid "GitLab"
+#~ msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr ""
+#~ msgid "Bitbucket"
+#~ msgstr ""
+
+#~ msgid "Twitter"
+#~ msgstr ""
+

--- a/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
@@ -1,30 +1,38 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 07:30-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
-"Language-Team: Spanish (https://app.transifex.com/12rambau/teams/166811/es/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Language-Team: Spanish "
+"(https://app.transifex.com/12rambau/teams/166811/es/)\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 "
+"? 1 : 2;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Saltar al contenido principal"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -36,96 +44,91 @@ msgstr "Error"
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:9
 msgid "Please activate JavaScript to enable the search functionality."
-msgstr ""
-"Por favor, active JavaScript para habilitar la funcionalidad de búsqueda."
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Migas de pan"
+msgstr "Por favor, active JavaScript para habilitar la funcionalidad de búsqueda."
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Miga de pan"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Inicio"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Copyright %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Editar en %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Editar"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr "Índices"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Índice General"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Índice Global de Módulos"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Índice de Módulos Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Actualizado por última vez en %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Navegación del sitio"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "En esta página"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "página anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "anterior"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "siguiente página"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "siguiente"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "Navegación del sección"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Mostrar el código"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -138,7 +141,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "claro/oscuro"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -149,18 +152,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\">Tema PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "página anterior"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Migas de pan"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "anterior"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "siguiente página"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "siguiente"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
@@ -1,30 +1,38 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 07:30-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
-"Language-Team: French (https://app.transifex.com/12rambau/teams/166811/fr/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Language-Team: French "
+"(https://app.transifex.com/12rambau/teams/166811/fr/)\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Passer au contenu principal"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -38,93 +46,89 @@ msgstr "Erreur"
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr "Veuillez activer le JavaScript pour que la recherche fonctionne."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Fils d'Ariane"
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Fil d'Ariane"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Accueil"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Copyright %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Modifier sur %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Modifier"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr "Indices"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Index général"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Index général des modules"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Index des modules Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Mis à jour le %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Navigation du site"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "Sur cette page"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "page précédente"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "précédente"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "page suivante"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "suivante"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "Navigation de la section"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Montrer le code source"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -137,7 +141,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "clair/sombre"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -148,18 +152,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\">Thème PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "page précédente"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Fils d'Ariane"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "précédente"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "page suivante"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "suivante"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
@@ -1,30 +1,39 @@
 # English translations for pydata-sphinx-theme.
 # Copyright (C) 2023 PyData developers
-# This file is distributed under the same license as the pydata-sphinx-theme project.
-# 
+# This file is distributed under the same license as the pydata-sphinx-theme
+# project.
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
-# 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 07:30-0700\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
-"Language-Team: Russian (https://app.transifex.com/12rambau/teams/166811/ru/)\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.11.0\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Language-Team: Russian "
+"(https://app.transifex.com/12rambau/teams/166811/ru/)\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) "
+"|| (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr "Перейти к основному содержанию"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -38,93 +47,89 @@ msgstr "Ошибка"
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr "Активируйте JavaScript, чтобы включить функцию поиска."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr "Навигационная цепочка"
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr "Хлебная крошка"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr "Главная"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr "© <a href=\\\"%(path)s\\\">Копирайт</a> %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr "© Копирайт %(copyright)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr "Редактировать на %(provider)s"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr "Редактировать"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr "GitLab"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr "Bitbucket"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr "Twitter"
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr "Общий указатель"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr "Глобальный индекс модулей"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr "Индекс модулей Python"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr "Последнее обновление %(last_updated)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr "Навигация по сайту"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr "На этой странице"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr "предыдущая страница"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr "назад"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr "следующая страница"
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr "далее"
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr "В этом разделе"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr "Просмотр исходного кода"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -137,7 +142,7 @@ msgstr ""
 msgid "light/dark"
 msgstr "светлая/темная"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -148,18 +153,18 @@ msgstr ""
 "theme.readthedocs.io/en/stable/index.html\\\">PyData Sphinx</a> "
 "%(theme_version)s."
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr "предыдущая страница"
+#~ msgid "Breadcrumbs"
+#~ msgstr "Навигационная цепочка"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr "назад"
+#~ msgid "GitHub"
+#~ msgstr "GitHub"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr "следующая страница"
+#~ msgid "GitLab"
+#~ msgstr "GitLab"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr "далее"
+#~ msgid "Bitbucket"
+#~ msgstr "Bitbucket"
+
+#~ msgid "Twitter"
+#~ msgstr "Twitter"
+

--- a/src/pydata_sphinx_theme/locale/sphinx.pot
+++ b/src/pydata_sphinx_theme/locale/sphinx.pot
@@ -8,20 +8,26 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-02-16 14:32-0500\n"
+"POT-Creation-Date: 2023-12-21 07:30-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.9.1\n"
+"Generated-By: Babel 2.13.0\n"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:50
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:53
 msgid "Skip to main content"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html:64
+msgid "Back to top"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:5
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:28
 msgid "Search"
@@ -35,93 +41,89 @@ msgstr ""
 msgid "Please activate JavaScript to enable the search functionality."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:12
-msgid "Breadcrumbs"
-msgstr ""
-
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:13
 msgid "Breadcrumb"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:16
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:17
 msgid "Home"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:5
 #, python-format
 msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:7
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html:8
 #, python-format
 msgid "© Copyright %(copyright)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:10
 #, python-format
 msgid "Edit on %(provider)s"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:11
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/edit-this-page.html:12
 msgid "Edit"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:31
-msgid "GitHub"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:32
-msgid "GitLab"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:33
-msgid "Bitbucket"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html:34
-msgid "Twitter"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:4
 msgid "Indices"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:9
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:11
 msgid "General Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:13
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:15
 msgid "Global Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:17
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/indices.html:19
 msgid "Python Module Index"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/last-updated.html:4
 #, python-format
 msgid "Last updated on %(last_updated)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:5
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:6
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/navbar-nav.html:7
 msgid "Site Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html:8
 msgid "On this page"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:6
+msgid "previous page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:9
+msgid "previous"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:17
+msgid "next page"
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/prev-next.html:19
+msgid "next"
+msgstr ""
+
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html:4
 msgid "Section Navigation"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:4
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sourcelink.html:5
 msgid "Show Source"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sphinx-version.html:4
 #, python-format
 msgid ""
 "Created using <a href=\"https://www.sphinx-doc.org/\">Sphinx</a> "
@@ -132,7 +134,7 @@ msgstr ""
 msgid "light/dark"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:2
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
 #, python-format
 msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
@@ -140,18 +142,3 @@ msgid ""
 "%(theme_version)s."
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:6
-msgid "previous page"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:9
-msgid "previous"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:17
-msgid "next page"
-msgstr ""
-
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/footer-article/prev-next.html:19
-msgid "next"
-msgstr ""


### PR DESCRIPTION
Seems like translations haven't been updated in a while?

I checked out the `main` branch and ran the extract and update commands to update the `.pot` and `.po` files respectively, as described in [Internationalization](https://pydata-sphinx-theme.readthedocs.io/en/latest/community/topics/i18n.html#mark-natural-language-text-as-translateable):

```console
pybabel extract . -F babel.cfg -o src/pydata_sphinx_theme/locale/sphinx.pot -k '_ __ l_ lazy_gettext'
pybabel update -i src/pydata_sphinx_theme/locale/sphinx.pot -d src/pydata_sphinx_theme/locale -D sphinx
```