### PR TITLE
optimize figure bottom margin

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_figures.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_figures.scss
@@ -16,6 +16,11 @@ figure {
     margin-left: auto;
     margin-right: auto;
 
+    p {
+      margin-top: 0.3rem;
+      margin-bottom: 0.0rem;
+    }
+
     table.table {
       width: fit-content;
       margin-left: auto;

--- a/src/pydata_sphinx_theme/assets/styles/content/_figures.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_figures.scss
@@ -15,10 +15,11 @@ figure {
     color: var(--pst-color-text-muted);
     margin-left: auto;
     margin-right: auto;
+    margin-top: 0.3rem;
 
-    p {
-      margin-top: 0.3rem;
-      margin-bottom: 0rem;
+    & > p:last-child {
+      // Don't add extra margin to already existing figure bottom margin
+      margin-bottom: 0;
     }
 
     table.table {

--- a/src/pydata_sphinx_theme/assets/styles/content/_figures.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_figures.scss
@@ -18,7 +18,7 @@ figure {
 
     p {
       margin-top: 0.3rem;
-      margin-bottom: 0.0rem;
+      margin-bottom: 0rem;
     }
 
     table.table {


### PR DESCRIPTION
Avoid multiple `margin-bottom` by `p` and `figure`, that result in too wide a bottom margin.