### PR TITLE
[css] De-jumble header items at intermediate widths :)

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -38,8 +38,7 @@
     display: flex;
     align-items: center;
     height: fit-content;
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding: 0.5rem 1rem;
   }
 
   :focus-visible {
@@ -48,8 +47,6 @@
 
   // These items will define the height of the header
   .navbar-item {
-    height: var(--pst-header-height);
-    max-height: var(--pst-header-height);
     display: flex;
     align-items: center;
   }
@@ -63,6 +60,8 @@
       display: inherit;
       flex-grow: 1;
       padding: 0 0 0 0.5rem;
+      flex-wrap: wrap;
+      row-gap: 0.5rem;
     }
   }
 
@@ -71,7 +70,7 @@
   .navbar-header-items__start {
     display: flex;
     align-items: center;
-    flex-flow: wrap;
+    flex-flow: nowrap;
 
     // In case we wrap our items to multiple rows on small screens
     row-gap: 0;
@@ -97,6 +96,7 @@
   // Contains the navigation links within the navbar
   ul.navbar-nav {
     display: flex;
+    flex-wrap: wrap;
 
     @include media-breakpoint-up($breakpoint-sidebar-primary) {
       // Align on wide screens so the dropdown button is centered properly


### PR DESCRIPTION
Hello :):)

I've noticed this on a few different sites that use `pydata-sphinx-theme` - the header items can look a little jumbly at intermediate widths where the navbar items need to wrap, eg. the current `dev` docs:

<img width="984" alt="Screenshot 2024-04-24 at 7 41 19 PM" src="https://github.com/pydata/pydata-sphinx-theme/assets/12961499/0efba76c-7df0-447d-a9ad-f259deae6acb">

It just looks a little random - a lot of whitespace is wasted in the center, and the way that items wrap on the right is odd.

Here's a tiny little change to the CSS that changes the wrapping behavior and makes it look like this: 

<img width="932" alt="Screenshot 2024-04-24 at 7 36 50 PM" src="https://github.com/pydata/pydata-sphinx-theme/assets/12961499/c0c4440e-64bf-48ef-a0b3-23b1217a00f6">

Specifically, i disabled wrapping in the top-level containers `.navbar-header-items__end` et al. instead the lower-level `navbar-item`s can wrap, which works with the way that the template currently puts lists of links inside of them.

I also replaced the implicit vertical padding that came from giving items a fixed height to explicit padding in the outermost nav container.

The theme puts >5 header links in the `More` dropdown, but this still works in the case that the 5 displayed links are extremely long like this:
<img width="998" alt="Screenshot 2024-04-24 at 7 32 24 PM" src="https://github.com/pydata/pydata-sphinx-theme/assets/12961499/c8b154f5-1c35-4ff2-ab78-13f9626dfe98">

Ideally, rather than wrap, the `search` bar and items would just be hidden, but that would require JS since the CSS-only approach of setting a fixed height to the bar and hiding overflow wouldn't work here because the `More` menu would be cut off too. This is a very slight improvement imo that just makes things look a little tidier without any functional changes :)
