### PR TITLE
fix: add anonymous crossoriginto fontawesome fonts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,7 +45,7 @@ const faPath = {fontAwesome: resolve(vendorPath, "fontawesome", vendorVersions.f
 function stylesheet(css){ return `<link href="{{ pathto('_static/${css}', 1) }}?digest=${this.hash}" rel="stylesheet" />`;}
 function preload(js){ return `<link rel="preload" as="script" href="{{ pathto('_static/${js}', 1) }}?digest=${this.hash}" />`;}
 function script(js){ return `<script src="{{ pathto('_static/${js}', 1) }}?digest=${this.hash}"></script>`;}
-function font(woff2){ return `<link rel="preload" as="font" type="font/woff2" crossorigin href="{{ pathto('_static/${woff2}', 1) }}" />`;}
+function font(woff2){ return `<link rel="preload" as="font" type="font/woff2" crossorigin="anonymous" href="{{ pathto('_static/${woff2}', 1) }}" />`;}
 
 /*******************************************************************************
  * the assets to load in the macro


### PR DESCRIPTION
Fix #1613 

@dbitouze I'm in unknown territory here so you should consider this PR experimental. 
I think the issue is relater to the definition of the links so I tried setting up more details in the webpack.config.js 

Could you try your build against this PR version and let us know ? 