### PR TITLE
Fix blockquote color contrasts

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_quotes.scss
@@ -2,7 +2,7 @@
 blockquote {
   padding: 1em 1em;
   color: var(--pst-color-text-muted);
-  border-left: 0.25em solid var(--pst-color-border);
+  border-left: 0.25em solid var(--pst-color-blockquote-notch);
   border-radius: $admonition-border-radius;
   position: relative;
 
@@ -22,6 +22,11 @@ blockquote {
 
   @include legacy-backdrop-placeholder;
   background-color: var(--pst-color-surface);
+
+  // Ensure there is enough contrast against the background
+  a {
+    color: var(--pst-color-inline-code-links);
+  }
 
   //hack to make the text in the blockquote selectable
   &:before {

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -189,6 +189,11 @@ $pst-semantic-colors: (
     "light": rgba(23, 23, 26, 0.2),
     "dark": #{map-deep-get($color-palette, "gray", "700")},
   ),
+  "blockquote-notch": (
+    // gray-500 has a contrast ratio > 3.0 for foundation white and black
+    "light": #{map-deep-get($color-palette, "gray", "500")},
+    "dark": #{map-deep-get($color-palette, "gray", "500")},
+  ),
   "inline-code": (
     "light": #{map-deep-get($color-palette, "pink", "600")},
     "dark": #{map-deep-get($color-palette, "pink", "300")},

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -190,9 +190,10 @@ $pst-semantic-colors: (
     "dark": #{map-deep-get($color-palette, "gray", "700")},
   ),
   "blockquote-notch": (
-    // gray-500 has a contrast ratio > 3.0 for foundation white and black
+    // gray-500 has a contrast ratio > 3.0 against both the background and
+    // surface colors that it is sandwiched between
     "light": #{map-deep-get($color-palette, "gray", "500")},
-    "dark": #{map-deep-get($color-palette, "gray", "500")},
+    "dark": #{map-deep-get($color-palette, "gray", "400")},
   ),
   "inline-code": (
     "light": #{map-deep-get($color-palette, "pink", "600")},

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -190,7 +190,7 @@ $pst-semantic-colors: (
     "dark": #{map-deep-get($color-palette, "gray", "700")},
   ),
   "blockquote-notch": (
-    // gray-500 has a contrast ratio > 3.0 against both the background and
+    // These colors have a contrast ratio > 3.0 against both the background and
     // surface colors that it is sandwiched between
     "light": #{map-deep-get($color-palette, "gray", "500")},
     "dark": #{map-deep-get($color-palette, "gray", "400")},

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -191,7 +191,7 @@ $pst-semantic-colors: (
   ),
   "blockquote-notch": (
     // These colors have a contrast ratio > 3.0 against both the background and
-    // surface colors that it is sandwiched between
+    // surface colors that the notch is sandwiched between
     "light": #{map-deep-get($color-palette, "gray", "500")},
     "dark": #{map-deep-get($color-palette, "gray", "400")},
   ),


### PR DESCRIPTION
Accessibility fix, see issue #1428

To fix the link contrast contrast violation, I just reused the `--pst-color-inline-code-links` variable. 

I also realized that the contrast between the blockquote background (`--pst-color-surface`) and the site background color (`--pst-color-background`) was very low. It would be very hard to increase the contrast between these two colors without creating a cascade of other contrast failures. However, blockquotes also have a left border ("notch"), and so I decided to increase the contrast of the notch with both backgrounds—both the site and the blockquote—so that its ratio with both is above 3.0. To be honest, I'm not entirely sure that we strictly have to meet this contrast threshold in order to satisfy [WCAG 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast), but it seemed like a good idea nonetheless so that blockquotes on the site are perceivable by low-vision users.

Here are links to the color contrast grids for the blockquote notch:

- [Color contrast grid for blockquote notch in light mode](https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=%23fff%2C%20Foundation%20white%0D%0A%23f3f4f5%2C%20Surface%20light%20(gray-100)%0D%0A&foreground-colors=%23677384%2C%20Blockquote%20notch%20(gray-500)%0D%0A&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18&es-color-form__show-contrast=dnp)
- [Color contrast grid for blockquote notch in dark mode](https://contrast-grid.eightshapes.com/?version=1.1.0&background-colors=%2314181e%2C%20Foundation%20black%0D%0A%2329313d%2C%20Surface%20dark%20(gray-700)%0D%0A&foreground-colors=%239ca4af%2C%20Blockquote%20notch%20(gray-400)%0D%0A&es-color-form__tile-size=compact&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18&es-color-form__show-contrast=dnp)

### Screenshots

| Before | After |
| ----- | ----- | 
| ![blockquote-light-contrast-fail](https://github.com/pydata/pydata-sphinx-theme/assets/317883/57e98714-5c88-485b-97ea-e5ce887a14eb) | ![blockquote-light-contrast-pass](https://github.com/pydata/pydata-sphinx-theme/assets/317883/52116be0-ee49-4a14-92f0-be229d86683e) |
| ![blockquote-dark-contrast-fail](https://github.com/pydata/pydata-sphinx-theme/assets/317883/4a061ae7-1744-4bf5-8cc7-0696a629e835) | ![blockquote-dark-contrast-pass](https://github.com/pydata/pydata-sphinx-theme/assets/317883/222cda0e-127f-4aed-9ae0-e170433cb313) |