### PR TITLE
fix: align all breadcrumb elements

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_breadcrumbs.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_breadcrumbs.scss
@@ -12,7 +12,7 @@ ul.bd-breadcrumbs {
 
   li.breadcrumb-item {
     display: flex;
-    align-items: baseline;
+    align-items: center;
 
     // Style should look like heavier in-page links
     // keeping visited in the default link colour


### PR DESCRIPTION
fix #1577 

It took me way too much time to figure out but I think I get it now.

working example from our documentation: https://pydata-sphinx-theme--1619.org.readthedocs.build/en/1619/examples/subpages/subsubpages/subsubpage1.html