### PR TITLE
FIX secondary sidebar persists even if it is empty

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -7,7 +7,8 @@
 {%- extends "basic/layout.html" %}
 {%- import "static/webpack-macros.html" as _webpack with context %}
 {# A flag for whether we include a secondary sidebar based on the page metadata #}
-{% set remove_sidebar_secondary = (meta is defined and meta is not none and 'html_theme.sidebar_secondary.remove' in meta) or not theme_secondary_sidebar_items %}
+{# Note: secondary_sidebar_items is an array set by set_secondary_sidebar_items() in utils.py #}
+{% set remove_sidebar_secondary = (meta is defined and meta is not none and 'html_theme.sidebar_secondary.remove' in meta) or secondary_sidebar_items|length == 0 %}
 {%- block css %}
   {# The data-cfasync attribute disables CloudFlare's Rocket loader so that #}
   {# mode/theme are correctly set before the browser renders the page. #}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1066,6 +1066,11 @@ def test_render_secondary_sidebar_dict(sphinx_build_factory) -> None:
     assert not sphinx_build.html_tree("section1/index.html").select("div.sourcelink")
     assert sphinx_build.html_tree("section2/index.html").select("div.sourcelink")
 
+    # Check that the secondary sidebar is completely removed for section1/index
+    assert not sphinx_build.html_tree("section1/index.html").select(
+        "div.bd-sidebar-secondary"
+    )
+
 
 def test_render_secondary_sidebar_dict_glob_subdir(sphinx_build_factory) -> None:
     """Test that the secondary sidebar can be built with a dict of templates that globs a subdir."""

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1178,3 +1178,20 @@ def test_role_main_for_search_highlights(sphinx_build_factory):
     """
     sphinx_build = sphinx_build_factory("base").build()
     assert sphinx_build.html_tree("index.html").select_one('[role="main"]')
+
+
+def test_sidebar_secondary_templates_all_empty(sphinx_build_factory) -> None:
+    """Test that the secondary sidebar is removed if all templates are empty."""
+    confoverrides = {
+        "html_theme_options": {
+            **COMMON_CONF_OVERRIDES,
+            "secondary_sidebar_items": ["page-toc", "sourcelink"],
+        },
+        "html_show_sourcelink": False,
+    }
+
+    # The page-toc component is empty because there is no in-page toc for page1
+    # The sourcelink component is empty because we disabled it in configuration
+    # Hence the secondary sidebar has all its templates empty and should be removed
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
+    assert not sphinx_build.html_tree("page1.html").select("div.bd-sidebar-secondary")


### PR DESCRIPTION
Fixes #1686.
Fixes #1691.

More details please see the referenced issues.