### PR TITLE
Fix alignment of sidebar TOC entries

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -174,7 +174,6 @@ $sidebar-padding-right: 1rem;
 
     position: relative;
 
-    align-items: center;
     > .reference,
     .caption {
       margin-right: calc(


### PR DESCRIPTION
A bad style rule came through with #1564.

### Before 

![kitchen-sink-link-sidebar-toc-before](https://github.com/pydata/pydata-sphinx-theme/assets/317883/172ea2e3-0f67-4b77-9f96-406dbf58ee1d)

### After 

![kitchen-sink-link-sidebar-toc-after](https://github.com/pydata/pydata-sphinx-theme/assets/317883/00d68c88-1728-411f-8939-5500412631f0)
