### PR TITLE
Revert codecov/codecov-action from 4 to 3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
         run: pytest -m "not a11y" --color=yes --cov --cov-report=xml
       - name: Upload to Codecov
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && matrix.sphinx-version == 'dev'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
The coverage report has been failing since PR #1706 was merged.

This is because codecov/codecov-action@v4 no longer allows tokenless uploading. I can fix that later, but reverting back to codecov/codecov-action@v3 will fix the issue for now.