### PR TITLE
Do not generate dropdown in sidebar.

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -6,7 +6,12 @@
     {% if theme_navbar_center %}
       <div class="sidebar-header-items__center">
         {% for navbar_item in theme_navbar_center %}
-          <div class="navbar-item">{% include navbar_item %}</div>
+          {#
+            In the mobile sidebar we do not want a dropdown, so set a large cutoff (999).
+          #}
+          {% with theme_header_links_before_dropdown=999 %}
+            <div class="navbar-item">{% include navbar_item %}</div>
+          {% endwith %}
         {% endfor %}
       </div>
     {% endif %}

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -2,7 +2,7 @@
 
 from functools import cache
 from itertools import count
-from typing import Iterator, List, Union
+from typing import Iterator, List, Tuple, Union
 from urllib.parse import urlparse
 
 import sphinx
@@ -101,8 +101,18 @@ def add_toctree_functions(
         return next(get_or_create_id_generator(base_id))
 
     @cache
-    def generate_header_nav_before_dropdown(n_links_before_dropdown):
-        """The cacheable part."""
+    def generate_header_nav_before_dropdown(
+        n_links_before_dropdown,
+    ) -> Tuple[str, List[str]]:
+        """Return html for navbar and dropdown.
+
+        Given the number of links before the dropdown, return the html for the navbar,
+        as well as the list of links to put in a dropdown.
+
+        Returns:
+            - HTML str for the navbar
+            - list of HTML str for the dropdown
+        """
         try:
             n_links_before_dropdown = int(n_links_before_dropdown)
         except Exception:

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -101,10 +101,14 @@ def add_toctree_functions(
         return next(get_or_create_id_generator(base_id))
 
     @cache
-    def generate_header_nav_before_dropdown(
+    def _generate_header_nav_before_dropdown(
         n_links_before_dropdown,
     ) -> Tuple[str, List[str]]:
         """Return html for navbar and dropdown.
+
+        .. warning::
+
+            Private helper function, do not call this directly.
 
         Given the number of links before the dropdown, return the html for the navbar,
         as well as the list of links to put in a dropdown.
@@ -236,7 +240,7 @@ def add_toctree_functions(
             n_links_before_dropdown:The number of links to show before nesting the remaining links in a Dropdown element.
             dropdown_text:Text of the dropdown element button.
         """
-        out, links_dropdown = generate_header_nav_before_dropdown(
+        out, links_dropdown = _generate_header_nav_before_dropdown(
             n_links_before_dropdown
         )
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -349,6 +349,8 @@ def test_navbar_header_dropdown(sphinx_build_factory, n_links) -> None:
     }
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     index_html = sphinx_build.html_tree("index.html")
+
+    # classic navbar:
     navbar = index_html.select("ul.bd-navbar-elements")[0]
     dropdowns = navbar.select("li.dropdown")
     standalone_links = navbar.select(".navbar-nav > li.nav-item:not(.dropdown)")
@@ -361,6 +363,13 @@ def test_navbar_header_dropdown(sphinx_build_factory, n_links) -> None:
     if n_links == 8:
         # There should be no dropdown and only standalone links
         assert standalone_links and not dropdowns
+
+    # sidebar nav should never have dropdown
+    navbar = index_html.select("ul.bd-navbar-elements")[1]
+    dropdowns = navbar.select("li.dropdown")
+    standalone_links = navbar.select(".navbar-nav > li.nav-item:not(.dropdown)")
+    assert len(standalone_links) == 7
+    assert len(dropdowns) == 0
 
 
 @pytest.mark.parametrize("dropdown_text", (None, "Other"))  # None -> default "More"


### PR DESCRIPTION
This should fix #1735, it is complementary to #1564 but with a different approach.

Instead of generating the same navbar as the fullpage width one, it generate one with no dropdowns, with this, any css that tries to make downtown looks like normal links in html becomes unnecessary.