### PR TITLE
Raise exception for response codes outside range 200-299

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
@@ -7,7 +7,7 @@ document.write(`<div class="bd-header-announcement"></div>`);
 fetch("{{ theme_announcement }}")
   .then(res => {
     if (!res.ok){
-      throw new Error("Error " + res.status)
+      throw new Error("Error " + res.status);
     }
     return res.text();})
   .then(data => {

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
@@ -5,7 +5,11 @@
 <script>
 document.write(`<div class="bd-header-announcement"></div>`);
 fetch("{{ theme_announcement }}")
-  .then(res => {return res.text();})
+  .then(res => {
+    if (!res.ok){
+      throw new Error("Error " + res.status)
+    }
+    return res.text();})
   .then(data => {
     if (data.length === 0) {
       console.log("[PST]: Empty announcement at: {{ theme_announcement }}");

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
@@ -7,7 +7,7 @@ document.write(`<div class="bd-header-announcement"></div>`);
 fetch("{{ theme_announcement }}")
   .then(res => {
     if (!res.ok){
-      throw new Error("Error " + res.status);
+      throw new Error("Error loading announcement banner:\n" + res.status);
     }
     return res.text();})
   .then(data => {


### PR DESCRIPTION
GitHub pages return valid HTML page when an element was removed. 

![image](https://github.com/pydata/pydata-sphinx-theme/assets/3826210/6b6ab715-91cb-4340-a9dc-b5ec249c35a9)

This PR add check for return code to not inject returned HTML if the return code is outside range 200-299. 