### PR TITLE
FIX make theme switcher have consistent widths

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -19,6 +19,10 @@
       text-decoration: none;
       color: var(--pst-color-link-hover);
     }
+
+    .fa-lg {
+      aspect-ratio: 1 / 1;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1649.

The discrepancy is likely caused by upgrading fontawesome 6.1.2 to 6.5.1. In 6.1.2 `fa-sun`, `fa-moon`, and `fa-circle-half-stroke` are all 1:1 with (`viewBox: 0 0 512 512`). In 6.5.1 `fa-sun` and `fa0-circle-half-stroke` seem to be unchanged but `fa-moon` changedd to 3:4 (`viewBox: 0 0 384 512`).