### PR TITLE
Provide copy button container sufficient min height

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_copybutton.scss
@@ -41,3 +41,10 @@ div.highlight button.copybtn {
     outline: $focus-ring-outline;
   }
 }
+
+div.highlight:has(button.copybtn) {
+  // Make sure the code block has enough height for the copy button.
+  // Sphinx-copybutton sets 0.3em top offset plus 1.7em height:
+  // https://github.com/executablebooks/sphinx-copybutton/blob/master/sphinx_copybutton/_static/copybutton.css
+  min-height: 2em;
+}


### PR DESCRIPTION
Code blocks with only one line of code did not have enough height, which clip the copy button, as the following screenshot shows:

<img width="895" alt="not enough height, copy button clipped" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/ccdd30ec-c790-44a9-9dca-69a0ab8732f2">

This PR puts a minimum height on the container (`div.highlight`) if it contains a copy button. ([The default copy button selector is "div.highlight pre."](https://github.com/executablebooks/sphinx-copybutton/blob/1a2ee439dae08de21d429dd5b4abc587579c3cf4/sphinx_copybutton/__init__.py#L82))