### PR TITLE
Make bootstrap globally available

### DIFF
--- a/docs/community/topics/bootstrap.rst
+++ b/docs/community/topics/bootstrap.rst
@@ -60,3 +60,4 @@ JavaScript
 ^^^^^^^^^^
 
 -   Data attributes for all JavaScript plugins are now namespaced to help distinguish Bootstrap functionality from third parties and your code. For example, we use ``data-bs-toggle`` instead of ``data-toggle``.
+-   Bootstrap's `Programmatic API <https://getbootstrap.com/docs/5.0/getting-started/javascript/#programmatic-api>`_, ``bootstrap``, is also available. This API can be useful for initializing opt-in components that are not initialized by default such as `Popovers <https://getbootstrap.com/docs/5.0/components/popovers/#overview>`_.

--- a/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
+++ b/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
@@ -1,6 +1,6 @@
 // Import and setup functions to control Bootstrap's behavior.
 import "@popperjs/core";
-import { Tooltip } from "bootstrap";
+import * as bootstrap from "bootstrap";
 import { documentReady } from "./mixin";
 
 import "../styles/bootstrap.scss";
@@ -17,7 +17,9 @@ function TriggerTooltip() {
     document.querySelectorAll('[data-bs-toggle="tooltip"]')
   );
   tooltipTriggerList.map(function (tooltipTriggerEl) {
-    return new Tooltip(tooltipTriggerEl, { delay: { show: 500, hide: 100 } });
+    return new bootstrap.Tooltip(tooltipTriggerEl, {
+      delay: { show: 500, hide: 100 },
+    });
   });
 }
 
@@ -54,3 +56,5 @@ function showBackToTop() {
 documentReady(TriggerTooltip);
 documentReady(backToTop);
 documentReady(showBackToTop);
+
+window.bootstrap = bootstrap;


### PR DESCRIPTION
Fixes https://github.com/pydata/pydata-sphinx-theme/issues/1638

This PR proposes adding `boostrap` to `window`, so that one can [use `bootstrap` to enable Popovers](https://getbootstrap.com/docs/5.3/components/popovers/#enable-popovers) and the like.