### PR TITLE
Force light mode for notebook outputs

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -10,14 +10,3 @@
     0 0.2rem 0.5rem var(--pst-color-shadow),
     0 0 0.0625rem var(--pst-color-shadow) !important;
 }
-
-/**
-   * Set background of some cell outputs to white-ish to make sure colors work
-   * This is because many libraries make output that only looks good on white
-   */
-@mixin cell-output-background {
-  color: var(--pst-color-on-background);
-  background-color: var(--pst-color-text-base);
-  border-radius: 0.25rem;
-  padding: 0.5rem;
-}

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_notebooks.scss
@@ -6,6 +6,47 @@
  * In the future, we might add dark theme support for specific packages.
  */
 
+// For both nbsphinx and MyST-NB, force light mode because many notebook outputs
+// do not support dark mode.
+
+.bd-content {
+  // nbsphinx
+  .nboutput,
+  // MyST-NB
+  .cell_output {
+    @include theme-colors("light");
+    @include sd-colors-for-mode("light");
+    color-scheme: light;
+    color: var(--pst-color-text-base);
+  }
+}
+
+// Dark theme special-cases
+html[data-theme="dark"] .bd-content {
+  @mixin cell-output-background {
+    background-color: var(--pst-color-background);
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+  }
+
+  .nboutput {
+    .output_area {
+      @include cell-output-background;
+    }
+
+    .output_area.stderr {
+      background-color: var(--pst-color-danger);
+    }
+  }
+
+  div.cell_output {
+    img,
+    .text_html {
+      @include cell-output-background;
+    }
+  }
+}
+
 /*******************************************************************************
  * nbsphinx
  */
@@ -14,19 +55,6 @@ html div.rendered_html,
 html .jp-RenderedHTMLCommon {
   table {
     table-layout: auto;
-  }
-}
-
-// Dark theme special-cases
-html[data-theme="dark"] .bd-content {
-  .nboutput {
-    .output_area.rendered_html {
-      @include cell-output-background;
-    }
-
-    .output_area.stderr {
-      background-color: var(--pst-color-danger);
-    }
   }
 }
 
@@ -42,16 +70,6 @@ div.nblast.container {
 div.cell_output .output {
   max-width: 100%;
   overflow-x: auto;
-}
-
-// Dark theme special-cases
-html[data-theme="dark"] .bd-content {
-  div.cell_output {
-    img,
-    .text_html {
-      @include cell-output-background;
-    }
-  }
 }
 
 // Prevent tables from scrunching together

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -78,35 +78,39 @@ $all-colors: map-merge($pst-semantic-colors, $extra-semantic-colors);
   --sd-color-#{$name}-highlight: var(--pst-color-#{$name}-highlight);
 }
 
+@mixin sd-colors-for-mode($mode) {
+  // check if this color is defined differently for light/dark
+  @each $name in $sd-semantic-color-names {
+    $definition: map-get($all-colors, $name);
+    @if type-of($definition) == map {
+      @each $key, $value in $definition {
+        @if str-index($key, $mode) != null {
+          // since now we define the bg colours in the semantic colours and not
+          // by changing opacity, we need to check if the key contains bg and the
+          // correct mode (light/dark)
+          @if str-index($key, "bg") != null {
+            --sd-color-#{$name}-bg: #{$value};
+            // create local variable
+            $bg-var: --sd-color-#{$name}-bg;
+            $value: check-color($value);
+            --sd-color-#{$name}-bg-text: #{a11y-combination($value)};
+          } @else {
+            $value: check-color($value);
+            @include create-sd-colors($value, $name);
+          }
+        }
+      }
+    } @else {
+      $value: map-get($all-colors, $name);
+      @include create-sd-colors($value, $name);
+    }
+  }
+}
+
 // Now we override the --sd-color-* variables.
 @each $mode in (light, dark) {
   html[data-theme="#{$mode}"] {
-    // check if this color is defined differently for light/dark
-    @each $name in $sd-semantic-color-names {
-      $definition: map-get($all-colors, $name);
-      @if type-of($definition) == map {
-        @each $key, $value in $definition {
-          @if str-index($key, $mode) != null {
-            // since now we define the bg colours in the semantic colours and not
-            // by changing opacity, we need to check if the key contains bg and the
-            // correct mode (light/dark)
-            @if str-index($key, "bg") != null {
-              --sd-color-#{$name}-bg: #{$value};
-              // create local variable
-              $bg-var: --sd-color-#{$name}-bg;
-              $value: check-color($value);
-              --sd-color-#{$name}-bg-text: #{a11y-combination($value)};
-            } @else {
-              $value: check-color($value);
-              @include create-sd-colors($value, $name);
-            }
-          }
-        }
-      } @else {
-        $value: map-get($all-colors, $name);
-        @include create-sd-colors($value, $name);
-      }
-    }
+    @include sd-colors-for-mode($mode);
   }
 }
 


### PR DESCRIPTION
If you compare the following screenshots, you will find that the some of the Xarray output is invisible in dark mode. 

| Xarray light mode | Xarray dark mode |
| ----- | ----- |
| ![xarray-light](https://github.com/pydata/pydata-sphinx-theme/assets/317883/788304f9-16dc-44da-aec1-6ded3a79a229) | ![xarray-dark](https://github.com/pydata/pydata-sphinx-theme/assets/317883/1f65dbe1-8ab7-4194-8c19-a805b3fbbaf9) |

This PR makes a stronger attempt at forcing notebook outputs into light mode by resetting all of the color variables on the notebook output element to light mode.