### PR TITLE
Revert changes to horizontal spacing in header nav

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -239,7 +239,7 @@ corresponds to the section in the docs that the user is currently reading.
     &:focus-visible {
       box-shadow: none; // override Bootstrap
       outline: 3px solid var(--pst-color-accent);
-      outline-offset: 2px;
+      outline-offset: 3px;
     }
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -201,7 +201,6 @@ corresponds to the section in the docs that the user is currently reading.
   > .dropdown-toggle {
     border-radius: 2px;
     color: var(--pst-color-text-muted);
-    font-weight: 700;
   }
 
   > .nav-link {
@@ -240,7 +239,7 @@ corresponds to the section in the docs that the user is currently reading.
     &:focus-visible {
       box-shadow: none; // override Bootstrap
       outline: 3px solid var(--pst-color-accent);
-      outline-offset: 3px;
+      outline-offset: 2px;
     }
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -88,7 +88,7 @@
     }
 
     li.pst-header-nav-item {
-      margin-inline: 2px; // breathing room so hover, focus styles do not overlap
+      margin-inline: 2px; // breathing room so hover and focus styles do not overlap
       &.dropdown {
         margin-inline: 4px;
         button {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -88,12 +88,15 @@
     }
 
     li.pst-header-nav-item {
-      margin-inline: 5px; // breathing room so hover, focus styles do not overlap
-      &:first-child {
-        margin-inline-start: 0;
+      margin-inline: 2px; // breathing room so hover, focus styles do not overlap
+      &.dropdown {
+        margin-inline: 4px;
+        button {
+          padding-inline: 8px;
+        }
       }
-      &:last-child {
-        margin-inline-end: 0;
+      a {
+        padding-inline: 6px;
       }
       @include header-link;
     }


### PR DESCRIPTION
### Note the base branch

`feature-focus`


### Effects of this PR

Spacing and font weight should be exactly the same as on main with this PR.

Hover and focus states are not as spaced apart as they previously were. Edges can now touch or overlap, as shown in the following two screenshots:

![hover underline touches but does not intersect focus ring](https://github.com/pydata/pydata-sphinx-theme/assets/317883/63c68b81-e6f4-406b-9166-3ac860f94e0f)

![hover ring edge and focus ring edges overlap but do not enter the interior of either ring](https://github.com/pydata/pydata-sphinx-theme/assets/317883/a755b2e7-bb36-43d7-804c-d08c5db9335f)

