### PR TITLE
Fix selector for table-layout rule

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
@@ -9,7 +9,7 @@
 /*******************************************************************************
  * nbsphinx
  */
-html div.rendered_html
+html div.rendered_html,
 // NBsphinx ipywidgets output selector
 html .jp-RenderedHTMLCommon {
   table {


### PR DESCRIPTION
Fixes #1063 (again, issue reopened).

I noticed a CSS selector that looks like it's missing a comma.

This CSS rule has some history:

- Add rule: #954 
- Increase selector specificity: #1018 
- Extend selector: #1089 