### PR TITLE
Make announcement banner into a landmark (aside/complementary)

### DIFF
--- a/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 13:22-0500\n"
+"POT-Creation-Date: 2024-04-29 13:43+0200\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Cristhian Rivera, 2024\n"
 "Language: ca\n"
@@ -155,6 +155,10 @@ msgstr ""
 "Construïda amb el <a href=\"https://pydata-sphinx-"
 "theme.readthedocs.io/en/stable/index.html\">Tema PyData Sphinx</a> "
 "%(theme_version)s."
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html:1
+msgid "Announcement"
+msgstr ""
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3
 #, fuzzy

--- a/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 13:22-0500\n"
+"POT-Creation-Date: 2024-04-29 13:43+0200\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Jan Breuer <j123b567@jaybee.cz>, 2024\n"
 "Language: cs\n"
@@ -155,6 +155,10 @@ msgstr ""
 "Vytvořeno pomocí <a href=\"https://pydata-sphinx-"
 "theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html:1
+msgid "Announcement"
+msgstr ""
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3
 #, fuzzy

--- a/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 13:22-0500\n"
+"POT-Creation-Date: 2024-04-29 13:43+0200\n"
 "PO-Revision-Date: 2023-02-16 13:19-0500\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -145,6 +145,10 @@ msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
 "theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html:1
+msgid "Announcement"
 msgstr ""
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3

--- a/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 13:22-0500\n"
+"POT-Creation-Date: 2024-04-29 13:43+0200\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Cristhian Rivera, 2024\n"
 "Language: es\n"
@@ -156,6 +156,10 @@ msgstr ""
 "Construido con el <a href=\"https://pydata-sphinx-"
 "theme.readthedocs.io/en/stable/index.html\">Tema PyData Sphinx</a> "
 "%(theme_version)s."
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html:1
+msgid "Announcement"
+msgstr ""
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3
 #, fuzzy

--- a/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 13:22-0500\n"
+"POT-Creation-Date: 2024-04-29 13:43+0200\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2024\n"
 "Language: fr\n"
@@ -155,6 +155,10 @@ msgstr ""
 "Construit avec le <a href=\"https://pydata-sphinx-"
 "theme.readthedocs.io/en/stable/index.html\">Thème PyData Sphinx</a> "
 "%(theme_version)s."
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html:1
+msgid "Announcement"
+msgstr ""
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3
 #, fuzzy

--- a/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 13:22-0500\n"
+"POT-Creation-Date: 2024-04-29 13:43+0200\n"
 "PO-Revision-Date: 2023-04-14 14:57+0000\n"
 "Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
 "Language: ru\n"
@@ -156,6 +156,10 @@ msgstr ""
 "Собрано с использованием темы <a href=\\\"https://pydata-sphinx-"
 "theme.readthedocs.io/en/stable/index.html\\\">PyData Sphinx</a> "
 "%(theme_version)s."
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html:1
+msgid "Announcement"
+msgstr ""
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3
 #, fuzzy

--- a/src/pydata_sphinx_theme/locale/sphinx.pot
+++ b/src/pydata_sphinx_theme/locale/sphinx.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-03-11 13:22-0500\n"
+"POT-Creation-Date: 2024-04-29 13:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -144,6 +144,10 @@ msgid ""
 "Built with the <a href=\"https://pydata-sphinx-"
 "theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
+msgstr ""
+
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html:1
+msgid "Announcement"
 msgstr ""
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
@@ -1,9 +1,10 @@
+{% set banner_label = _("Announcement") %}
 {% set header_classes = ["bd-header-announcement", "container-fluid", "init"] %}
 {% set is_remote=theme_announcement.startswith("http") %}
 {# If we are remote, add a script to make an HTTP request for the value on page load #}
 {%- if is_remote %}
 <script>
-document.write(`<div class="bd-header-announcement"></div>`);
+document.write(`<aside class="bd-header-announcement" aria-label="{{ banner_label }}"></aside>`);
 fetch("{{ theme_announcement }}")
   .then(res => {return res.text();})
   .then(data => {
@@ -42,7 +43,8 @@ fetch("{{ theme_announcement }}")
 </script>
 {#- if announcement text is not remote, populate announcement w/ local content -#}
 {%- else %}
-  <div class="{{ header_classes | join(' ') }} bd-header-announcement">
+  <aside class="{{ header_classes | join(' ') }} bd-header-announcement"
+         aria-label="{{ banner_label }}">
     <div class="bd-header-announcement__content">{{ theme_announcement }}</div>
-  </div>
+  </aside>
 {% endif %}


### PR DESCRIPTION
One of many fixes for #1428.

Axe-core wants: [all page content should be contained by landmarks](https://dequeuniversity.com/rules/axe/4.8/region).

The announcement banner was not a landmark, nor contained by one, so this PR:

- changes the announcement from a `div` to an `aside`, making it into a "complementary" landmark
- adds the translatable string "Announcement" and sets it as the accessible label for the `aside`

This follows the implementation of the Black Lives Matter banner on a11yproject.com (i.e, an aside + aria-label).

I thought about putting both banners (version warning + announcement) together into a single landmark, but my thinking is that for sighted users, both banners are visually distinguishable and draw attention to themselves on every page, so I think making them both into separate landmarks achieves the same level of emphasis for both sighted and non-sighted users. It's also the simpler, more straightforward implementation.

After this PR, the landmarks read:

- Version warning complementary
- Announcement complementary
- banner
- navigation
- Section Navigation navigation 
- main
- Breadcrumb navigation
- article 
- footer

Note: we need to fix the section navigation landmark since it repeats the word navigation twice.