### PR TITLE
Don't try to populate version switcher w/ relative path on local static site

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -348,7 +348,7 @@ async function fetchVersionSwitcherJSON(url) {
   } catch (err) {
     if (err instanceof TypeError) {
       if (!window.location.origin) {
-        // window.locaiton.origin is null for local static sites
+        // window.location.origin is null for local static sites
         // (ie. window.location.protocol == 'file:')
         //
         // TODO: Fix this to return the static version switcher by working out

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -564,6 +564,8 @@ if (hasVersionsJSON && (hasSwitcherMenu || wantsWarningBanner)) {
   const data = await fetchVersionSwitcherJSON(
     DOCUMENTATION_OPTIONS.theme_switcher_json_url
   );
+  // TODO: remove the `if(data)` once the `return null` is fixed within fetchVersionSwitcherJSON.
+  // We don't really want the switcher and warning bar to silently not work.
   if (data) {
     populateVersionSwitcher(data, versionSwitcherBtns);
     if (wantsWarningBanner) {

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -347,6 +347,14 @@ async function fetchVersionSwitcherJSON(url) {
     var result = new URL(url);
   } catch (err) {
     if (err instanceof TypeError) {
+      if (!window.location.origin) {
+        // window.locaiton.origin is null for local static sites
+        // (ie. window.location.protocol == 'file:')
+        //
+        // TODO: Fix this to return the static version switcher by working out
+        // how to get the correct path to the switcher JSON file on local static builds
+        return null;
+      }
       // assume we got a relative path, and fix accordingly. But first, we need to
       // use `fetch()` to follow redirects so we get the correct final base URL
       const origin = await fetch(window.location.origin, { method: "HEAD" });
@@ -556,9 +564,11 @@ if (hasVersionsJSON && (hasSwitcherMenu || wantsWarningBanner)) {
   const data = await fetchVersionSwitcherJSON(
     DOCUMENTATION_OPTIONS.theme_switcher_json_url
   );
-  populateVersionSwitcher(data, versionSwitcherBtns);
-  if (wantsWarningBanner) {
-    showVersionWarningBanner(data);
+  if (data) {
+    populateVersionSwitcher(data, versionSwitcherBtns);
+    if (wantsWarningBanner) {
+      showVersionWarningBanner(data);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/pydata/pydata-sphinx-theme/issues/1654. I figured it was an improvement to at least not even try to populate the version switcher instead of throwing an error and breaking search. Sadly my javascript isn't up to scratch to make a proper fix, but I've left a TODO comment.