### PR TITLE
fix: border in search field

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -136,17 +136,17 @@
 .search-button-field {
   display: inline-flex;
   align-items: center;
-  border: var(--pst-color-border) solid 1px;
+  outline: var(--pst-color-border) solid 1px;
   border-radius: 1.5em;
   color: var(--pst-color-text-muted);
   padding: 0.5em;
   background-color: var(--pst-color-surface);
 
   &:hover {
-    border: 2px solid var(--pst-color-link-hover);
+    outline: 2px solid var(--pst-color-link-hover);
   }
   &:focus-visible {
-    border: 2px solid var(--pst-color-accent);
+    outline: 2px solid var(--pst-color-accent);
   }
 
   // The keyboard shotcut text


### PR DESCRIPTION
When hovering over the search field, the 2px border makes it expand and take up more space, causing the content around it to be shifted.

Using an outline, the search field doesn't use additional space.

This is more noticiable in sites like https://sphinx-book-theme.readthedocs.io/