### PR TITLE
CI - Swap to trusted publisher for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,12 @@ on:
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
+
   publish:
     name: publish
     needs: [tests] # require tests to pass before deploy runs
+    permissions:
+      id-token: write # needed for PyPI upload
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -29,6 +32,3 @@ jobs:
           python -m build
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,34 +1,59 @@
-# This will run every time a tag is created and pushed to the repository.
+# This will run every time a release is created and published.
 # It calls our tests workflow via a `workflow_call`, and if tests pass
 # then it triggers our upload to PyPI for a new release.
 name: Publish to PyPI
 on:
   release:
-    types: ["published"]
+    types:
+      - published
+  workflow_dispatch:
+
+env:
+  FORCE_COLOR: "1" # Make tools pretty.
+
+permissions:
+  contents: read
+  id-token: write # needed for PyPI upload
 
 jobs:
+  # calls our tests workflow
   tests:
     uses: ./.github/workflows/tests.yml
 
-  publish:
-    name: publish
+  build-package:
+    name: "Build & verify PST package"
     needs: [tests] # require tests to pass before deploy runs
-    permissions:
-      id-token: write # needed for PyPI upload
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
+      - name: "Checkout repository 🛎"
         uses: actions/checkout@v4
-      - name: Set up Python 3.9
+
+      - name: "Set up Python 3.9"
         uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-      - name: Install gettext for translations
+
+      - name: "Install gettext for translations 🌐"
         run: |
           sudo apt-get install gettext
-      - name: Build package
-        run: |
-          python -m pip install -U pip build
-          python -m build
-      - name: Publish
+
+      - name: "Build and inspect package 📦"
+        uses: hynek/build-and-inspect-python-package@v2
+        id: baipp
+
+      - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }}
+
+  release-pypi:
+    runs-on: ubuntu-latest
+    needs: [build-package]
+    steps:
+      - name: "Download PST built package 📦"
+        uses: actions/download-artifact@v4
+        with:
+          name: PST-package
+          path: dist
+
+      - name: "Publish PST package to PyPI 🚀"
         uses: pypa/gh-action-pypi-publish@release/v1
+        # only publish if this is a published release by pydata
+        if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
Closes #1754 

I only modified the `publish.yml` workflow in this PR to remove the token. 

Separately, I already added this as a trusted publisher in PyPI.