### PR TITLE
Fix GUI label contrast

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -4,7 +4,6 @@
 
 span.guilabel {
   border: 1px solid var(--pst-color-info);
-  color: var(--pst-color-info);
   font-size: 80%;
   font-weight: 700;
   border-radius: 4px;

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -151,7 +151,7 @@ $pst-semantic-colors: (
     "dark": #5fb488,
     "bg-dark": #002f17,
   ),
-  // This is is based on the warning color
+  // This is based on the warning color
   "attention":
     (
       "light": var(--pst-color-warning),


### PR DESCRIPTION
One of many fixes for the failing accessibility tests (see #1428). The color contrast between the text and background colors in the GUI label in light mode were not meeting WCAG. This PR simply allows the label to inherit the text color of its container.

### Screenshots

| Before | After | 
| ----- | ----- |
| ![gui-label-light-before](https://github.com/pydata/pydata-sphinx-theme/assets/317883/3964a184-c184-4dc7-8e50-392452e29077) | ![gui-label-light-after](https://github.com/pydata/pydata-sphinx-theme/assets/317883/bf5aca8a-496b-4be9-a2ad-3a5251ac7552) |
| ![gui-label-dark-before](https://github.com/pydata/pydata-sphinx-theme/assets/317883/2ec0c798-f9b4-4037-bdca-21ec2f69eaea) | ![gui-label-dark-after](https://github.com/pydata/pydata-sphinx-theme/assets/317883/d49bd46b-35e1-4108-87ac-ce3613ee01ad) |
