### PR TITLE
Ensure code blocks (<pre>) are keyboard focusable

### DIFF
--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -23,9 +23,17 @@ class BootstrapHTML5TranslatorMixin:
         self.settings.table_style = "table"
 
     def starttag(self, *args, **kwargs):
-        """Ensure an aria-level is set for any heading role."""
+        """Perform small modifications to tags.
+
+        - ensure aria-level is set for any tag with heading role
+        - ensure <pre> tags have tabindex="0".
+        """
         if kwargs.get("ROLE") == "heading" and "ARIA-LEVEL" not in kwargs:
             kwargs["ARIA-LEVEL"] = "2"
+
+        if "pre" in args:
+            kwargs["tabindex"] = "0"
+
         return super().starttag(*args, **kwargs)
 
     def visit_table(self, node):

--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -40,8 +40,8 @@ class BootstrapHTML5TranslatorMixin:
     def visit_literal_block(self, node):
         """Modify literal blocks.
 
-        - ensure tabindex="0" for <pre> tags buried in the HTML tree that Sphinx
-          (with Pygments) generates for literal blocks
+        - add tabindex="0" to <pre> tags within the HTML tree of the literal
+          block
         """
         try:
             super().visit_literal_block(node)

--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -3,6 +3,7 @@
 import types
 
 import sphinx
+from docutils import nodes
 from packaging.version import Version
 from sphinx.application import Sphinx
 from sphinx.ext.autosummary import autosummary_table
@@ -35,6 +36,22 @@ class BootstrapHTML5TranslatorMixin:
             kwargs["tabindex"] = "0"
 
         return super().starttag(*args, **kwargs)
+
+    def visit_literal_block(self, node):
+        """Modify literal blocks.
+
+        - ensure tabindex="0" for <pre> tags buried in the HTML tree that Sphinx
+          (with Pygments) generates for literal blocks
+        """
+        try:
+            super().visit_literal_block(node)
+        except nodes.SkipNode:
+            # If the super method raises nodes.SkipNode, then we know it
+            # executed successfully and appended to self.body a string of HTML
+            # representing the code block, which we then modify.
+            html_string = self.body[-1]
+            self.body[-1] = html_string.replace("<pre", '<pre tabindex="0"')
+            raise nodes.SkipNode
 
     def visit_table(self, node):
         """Custom visit table method.


### PR DESCRIPTION
Fixes #1100.
Also closes one of the subtasks of #1428.
Inspired by #1104.

Whitespace-preserving [blocks](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/blocks.html) in our theme, such as code blocks, currently do not have an easy way for keyboard users to focus on them and use the arrow keys to scroll the block to the right in order to read long lines that overflow the width of the block. This is also an accessibility issue; if you have to use a mouse, a pointer, or your finger—anything other than just your keyboard—to scroll a code block, then that's a violation of [WCAG 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html).

----

Check the end user effects of this PR on the Read the Docs [preview build of the Kitchen Sink Blocks page](https://pydata-sphinx-theme--1636.org.readthedocs.build/en/1636/examples/kitchen-sink/blocks.html)