### PR TITLE
FIX make search button closer to other icons in topbar

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -75,6 +75,7 @@
   align-items: center;
   align-content: center;
   color: var(--pst-color-text-muted);
+  padding: 0;
   border-radius: 0;
   @include icon-navbar-hover;
   @include focus-indicator;


### PR DESCRIPTION
Fixes #1658. Instead of in #1620 which directly removes the padding line, this forcefully sets padding to 0 to override horizontal paddings of `.btn-sm`.