### PR TITLE
Fix: more efficient determination of when to hide primary sidebar

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
@@ -2,5 +2,5 @@
 <nav class="bd-docs-nav bd-links"
      aria-label="{{ _('Section Navigation') }}">
   <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
-  <div class="bd-toc-item navbar-nav">{{ sidebar_nav_html }}</div>
+  <div class="bd-toc-item navbar-nav">{{ pst_ns.sidebar_nav_html }}</div>
 </nav>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
@@ -2,5 +2,15 @@
 <nav class="bd-docs-nav bd-links"
      aria-label="{{ _('Section Navigation') }}">
   <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
-  <div class="bd-toc-item navbar-nav">{{ pst_ns.sidebar_nav_html }}</div>
+  <div class="bd-toc-item navbar-nav">
+    {{- generate_toctree_html(
+      "sidebar",
+      show_nav_level=theme_show_nav_level|int,
+      maxdepth=theme_navigation_depth|int,
+      collapse=theme_collapse_navigation|tobool,
+      includehidden=True,
+      titles_only=True
+      )
+    -}}
+  </div>
 </nav>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -7,9 +7,7 @@
 {%- extends "basic/layout.html" %}
 {%- import "static/webpack-macros.html" as _webpack with context %}
 {# A flag for whether we include a secondary sidebar based on the page metadata #}
-{% set remove_sidebar_secondary = (meta is defined and meta is not none
-and 'html_theme.sidebar_secondary.remove' in meta)
-or not theme_secondary_sidebar_items %}
+{% set remove_sidebar_secondary = (meta is defined and meta is not none and 'html_theme.sidebar_secondary.remove' in meta) or not theme_secondary_sidebar_items %}
 {%- block css %}
   {# The data-cfasync attribute disables CloudFlare's Rocket loader so that #}
   {# mode/theme are correctly set before the browser renders the page. #}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -6,19 +6,6 @@
 {% endset %}
 {%- extends "basic/layout.html" %}
 {%- import "static/webpack-macros.html" as _webpack with context %}
-{# Metadata and asset linking #}
-{# Create the sidebar links HTML here to re-use in a few places #}
-{# If we have no sidebar links, pop the links component from the sidebar list #}
-{%- set sidebar_nav_html = generate_toctree_html("sidebar",
-show_nav_level=theme_show_nav_level|int,
-maxdepth=theme_navigation_depth|int,
-collapse=theme_collapse_navigation|tobool,
-includehidden=True,
-titles_only=True)
--%}
-{% if sidebar_nav_html | length == 0 %}
-  {% set sidebars = sidebars | reject("in", "sidebar-nav-bs.html") | list %}
-{% endif %}
 {# A flag for whether we include a secondary sidebar based on the page metadata #}
 {% set remove_sidebar_secondary = (meta is defined and meta is not none
 and 'html_theme.sidebar_secondary.remove' in meta)

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -83,6 +83,9 @@ or not theme_secondary_sidebar_items %}
   <div class="bd-container">
     <div class="bd-container__inner bd-page-width">
       {# Primary sidebar #}
+      {% if get_sidebar_toctree_length(show_nav_level=theme_show_nav_level|int) == 0 %}
+        {% set sidebars = sidebars | reject("in", "sidebar-nav-bs.html") | list %}
+      {% endif %}
       <div class="bd-sidebar-primary bd-sidebar{% if not sidebars %} hide-on-wide{% endif %}">
         {% include "sections/sidebar-primary.html" %}
       </div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -83,6 +83,7 @@ or not theme_secondary_sidebar_items %}
   <div class="bd-container">
     <div class="bd-container__inner bd-page-width">
       {# Primary sidebar #}
+      {# If we have no sidebar TOC, pop the TOC component from the sidebar list #}
       {% if get_sidebar_toctree_length(show_nav_level=theme_show_nav_level|int) == 0 %}
         {% set sidebars = sidebars | reject("in", "sidebar-nav-bs.html") | list %}
       {% endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -1,21 +1,4 @@
 {% block docs_sidebar %}
-{# Create sidebar TOC links HTML here; if it's empty we'll skip adding its container #}
-{%- set pst_ns = namespace(
-  sidebar_nav_html=generate_toctree_html(
-    "sidebar",
-    show_nav_level=theme_show_nav_level|int,
-    maxdepth=theme_navigation_depth|int,
-    collapse=theme_collapse_navigation|tobool,
-    includehidden=True,
-    titles_only=True
-    )
-  )
--%}
-{# If we have no sidebar links, pop the links component from the sidebar list #}
-{% if pst_ns.sidebar_nav_html | length == 0 %}
-  {% set sidebars = sidebars | reject("in", "sidebar-nav-bs.html") | list %}
-{% endif %}
-
 {% if theme_navbar_center or theme_navbar_end or sidebars or theme_primary_sidebar_end %}
   {# Header items that will be displayed in the sidebar on mobile #}
   <div class="sidebar-header-items sidebar-primary__section">

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -1,4 +1,21 @@
 {% block docs_sidebar %}
+{# Create sidebar TOC links HTML here; if it's empty we'll skip adding its container #}
+{%- set pst_ns = namespace(
+  sidebar_nav_html=generate_toctree_html(
+    "sidebar",
+    show_nav_level=theme_show_nav_level|int,
+    maxdepth=theme_navigation_depth|int,
+    collapse=theme_collapse_navigation|tobool,
+    includehidden=True,
+    titles_only=True
+    )
+  )
+-%}
+{# If we have no sidebar links, pop the links component from the sidebar list #}
+{% if pst_ns.sidebar_nav_html | length == 0 %}
+  {% set sidebars = sidebars | reject("in", "sidebar-nav-bs.html") | list %}
+{% endif %}
+
 {% if theme_navbar_center or theme_navbar_end or sidebars or theme_primary_sidebar_end %}
   {# Header items that will be displayed in the sidebar on mobile #}
   <div class="sidebar-header-items sidebar-primary__section">

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -241,7 +241,7 @@ def add_toctree_functions(
         if kind == "sidebar":
             # Add bootstrap classes for first `ul` items
             for ul in soup("ul", recursive=False):
-                ul.attrs["class"] = ul.attrs.get("class", []) + ["nav", "bd-sidenav"]
+                ul.attrs["class"] = [*ul.attrs.get("class", []), "nav", "bd-sidenav"]
 
             # Add collapse boxes for parts/captions.
             # Wraps the TOC part in an extra <ul> to behave like chapters with toggles
@@ -289,22 +289,22 @@ def add_toctree_functions(
             if ul is None:
                 return
             if level <= (context["theme_show_toc_level"] + 1):
-                ul["class"] = ul.get("class", []) + ["visible"]
+                ul["class"] = [*ul.get("class", []), "visible"]
             for li in ul("li", recursive=False):
-                li["class"] = li.get("class", []) + [f"toc-h{level}"]
+                li["class"] = [*li.get("class", []), f"toc-h{level}"]
                 add_header_level_recursive(li.find("ul", recursive=False), level + 1)
 
         add_header_level_recursive(soup.find("ul"), 1)
 
         # Add in CSS classes for bootstrap
         for ul in soup("ul"):
-            ul["class"] = ul.get("class", []) + ["nav", "section-nav", "flex-column"]
+            ul["class"] = [*ul.get("class", []), "nav", "section-nav", "flex-column"]
 
         for li in soup("li"):
-            li["class"] = li.get("class", []) + ["nav-item", "toc-entry"]
+            li["class"] = [*li.get("class", []), "nav-item", "toc-entry"]
             if li.find("a"):
                 a = li.find("a")
-                a["class"] = a.get("class", []) + ["nav-link"]
+                a["class"] = [*a.get("class", []), "nav-link"]
 
         # If we only have one h1 header, assume it's a title
         h1_headers = soup.select(".toc-h1")
@@ -368,7 +368,7 @@ def add_collapse_checkboxes(soup: BeautifulSoup) -> None:
             continue
 
         # Add a class to indicate that this has children.
-        element["class"] = classes + ["has-children"]
+        element["class"] = [*classes, "has-children"]
 
         # We're gonna add a checkbox.
         toctree_checkbox_count += 1

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -1,6 +1,6 @@
 """Methods to build the toctree used in the html pages."""
 
-from functools import lru_cache
+from functools import cache
 from itertools import count
 from typing import Iterator, List, Union
 from urllib.parse import urlparse
@@ -37,7 +37,7 @@ def add_toctree_functions(
 ) -> None:
     """Add functions so Jinja templates can add toctree objects."""
 
-    @lru_cache(maxsize=None)
+    @cache
     def get_or_create_id_generator(base_id: str) -> Iterator[str]:
         for n in count(start=1):
             if n == 1:
@@ -53,7 +53,7 @@ def add_toctree_functions(
         """
         return next(get_or_create_id_generator(base_id))
 
-    @lru_cache(maxsize=None)
+    @cache
     def generate_header_nav_before_dropdown(n_links_before_dropdown):
         """The cacheable part."""
         try:
@@ -191,7 +191,7 @@ def add_toctree_functions(
 
     # Cache this function because it is expensive to run, and because Sphinx
     # somehow runs this twice in some circumstances in unpredictable ways.
-    @lru_cache(maxsize=None)
+    @cache
     def generate_toctree_html(
         kind: str, startdepth: int = 1, show_nav_level: int = 1, **kwargs
     ) -> Union[BeautifulSoup, str]:
@@ -276,7 +276,7 @@ def add_toctree_functions(
 
         return soup
 
-    @lru_cache(maxsize=None)
+    @cache
     def generate_toc_html(kind: str = "html") -> BeautifulSoup:
         """Return the within-page TOC links in HTML."""
         if "toc" not in context:

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -70,7 +70,8 @@ def add_toctree_functions(
     def get_sidebar_toctree_length(
         startdepth: int = 1, show_nav_level: int = 1, **kwargs
     ):
-        return len(get_unrendered_local_toctree(app, pagename, startdepth))
+        toctree = get_unrendered_local_toctree(app, pagename, startdepth)
+        return 0 if toctree is None else len(toctree)
 
     @cache
     def get_or_create_id_generator(base_id: str) -> Iterator[str]:


### PR DESCRIPTION
I think this PR will allow SciPy to finally upgrade past theme version 0.9.0. TL;DR:

- **the background** is that our `layout.html` template currently renders the primary-sidebar TOC (in order to check if it's empty and assign classes accordingly). That TOC is later displayed in an `%include%`d template `sidebar-nav-bs`
- **the problem** is that for some reason this really really slows down scipy doc builds. I think it has something to do with the fact that the TOC is rendered multiple times unnecessarily on each page, (though I never quite tracked down why that was happening)
- **the solution** is to check the *unrendered* TOC in `layout.html` and use that to assign classes, and only instantiate the rendered TOC inside `sidebar-nav-bs`. This was ultimately a fairly easy refactoring, but took forever to figure out (there was a long dead-end trying a `SphinxPostTransform` only to realize that the sidebars aren't part of the doctree 🤦🏻)

Locally for me, the scipy build goes from 7:41 to 9:19.  Still a bit slower, but nowhere near the ~30 minutes we were seeing with version `0.10` and later prior to this PR. I also tested building our own docs on this PR, and they're not noticeably slower (didn't do timings) and the left sidebar is still correctly hidden / not taking space on our homepage and on the "test of no sidebar" page.

closes #889 

SIDE NOTE: I replaced `lru_cache(maxsize=None)` with plain `@cache` since they're equivalent and `@cache` is slightly faster.

@choldgraf I know your availability is poor but since you wrote a lot of the code I've touched you're probably the most qualified to review it, if you have time.

cc @tupui @stefanv @melissawm 