### PR TITLE
remove toggle button for secondary sidebar if empty

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -39,7 +39,7 @@
     </div>
   {% endfor %}
 
-  {% if not remove_sidebar_secondary %}
+  {% if not remove_sidebar_secondary and secondary_sidebar_items %}
     <label class="sidebar-toggle secondary-toggle" for="__secondary" tabindex="0">
       <span class="fa-solid fa-outdent"></span>
     </label>


### PR DESCRIPTION
This PR adds the fact that the toggle button for the secondary sidebar is not displayed when it is empty. 

See https://pydata-sphinx-theme.readthedocs.io/en/stable/examples/no-sidebar.html for example where the toggle button appears but the sidebar is empty.