### PR TITLE
Allow only theme_footer_center to be set

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/footer.html
@@ -1,4 +1,4 @@
-{% if theme_footer_start or theme_footer_end %}
+{% if theme_footer_start or theme_footer_center or theme_footer_end %}
 <div class="bd-footer__inner bd-page-width">
   {% if theme_footer_start %}
     <div class="footer-items__start">


### PR DESCRIPTION
With the current code, you need to have `theme_footer_start` or `theme_footer_end` *also* set in order to be able to use `theme_footer_center`.

This is probably not the intention?