### PR TITLE
Bump minimum Python from 3.8 to 3.9; add 3.12 to CIs

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -44,22 +44,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         sphinx-version: [""]
         include:
           # macos test
           - os: macos-latest
-            python-version: "3.11"
+            python-version: "3.12"
           # windows test
           - os: windows-latest
-            python-version: "3.11"
+            python-version: "3.12"
           # old Sphinx test
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
             sphinx-version: "old"
           # dev Sphinx test
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             sphinx-version: "dev"
     # needed to cache the browsers for the accessibility tests
     env:
@@ -93,7 +93,7 @@ jobs:
       - name: Run tests
         run: pytest -m "not a11y" --color=yes --cov --cov-report=xml
       - name: Upload to Codecov
-        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -111,7 +111,7 @@ jobs:
             ${{ runner.os }}-pw-
 
       - name: Run accessibility tests with playwright
-        if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
+        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
         run: |
           nox -s a11y
         continue-on-error: true
@@ -123,14 +123,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         sphinx-version: [""]
         include:
           - os: ubuntu-latest
-            python-version: "3.8"
+            python-version: "3.9"
             sphinx-version: "old"
           - os: ubuntu-latest
-            python-version: "3.11"
+            python-version: "3.12"
             sphinx-version: "dev"
     env:
       SPHINX_VERSION: ${{ matrix.sphinx-version }}
@@ -162,7 +162,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -205,7 +205,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "pydata-sphinx-theme"
 description = "Bootstrap-based Sphinx theme from the PyData community"
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "sphinx>=5.0",
   "beautifulsoup4",
@@ -36,10 +36,10 @@ maintainers = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Framework :: Sphinx",
   "Framework :: Sphinx :: Theme",
   "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
Python 3.8 Active support ended over 2.5 years ago, and its security support ends in ~9 months. Meanwhile 3.12 has been out for 3 months already. This cycles our CI version range to drop 3.8 and add 3.12.

It also changes `pyproject.toml` to require 3.9 as the new minimum version. This is not strictly necessary, but I'd like to add 3.9-only features in #1609, so this enables that.

Assuming CIs are happy I'll plan to self-merge this one so that #1609 can go in and we can cut a release soon.