### PR TITLE
Refactor navbar generating function

### DIFF
--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -113,7 +113,7 @@ def add_toctree_functions(
         return next(get_or_create_id_generator(base_id))
 
     @cache
-    def _generate_nav_info() -> List[LinkInfo]:
+    def _generate_nav_info(self) -> List[LinkInfo]:
         """Generate informations necessary to generate nav.
 
         Instead of messing with html later, having this as a util function
@@ -198,7 +198,7 @@ def add_toctree_functions(
         return links_data
 
     @cache
-    def generate_header_nav_before_dropdown(
+    def _generate_header_nav_before_dropdown(
         n_links_before_dropdown,
     ) -> Tuple[str, List[str]]:
         """Return html for navbar and dropdown.

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -113,7 +113,7 @@ def add_toctree_functions(
         return next(get_or_create_id_generator(base_id))
 
     @cache
-    def _generate_nav_info(self) -> List[LinkInfo]:
+    def _generate_nav_info() -> List[LinkInfo]:
         """Generate informations necessary to generate nav.
 
         Instead of messing with html later, having this as a util function
@@ -216,19 +216,25 @@ def add_toctree_functions(
             raise ValueError(
                 f"n_links_before_dropdown is not an int: {n_links_before_dropdown}"
             )
-        links_data = _generate_nav_info(n_links_before_dropdown)
+        links_data = _generate_nav_info()
 
         links_html = []
+        boilerplate = """
+            <li class="nav-item pst-header-nav-item{active}">
+              <a class="nav-link nav-{ext_int}" href="{href}">
+                {title}
+              </a>
+            </li>
+            """
         for link in links_data:
             links_html.append(
                 dedent(
-                    f"""
-                <li class="nav-item pst-header-nav-item {"current active" if link.is_current else ""}">
-                  <a class="nav-link {"nav-external" if link.is_external else "nav-internal"}" href="{ link.href}">
-                    { link.title }
-                  </a>
-                </li>
-            """
+                    boilerplate.format(
+                        active=" current active" if link.is_current else "",
+                        ext_int="external" if link.is_external else "internal",
+                        href=link.href,
+                        title=link.title,
+                    )
                 )
             )
 


### PR DESCRIPTION
Should fix #1773

This try to split the function into two parts: one that wrangle the
data,  one that generate html.

The generating the data part should be cacheable, while the other can be
made more flexible to be reusable in different part of the theme
(typically generating or not dropdowns in the sidebar or navbar).