### PR TITLE
Exclude copy button from notebook cell numbers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,6 +94,9 @@ blog_authors = {
 togglebutton_hint = str(_("Click to expand"))
 togglebutton_hint_hide = str(_("Click to collapse"))
 
+# -- Sphinx-copybutton options ---------------------------------------------
+# Exclude copy button from appearing over notebook cell numbers by using :not()
+copybutton_selector = ":not(.prompt) > div.highlight pre"
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
Because of the way nbsphinx renders notebook cells and the way that Sphinx-copybutton targets code blocks, the line numbers next to notebook cells were getting the copy button, as the following screenshot shows:

<img width="362" alt="copy button on line number" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/ab9ec2b9-f770-4968-8596-edb68f8fc6c1">

This PR changes the copy button selector to exclude the notebook cell line numbers. 

Note: [the default copy button selector is "div.highlight pre."](https://github.com/executablebooks/sphinx-copybutton/blob/1a2ee439dae08de21d429dd5b4abc587579c3cf4/sphinx_copybutton/__init__.py#L82)