### PR TITLE
Replace aside tags with div tags when converting rST to HTML

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -255,8 +255,7 @@ div.admonition,
 div.topic,
 div.topic.contents,
 // Docutils >= 0.18
-nav.contents,
-aside.topic {
+nav.contents {
   display: flex;
   flex-direction: column;
   background-color: var(--pst-color-surface);
@@ -288,7 +287,7 @@ aside.topic {
 /**
  * Sidebar directive
  */
-aside.sidebar {
+div.sidebar {
   border: 1px solid var(--pst-color-border);
   background-color: var(--pst-color-surface);
   border-radius: $admonition-border-radius;

--- a/src/pydata_sphinx_theme/assets/styles/content/_footnotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_footnotes.scss
@@ -14,8 +14,8 @@ a.footnote-reference {
   font-size: small;
 }
 
-// Docutils 0.18 uses an `aside.footnote` container with different internal structure
-aside.footnote {
+// Docutils 0.18 uses a container with different internal structure
+div.footnote {
   margin-bottom: 0.5rem;
   &:last-child {
     margin-bottom: 1rem;
@@ -27,5 +27,23 @@ aside.footnote {
 
   &:target {
     background-color: var(--pst-color-target);
+  }
+
+  // Replicate styles from Sphinx that target aside.footnote
+  > span {
+    float: left;
+    &:last-of-type {
+      padding-right: 0.5em;
+    }
+  }
+  > p {
+    margin-left: 2em;
+    &:last-of-type {
+      margin-bottom: 0em;
+      &:after {
+        content: "";
+        clear: both;
+      }
+    }
   }
 }

--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -84,6 +84,43 @@ class BootstrapHTML5TranslatorMixin:
         tag = self.starttag(node, "table", CLASS=" ".join(classes), **atts)
         self.body.append(tag)
 
+    def visit_sidebar(self, node):
+        """r/aside/div copy of Docutils html5 writer method.
+
+        Ref: https://www.docutils.org/docs/user/html.html#html5)
+        """
+        self.body.append(self.starttag(node, "div", CLASS="sidebar"))
+        self.in_sidebar = True
+
+    def depart_sidebar(self, node):
+        """r/aside/div copy of Docutils html5 writer method.
+
+        Ref: https://www.docutils.org/docs/user/html.html#html5
+        """
+        self.body.append("</div>\n")
+        self.in_sidebar = False
+
+    def visit_footnote(self, node) -> None:
+        """r/aside/div copy of Docutils html5 writer method.
+
+        Ref: https://www.docutils.org/docs/user/html.html#html5
+        """
+        label_style = self.settings.footnote_references
+        if not isinstance(node.previous_sibling(), type(node)):  # type: ignore[attr-defined]
+            self.body.append(f'<div class="footnote-list {label_style}">\n')
+        self.body.append(
+            self.starttag(node, "div", classes=[node.tagname, label_style], role="note")
+        )
+
+    def depart_footnote(self, node) -> None:
+        """r/aside/div copy of Docutils html5 writer method.
+
+        Ref: https://www.docutils.org/docs/user/html.html#html5
+        """
+        self.body.append("</div>\n")
+        if not isinstance(node.next_node(descend=False, siblings=True), type(node)):
+            self.body.append("</div>\n")
+
 
 def setup_translators(app: Sphinx):
     """Add bootstrap HTML functionality if we are using an HTML translator.

--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -113,7 +113,7 @@ class BootstrapHTML5TranslatorMixin:
         )
 
     def depart_footnote(self, node) -> None:
-        """r/aside/div copy of Docutils html5 writer method.
+        """r/aside/div copy of Sphinx-patched Docutils html5 writer method.
 
         Link to original: https://github.com/sphinx-doc/sphinx/blob/9ebc46a74fa766460c450bd60cdef46b98492939/sphinx/util/docutils.py#L193
         """

--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -87,7 +87,7 @@ class BootstrapHTML5TranslatorMixin:
     def visit_sidebar(self, node):
         """r/aside/div copy of Docutils html5 writer method.
 
-        Ref: https://www.docutils.org/docs/user/html.html#html5)
+        Link to original: https://github.com/docutils/docutils/blob/ff0b419256d6b7bfdd4363dd078c2255701de605/docutils/docutils/writers/html5_polyglot/__init__.py#L350
         """
         self.body.append(self.starttag(node, "div", CLASS="sidebar"))
         self.in_sidebar = True
@@ -95,15 +95,15 @@ class BootstrapHTML5TranslatorMixin:
     def depart_sidebar(self, node):
         """r/aside/div copy of Docutils html5 writer method.
 
-        Ref: https://www.docutils.org/docs/user/html.html#html5
+        Link to original: https://github.com/docutils/docutils/blob/ff0b419256d6b7bfdd4363dd078c2255701de605/docutils/docutils/writers/html5_polyglot/__init__.py#L355
         """
         self.body.append("</div>\n")
         self.in_sidebar = False
 
     def visit_footnote(self, node) -> None:
-        """r/aside/div copy of Docutils html5 writer method.
+        """r/aside/div copy of Sphinx-patched Docutils html5 writer method.
 
-        Ref: https://www.docutils.org/docs/user/html.html#html5
+        Link to original: https://github.com/sphinx-doc/sphinx/blob/9ebc46a74fa766460c450bd60cdef46b98492939/sphinx/util/docutils.py#L185
         """
         label_style = self.settings.footnote_references
         if not isinstance(node.previous_sibling(), type(node)):  # type: ignore[attr-defined]
@@ -115,7 +115,7 @@ class BootstrapHTML5TranslatorMixin:
     def depart_footnote(self, node) -> None:
         """r/aside/div copy of Docutils html5 writer method.
 
-        Ref: https://www.docutils.org/docs/user/html.html#html5
+        Link to original: https://github.com/sphinx-doc/sphinx/blob/9ebc46a74fa766460c450bd60cdef46b98492939/sphinx/util/docutils.py#L193
         """
         self.body.append("</div>\n")
         if not isinstance(node.next_node(descend=False, siblings=True), type(node)):


### PR DESCRIPTION
This is a proof of concept that fixes #1479.

I'm not entirely sure this is a maintainable approach, though. The problem is that if we upgrade Sphinx, then we will need to revisit the methods that this PR overrides to make sure that they aren't missing any features that may or may not have been added in a Sphinx update.

A better approach would be a simple substitution of `aside` for `div` tags when the doc pages get written as HTML, but I don't know how to do that.