### PR TITLE
DOC: Add missing "footer_center" in layout overview diagram

### DIFF
--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -170,6 +170,7 @@ For  complete reference of the existing option please see :ref:`the last section
             Footer
 
         ``footer_start``
+        ``footer_center``
         ``footer_end``
 
 Horizontal spacing


### PR DESCRIPTION
Small edit to the layout diagram at https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html#overview-of-theme-layout