### PR TITLE
only do security updates for NPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,4 @@ updates:
     labels:
       - "tag: dependencies"
       - "tag: javascript"
+    open-pull-requests-limit: 0 # security updates only


### PR DESCRIPTION
follow-up to #1668, so that we only get *security* updates for our NPM stack