### PR TITLE
BUG - Ensure lists markers colours are visible

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -44,7 +44,8 @@ td {
   }
 }
 
-// override bootstrap background colors
+// override bootstrap table colors
 .table {
-  --bs-table-bg: transparent;
+  --bs-table-bg: transparent;  //background
+  --bs-table-color: var(--pst-color-text-base);  // ensure text and bullets are visible
 }

--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -46,6 +46,8 @@ td {
 
 // override bootstrap table colors
 .table {
-  --bs-table-bg: transparent;  //background
-  --bs-table-color: var(--pst-color-text-base);  // ensure text and bullets are visible
+  --bs-table-bg: transparent; //background
+  --bs-table-color: var(
+    --pst-color-text-base
+  ); // ensure text and bullets are visible
 }


### PR DESCRIPTION
Closes #1710 

Sets the table colour to `--pst-color-text-base` instead of the default Bootstrap colour