### PR TITLE
tiny CSS change

### DIFF
--- a/docs/user_guide/light-dark.rst
+++ b/docs/user_guide/light-dark.rst
@@ -59,14 +59,14 @@ For example to define a different background color for both the light and dark t
     html[data-theme="light"] {
 
         /* whatever you want to change */
-        background: white;
+        background-color: white;
     }
 
     /* anything related to the dark theme */
     html[data-theme="dark"] {
 
         /* whatever you want to change */
-        background: black;
+        background-color: black;
     }
 
 A complete list of the colors used in this theme can be found in the :doc:`CSS style section <styling>`.

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -15,7 +15,7 @@ body {
 
   // hack to avoid the black background on some browser including Safari
   &::-webkit-scrollbar-track {
-    background: var(--pst-color-background);
+    background-color: var(--pst-color-background);
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
@@ -25,7 +25,7 @@ html[data-theme="dark"] .bd-content {
     }
 
     .output_area.stderr {
-      background: var(--pst-color-danger);
+      background-color: var(--pst-color-danger);
     }
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -13,7 +13,7 @@
   z-index: $zindex-fixed;
 
   // Overrides bootstrap
-  background: var(--pst-color-on-background) !important;
+  background-color: var(--pst-color-on-background) !important;
   box-shadow: 0 0.125rem 0.25rem 0 var(--pst-color-shadow);
 
   width: 100%;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -142,7 +142,7 @@
     align-items: center;
 
     &:hover {
-      background: var(--pst-color-surface);
+      background-color: var(--pst-color-surface);
     }
 
     i {
@@ -158,7 +158,7 @@
     width: 100%;
     height: 100%;
     &:hover {
-      background: none;
+      background-color: none;
     }
     i {
       width: 30px;

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -289,7 +289,7 @@ $pst-semantic-colors: (
     *  which case assume they're already optimized for dark mode).
     */
     .bd-content img:not(.only-dark):not(.dark-light) {
-      background: rgb(255, 255, 255);
+      background-color: rgb(255, 255, 255);
       border-radius: 0.25rem;
     }
     // MathJax SVG outputs should be filled to same color as text.


### PR DESCRIPTION
This PR changes `background` properties to `background-color`. This should make no difference to the rendered site (when only color is given, the two properties yield identical results).  But for some reason, in the Firefox developer tools, specifying as `background-color` makes it show up in the "computed styles" list when filtering on either "background" or "color" (as you would expect), but when specified as just `background` the property doesn't show up for either search term.

Arguably this is a bug in the FF dev tools, but this workaround is fast and painless so why not?