### PR TITLE
Correctly specify the source path to a logo to copy_asset_file

### DIFF
--- a/src/pydata_sphinx_theme/logo.py
+++ b/src/pydata_sphinx_theme/logo.py
@@ -81,4 +81,4 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
                 f"The {kind} logo path '{path_image}' looks like a Sphinx template; "
                 "please provide a static logo image."
             )
-        copy_asset_file(full_logo_path, staticdir)
+        copy_asset_file(str(full_logo_path), staticdir)

--- a/src/pydata_sphinx_theme/logo.py
+++ b/src/pydata_sphinx_theme/logo.py
@@ -62,6 +62,7 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
     warning = partial(maybe_warn, app)
     logo = get_theme_options_dict(app).get("logo", {})
     staticdir = Path(app.builder.outdir) / "_static"
+    assert staticdir.is_absolute()
     for kind in ["light", "dark"]:
         path_image = logo.get(f"image_{kind}")
         if not path_image or isurl(path_image):
@@ -70,7 +71,9 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
             # file already exists in static dir e.g. because a theme has
             # bundled the logo and installed it there
             continue
-        if not (Path(app.srcdir) / path_image).exists():
+        full_logo_path = Path(app.srcdir) / path_image
+        assert full_logo_path.is_absolute()
+        if not full_logo_path.exists():
             warning(f"Path to {kind} image logo does not exist: {path_image}")
         # Ensure templates cannot be passed for logo path to avoid security vulnerability
         if path_image.lower().endswith("_t"):
@@ -78,4 +81,4 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
                 f"The {kind} logo path '{path_image}' looks like a Sphinx template; "
                 "please provide a static logo image."
             )
-        copy_asset_file(str(Path(app.srcdir) / path_image), staticdir)
+        copy_asset_file(full_logo_path, staticdir)

--- a/src/pydata_sphinx_theme/logo.py
+++ b/src/pydata_sphinx_theme/logo.py
@@ -78,4 +78,4 @@ def copy_logo_images(app: Sphinx, exception=None) -> None:
                 f"The {kind} logo path '{path_image}' looks like a Sphinx template; "
                 "please provide a static logo image."
             )
-        copy_asset_file(path_image, staticdir)
+        copy_asset_file(str(Path(app.srcdir) / path_image), staticdir)


### PR DESCRIPTION
I think this fixes https://github.com/pydata/pydata-sphinx-theme/issues/1385, I think that bug report is expecting to be able to pass a logo in the `docs/_static` directory but according to the docs here: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/branding.html#different-logos-for-light-and-dark-mode the path should be relative to conf.py.

I think the actual bug is that we were not passing the correct source to the sphinx copy function which exits silently (for some reason) if the source does not exist.