### PR TITLE
Allow paragraph elements to inherit color

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -22,7 +22,6 @@ body {
 p {
   margin-bottom: 1.15rem;
   font-size: 1em;
-  color: var(--pst-color-text-base);
 
   /* section header in docstring pages */
   &.rubric {

--- a/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
@@ -5,6 +5,7 @@
   width: 100%;
 
   p {
+    color: var(--pst-color-text-muted);
     margin: 0 0.3em;
     line-height: 1.3em;
   }

--- a/src/pydata_sphinx_theme/assets/styles/components/header/_header-logo.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/header/_header-logo.scss
@@ -17,6 +17,7 @@
 
   // If there's no logo image, we use a p element w/ the site title
   p {
+    color: var(--pst-color-text-base);
     margin-bottom: 0;
   }
 
@@ -27,16 +28,9 @@
     width: auto;
   }
 
-  // remove underline from brand title on default state
-  a {
-    text-decoration: none;
-  }
-  &:hover {
+  &:hover,
+  &:visited:hover {
     @include link-style-hover;
-  }
-  &:visited {
-    &:hover {
-      @include link-style-hover;
-    }
+    color: var(--pst-color-text-base);
   }
 }


### PR DESCRIPTION
As https://github.com/pydata/pydata-sphinx-theme/pull/741 describes, we make notebook cell outputs "white-ish" even when our theme is in dark mode because dark mode isn't well supported by the tools that render notebook cell outputs to HTML.

However, our theme also sets the font color of `p` elements to a CSS variable that changes depending on whether the theme is set to light or dark mode.

These two things combined to create a bug, by layering the following colors on top of each other:

1. dark site background 
2. light cell output background
3. light paragraph text

This made some of the text on notebook cell outputs invisible in dark mode. Here is a pair of before and after screenshots:

| before | after |
| ------ | ----- |
| ![pydata-sphinx-theme readthedocs io_en_latest_examples_pydata html (1)](https://github.com/pydata/pydata-sphinx-theme/assets/317883/b89323ed-5e70-47ab-a95b-e0a1336d3184) | ![pydata-sphinx-theme readthedocs io_en_latest_examples_pydata html](https://github.com/pydata/pydata-sphinx-theme/assets/317883/e6763d4e-52fe-4a32-813e-966466a640ba) |

Notice the text in the lower left that reads "100 rows × 26 columns"? That text is contained in a p-tag. 

This PR removes the CSS `color` rule on the `p` selector so that the paragraph can inherit its color from the nearest parent element that has it set. 

I think this change makes sense because both `body { color }` and `p { color }` are (before this PR) set to the same CSS variable, `var(--pst-color-text-base)`. In the past, [the paragraph color was set to a different CSS color variable](https://github.com/pydata/pydata-sphinx-theme/commit/ce4712dab4ae7c5ce8183ad2fd7ad86087e6873d#diff-d7ec2df902c26629189141725c9fee3e0074b05edd09a99e51feb8f8f2f19c0dR18), which was probably done to allow theme consumers to style copy color separate from the color of other text on the site, but since that [distinction has since been removed](https://github.com/pydata/pydata-sphinx-theme/pull/659), I don't think it makes sense to set `p { color }` explicitly. Just let it inherit.

