### PR TITLE
fix version-switcher with dirhtml builder

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -320,7 +320,15 @@ var setupSearchButtons = () => {
 async function checkPageExistsAndRedirect(event) {
   // ensure we don't follow the initial link
   event.preventDefault();
-  let currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
+  let currentFilePath;
+  if (DOCUMENTATION_OPTIONS.BUILDER == "dirhtml") {
+    currentFilePath =
+      DOCUMENTATION_OPTIONS.pagename == "index"
+        ? `/`
+        : `${DOCUMENTATION_OPTIONS.pagename}/`;
+  } else {
+    currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
+  }
   let tryUrl = event.currentTarget.getAttribute("href");
   let otherDocsHomepage = tryUrl.replace(currentFilePath, "");
   try {
@@ -372,7 +380,15 @@ async function fetchVersionSwitcherJSON(url) {
 
 // Populate the version switcher from the JSON data
 function populateVersionSwitcher(data, versionSwitcherBtns) {
-  const currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
+  let currentFilePath;
+  if (DOCUMENTATION_OPTIONS.BUILDER == "dirhtml") {
+    currentFilePath =
+      DOCUMENTATION_OPTIONS.pagename == "index"
+        ? `/`
+        : `${DOCUMENTATION_OPTIONS.pagename}/`;
+  } else {
+    currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
+  }
   versionSwitcherBtns.forEach((btn) => {
     // Set empty strings by default so that these attributes exist and can be used in CSS selectors
     btn.dataset["activeVersionName"] = "";
@@ -490,7 +506,14 @@ function showVersionWarningBanner(data) {
   inner.classList = "sidebar-message";
   button.classList =
     "btn text-wrap font-weight-bold ms-3 my-1 align-baseline pst-button-link-to-stable-version";
-  button.href = `${preferredURL}${DOCUMENTATION_OPTIONS.pagename}.html`;
+  if (DOCUMENTATION_OPTIONS.BUILDER == "dirhtml") {
+    button.href =
+      DOCUMENTATION_OPTIONS.pagename == "index"
+        ? `/`
+        : `${DOCUMENTATION_OPTIONS.pagename}/`;
+  } else {
+    button.href = `${DOCUMENTATION_OPTIONS.pagename}.html`;
+  }
   button.innerText = "Switch to stable version";
   button.onclick = checkPageExistsAndRedirect;
   // add the version-dependent text

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -312,6 +312,18 @@ var setupSearchButtons = () => {
  */
 
 /**
+ * path component of URL
+ */
+var getCurrentUrlPath = () => {
+  if (DOCUMENTATION_OPTIONS.BUILDER == "dirhtml") {
+    return DOCUMENTATION_OPTIONS.pagename == "index"
+      ? `/`
+      : `${DOCUMENTATION_OPTIONS.pagename}/`;
+  }
+  return `${DOCUMENTATION_OPTIONS.pagename}.html`;
+};
+
+/**
  * Check if corresponding page path exists in other version of docs
  * and, if so, go there instead of the homepage of the other docs version
  *
@@ -320,15 +332,7 @@ var setupSearchButtons = () => {
 async function checkPageExistsAndRedirect(event) {
   // ensure we don't follow the initial link
   event.preventDefault();
-  let currentFilePath;
-  if (DOCUMENTATION_OPTIONS.BUILDER == "dirhtml") {
-    currentFilePath =
-      DOCUMENTATION_OPTIONS.pagename == "index"
-        ? `/`
-        : `${DOCUMENTATION_OPTIONS.pagename}/`;
-  } else {
-    currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
-  }
+  const currentFilePath = getCurrentUrlPath();
   let tryUrl = event.currentTarget.getAttribute("href");
   let otherDocsHomepage = tryUrl.replace(currentFilePath, "");
   try {
@@ -380,15 +384,7 @@ async function fetchVersionSwitcherJSON(url) {
 
 // Populate the version switcher from the JSON data
 function populateVersionSwitcher(data, versionSwitcherBtns) {
-  let currentFilePath;
-  if (DOCUMENTATION_OPTIONS.BUILDER == "dirhtml") {
-    currentFilePath =
-      DOCUMENTATION_OPTIONS.pagename == "index"
-        ? `/`
-        : `${DOCUMENTATION_OPTIONS.pagename}/`;
-  } else {
-    currentFilePath = `${DOCUMENTATION_OPTIONS.pagename}.html`;
-  }
+  const currentFilePath = getCurrentUrlPath();
   versionSwitcherBtns.forEach((btn) => {
     // Set empty strings by default so that these attributes exist and can be used in CSS selectors
     btn.dataset["activeVersionName"] = "";
@@ -506,14 +502,7 @@ function showVersionWarningBanner(data) {
   inner.classList = "sidebar-message";
   button.classList =
     "btn text-wrap font-weight-bold ms-3 my-1 align-baseline pst-button-link-to-stable-version";
-  if (DOCUMENTATION_OPTIONS.BUILDER == "dirhtml") {
-    button.href =
-      DOCUMENTATION_OPTIONS.pagename == "index"
-        ? `/`
-        : `${DOCUMENTATION_OPTIONS.pagename}/`;
-  } else {
-    button.href = `${DOCUMENTATION_OPTIONS.pagename}.html`;
-  }
+  button.href = getCurrentUrlPath();
   button.innerText = "Switch to stable version";
   button.onclick = checkPageExistsAndRedirect;
   // add the version-dependent text

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -502,7 +502,7 @@ function showVersionWarningBanner(data) {
   inner.classList = "sidebar-message";
   button.classList =
     "btn text-wrap font-weight-bold ms-3 my-1 align-baseline pst-button-link-to-stable-version";
-  button.href = getCurrentUrlPath();
+  button.href = `${preferredURL}${getCurrentUrlPath()}`;
   button.innerText = "Switch to stable version";
   button.onclick = checkPageExistsAndRedirect;
   // add the version-dependent text


### PR DESCRIPTION
Problem: version-switcher suffixes `.html` even if sphinx was used with the `dirhtml` builder.

Solution: suffix `/` instead where necessary.
