### PR TITLE
fix: align the search button with other icons

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ html_theme_options = {
     "navbar_center": ["version-switcher", "navbar-nav"],
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],
-    "navbar_persistent": ["search-button", "search-field"],
+    "navbar_persistent": ["search-button"],
     # "primary_sidebar_end": ["custom-template", "sidebar-ethical-ads"],
     # "article_footer_items": ["test", "test"],
     # "content_footer_items": ["test", "test"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ html_theme_options = {
     "navbar_center": ["version-switcher", "navbar-nav"],
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],
-    # "navbar_persistent": ["search-button"],
+    "navbar_persistent": ["search-button", "search-field"],
     # "primary_sidebar_end": ["custom-template", "sidebar-ethical-ads"],
     # "article_footer_items": ["test", "test"],
     # "content_footer_items": ["test", "test"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ html_theme_options = {
     "navbar_center": ["version-switcher", "navbar-nav"],
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],
-    "navbar_persistent": ["search-button"],
+    # "navbar_persistent": ["search-button"],
     # "primary_sidebar_end": ["custom-template", "sidebar-ethical-ads"],
     # "article_footer_items": ["test", "test"],
     # "content_footer_items": ["test", "test"],

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -75,8 +75,6 @@
   align-items: center;
   align-content: center;
   color: var(--pst-color-text-muted);
-  // Needed to match other icons hover
-  padding: 0 0 0.25rem 0;
   border-radius: 0;
   @include icon-navbar-hover;
   @include focus-indicator;


### PR DESCRIPTION
Fix #1477

as usual with css a simple line change and everything fall into its rightfull place. I think we initially moved it up to align it with an older version of the navbar items. Removing the padding line set back the icon into place. I computed it locally but here is a screenshot: 

<img width="492" alt="image" src="https://github.com/pydata/pydata-sphinx-theme/assets/12596392/f4e01521-5650-4b31-b18a-0636f083a2d5">

