### PR TITLE
fix: allow user to control the back-to-top button presence

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,7 +189,7 @@ html_theme_options = {
         "version_match": version_match,
     },
     "navigation_with_keys": False,
-    "back_to_top_button": False,
+    # "back_to_top_button": False,
     # "search_bar_position": "navbar",  # TODO: Deprecated - remove in future version
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,6 +189,7 @@ html_theme_options = {
         "version_match": version_match,
     },
     "navigation_with_keys": False,
+    "back_to_top_button": False,
     # "search_bar_position": "navbar",  # TODO: Deprecated - remove in future version
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "pydata_sphinx_theme",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "6.5.1",
+        "@fortawesome/fontawesome-free": "6.1.2",
         "@popperjs/core": "^2.11.6",
         "bootstrap": "^5.2.2",
         "compare-versions": "^5.0.3"
@@ -3652,9 +3652,9 @@
       "dev": true
     },
     "@fortawesome/fontawesome-free": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
-      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw=="
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
+      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ=="
     },
     "@jest/schemas": {
       "version": "29.6.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "pydata_sphinx_theme",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "6.1.2",
+        "@fortawesome/fontawesome-free": "6.5.1",
         "@popperjs/core": "^2.11.6",
         "bootstrap": "^5.2.2",
         "compare-versions": "^5.0.3"
@@ -3652,9 +3652,9 @@
       "dev": true
     },
     "@fortawesome/fontawesome-free": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.1.2.tgz",
-      "integrity": "sha512-XwWADtfdSN73/udaFm+1mnGIj/ShDZNFMe/PRoqv3FhQ4GNI2PUN70yFTPsjq65Lw2C9i4TG5/hTbxXIXVCiqQ=="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
+      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw=="
     },
     "@jest/schemas": {
       "version": "29.6.3",

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -172,7 +172,7 @@ pre {
   z-index: $zindex-tooltip;
   position: fixed;
   display: none;
-  top: 80vh;
+  top: 90vh;
   left: 50vw;
   transform: translate(-50%);
   color: var(--pst-color-secondary-text);

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -43,7 +43,7 @@
   {# A tiny helper pixel to detect if we've scrolled #}
   <div id="pst-scroll-pixel-helper"></div>
 
-  {%- if html_back_to_top_button %}
+  {%- if theme_back_to_top_button %}
   {# the scroll to top button #}
   <button type="button" class="btn rounded-pill" id="pst-back-to-top">
     <i class="fa-solid fa-arrow-up"></i>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -43,11 +43,13 @@
   {# A tiny helper pixel to detect if we've scrolled #}
   <div id="pst-scroll-pixel-helper"></div>
 
+  {%- if back_to_top_button %}
   {# the scroll to top button #}
   <button type="button" class="btn rounded-pill" id="pst-back-to-top">
     <i class="fa-solid fa-arrow-up"></i>
     {{ _("Back to top") }}
   </button>
+  {%- endif %}
 
   {# checkbox to toggle primary sidebar #}
   <input type="checkbox"

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -43,7 +43,7 @@
   {# A tiny helper pixel to detect if we've scrolled #}
   <div id="pst-scroll-pixel-helper"></div>
 
-  {%- if back_to_top_button %}
+  {%- if html_back_to_top_button %}
   {# the scroll to top button #}
   <button type="button" class="btn rounded-pill" id="pst-back-to-top">
     <i class="fa-solid fa-arrow-up"></i>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -37,6 +37,7 @@ pygment_light_style = a11y-high-contrast-light
 pygment_dark_style = a11y-high-contrast-dark
 logo =
 surface_warnings = True
+back_to_top_button = True
 
 # Template placement in theme layouts
 navbar_start = navbar-logo


### PR DESCRIPTION
fix #1497 

- I placed the back-to-top button closer to the bottom of the page (90%) so that it's less conflicting with the content of the article.
- I added a parameter to control if the button should or should not be displayed. by default `back-to-top-button` is set to `True`. Set it to false and the button will be removed from all pages.  
