### PR TITLE
Remove :hover pseudo-class from link-style-hover mixin

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -49,13 +49,12 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
 }
 
 // Simple hover style - can be used alone or in conjunction with other mixins
-// Add the text underline and change in thickness on hover
+// Add the text underline and change in thickness on hover.
+// Intended for use with the `:hover` pseudo-class.
 @mixin link-style-hover {
-  &:hover {
-    @include link-decoration;
-    @include link-decoration-hover;
-    color: var(--pst-color-link-hover);
-  }
+  @include link-decoration;
+  @include link-decoration-hover;
+  color: var(--pst-color-link-hover);
 }
 
 // Default link styles

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -185,8 +185,8 @@ pre {
     margin-inline-end: 0.5em;
   }
 
-  @include link-style-hover;
   &:hover {
+    @include link-style-hover;
     text-decoration-thickness: 1px;
     background-color: var(--pst-violet-600);
     color: var(--pst-color-secondary-text);

--- a/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_prev-next.scss
@@ -30,15 +30,10 @@
       font-size: 1.1em;
     }
 
-    &:hover p.prev-next-title {
-      @include link-style-hover;
-    }
-    // Exception here - keep visited in the default link colour
-    // it still should hover on the default link hover colour
-    &:visited p.prev-next-title {
-      color: var(--pst-color-link);
-      &:hover {
-        color: var(--pst-color-link-hover);
+    &:hover,
+    &:visited:hover {
+      p.prev-next-title {
+        @include link-style-hover;
       }
     }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -31,8 +31,8 @@ button.btn.version-switcher__button {
     &:not(:last-child) {
       border-bottom: 1px solid var(--pst-color-border);
     }
-    @include link-style-hover;
     &:hover {
+      @include link-style-hover;
       background-color: var(--pst-color-surface);
     }
     &.active {

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -314,8 +314,8 @@ html {
     min-width: 2.25rem;
     padding: 0.3125rem 0.75rem 0.4375rem; // 5px 12px 7px
 
-    @include link-style-hover; // override Sphinx Design
     &:hover {
+      @include link-style-hover; // override Sphinx Design
       text-decoration-thickness: 1px;
     }
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -110,7 +110,10 @@
       button {
         display: unset;
         border: none;
-        @include link-style-hover;
+
+        &:hover {
+          @include link-style-hover;
+        }
       }
 
       .dropdown-menu {
@@ -154,7 +157,9 @@
 }
 
 .nav-link {
-  @include link-style-hover;
+  &:hover {
+    @include link-style-hover;
+  }
 
   // Override Bootstrap
   transition: none;


### PR DESCRIPTION
This PR:

- Removes the :hover pseudo-class from the link-style-hover mixin
- Uses the modified mixin to slightly change the way the links in the footer respond to hover

Removing the pseudo-class from within the link-style-hover makes the mixin a bit more flexible. For example, I realized that I wanted to change the "next" and "previous" links in the footer so that when any part of the `a` element is hovered, the link text is underlined. It was complicated to do that with the pseudo-class in the mixin, but easy to do afterwards.

Before:

<img width="357" alt="if you hover part of the `a` element, such as on the next/previous keyword or the arrow icon, but not the actual link text, then the link text does not show the hover effect" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/03f0408b-818e-4320-80ae-d8eefc4369f3">

After:

<img width="360" alt="if you hover any part of the `a` element, then the link text shows the hover effect (color changes purple, underline becomes thicker)" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/a27911de-0aa6-4e96-b14b-fc01dacc3100">
