### PR TITLE
Add "main" role to article in docs_body

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -100,7 +100,7 @@
               {% block docs_body %}
               {# This is empty and only shows up if text has been highlighted by the URL #}
                 {% include "components/searchbox.html" %}
-                <article class="bd-article">
+                <article class="bd-article" role="main">
                   {% block body %}{% endblock %}
                 </article>
               {% endblock docs_body %}


### PR DESCRIPTION
Fixes https://github.com/pydata/pydata-sphinx-theme/issues/1676

As mentioned in the above issue, I'm not totally certain that this is the appropriate place to put `role="main`", but it does seem to help.