### PR TITLE
bump: 0.15.3rc0 -> 0.15.3rc1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,14 +94,6 @@ jobs:
           nox -s compile
       - name: Run tests
         run: pytest -m "not a11y" --color=yes --cov --cov-report=xml
-      - name: Upload to Codecov
-        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && matrix.sphinx-version == 'dev'
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       # note I am setting this on top of the Python cache as I could not find
       # how to set the hash key on the python one

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![conda-forge version badge](https://img.shields.io/conda/vn/conda-forge/pydata-sphinx-theme.svg?logo=anaconda&logoColor=white&color=orange)](https://anaconda.org/conda-forge/pydata-sphinx-theme)
 [![GitHub Workflow test status badge](https://img.shields.io/github/actions/workflow/status/pydata/pydata-sphinx-theme/tests.yml?logo=github&logoColor=white)](https://github.com/pydata/pydata-sphinx-theme/actions/workflows/tests.yml)
 [![Read the Docs build status badge](https://img.shields.io/readthedocs/pydata-sphinx-theme/latest?logo=readthedocs&logoColor=white)](https://readthedocs.org/projects/pydata-sphinx-theme/builds/)
-[![Codecov test coverage percentage badge](https://img.shields.io/codecov/c/github/pydata/pydata-sphinx-theme?logo=codecov&logoColor=white)](https://codecov.io/gh/pydata/pydata-sphinx-theme)
 
 A clean, three-column, Bootstrap-based Sphinx theme by and for the [PyData community](https://pydata.org).
 

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -4,8 +4,8 @@
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/latest/"
   },
   {
-    "name": "0.15.3 (stable)",
-    "version": "v0.15.3",
+    "name": "0.15.2 (stable)",
+    "version": "v0.15.2",
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/stable/",
     "preferred": true
   },

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -14,7 +14,7 @@ from sphinx.errors import ExtensionError
 
 from . import edit_this_page, logo, pygment, short_link, toctree, translator, utils
 
-__version__ = "0.15.3"
+__version__ = "0.15.3rc1"
 
 
 def update_config(app):


### PR DESCRIPTION
hopefully without Codecov, the release action will upload to PyPI successfully.

This also reverts the change to what is labeled "stable" in the version switcher JSON, which probably shouldn't have been done at the RC stage.