### PR TITLE
fix missing sphinx testing dependencies

### DIFF
--- a/tools/github_actions_install.sh
+++ b/tools/github_actions_install.sh
@@ -7,11 +7,11 @@ export PYTHONUTF8=1
 if [[ "$SPHINX_VERSION" == "" ]]; then
     SPHINX_INSTALL=""
 elif [[ "$SPHINX_VERSION" == "dev" ]]; then
-    SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx"
+    SPHINX_INSTALL="git+https://github.com/sphinx-doc/sphinx [test]"
 elif [[ "$SPHINX_VERSION" == "old" ]]; then
-    SPHINX_INSTALL="sphinx==6.1.0"
+    SPHINX_INSTALL="sphinx[test]==6.1.0"
 else  # not used currently but easy enough
-    SPHINX_INSTALL="sphinx==$SPHINX_VERSION"
+    SPHINX_INSTALL="sphinx[test]==$SPHINX_VERSION"
 fi
 set -x  # print commands
 python -m pip install --upgrade pip wheel setuptools


### PR DESCRIPTION
cc @trallard this should fix the `defusedxml` errors.  It was added as a new optional dependency to sphinx within the last week. It seems like we were already getting all the other sphinx `[test]` deps in other ways (just by luck) so strictly speaking I could have just added `[test]` to the sphinx dev URL, but why leave it fragile if we don't have to.