### PR TITLE
Add a pre-commit hook that remove PO files metadata.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,8 @@ repos:
     rev: "0.7.1"
     hooks:
       - id: nbstripout
+
+  - repo: https://github.com/mondeja/pre-commit-po-hooks
+    rev: v1.7.3
+    hooks:
+      - id: remove-metadata

--- a/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
@@ -8,19 +8,6 @@
 # Cristhian Rivera, 2024
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-29 13:43+0200\n"
-"PO-Revision-Date: 2023-04-14 14:57+0000\n"
-"Last-Translator: Cristhian Rivera, 2024\n"
-"Language: ca\n"
-"Language-Team: Catalan "
-"(https://app.transifex.com/12rambau/teams/166811/ca/)\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.0\n"
 
 #: docs/conf.py:94
 msgid "Click to expand"
@@ -179,4 +166,3 @@ msgstr "Navegació del lloc"
 
 #~ msgid "Twitter"
 #~ msgstr "Twitter"
-

--- a/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
@@ -7,20 +7,6 @@
 # Jan Breuer <j123b567@jaybee.cz>, 2024
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-29 13:43+0200\n"
-"PO-Revision-Date: 2023-04-14 14:57+0000\n"
-"Last-Translator: Jan Breuer <j123b567@jaybee.cz>, 2024\n"
-"Language: cs\n"
-"Language-Team: Czech "
-"(https://app.transifex.com/12rambau/teams/166811/cs/)\n"
-"Plural-Forms: nplurals=4; plural=(n == 1 && n % 1 == 0) ? 0 : (n >= 2 && "
-"n <= 4 && n % 1 == 0) ? 1: (n % 1 != 0 ) ? 2 : 3;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.0\n"
 
 #: docs/conf.py:94
 msgid "Click to expand"

--- a/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
@@ -5,18 +5,6 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-29 13:43+0200\n"
-"PO-Revision-Date: 2023-02-16 13:19-0500\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: en\n"
-"Language-Team: en <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.0\n"
 
 #: docs/conf.py:94
 msgid "Click to expand"

--- a/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
@@ -8,20 +8,6 @@
 # Cristhian Rivera, 2024
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-29 13:43+0200\n"
-"PO-Revision-Date: 2023-04-14 14:57+0000\n"
-"Last-Translator: Cristhian Rivera, 2024\n"
-"Language: es\n"
-"Language-Team: Spanish "
-"(https://app.transifex.com/12rambau/teams/166811/es/)\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 "
-"? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.0\n"
 
 #: docs/conf.py:94
 msgid "Click to expand"

--- a/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
@@ -7,20 +7,6 @@
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2024
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-29 13:43+0200\n"
-"PO-Revision-Date: 2023-04-14 14:57+0000\n"
-"Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2024\n"
-"Language: fr\n"
-"Language-Team: French "
-"(https://app.transifex.com/12rambau/teams/166811/fr/)\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
-"1000000 == 0 ? 1 : 2;\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.0\n"
 
 #: docs/conf.py:94
 msgid "Click to expand"

--- a/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
@@ -7,21 +7,6 @@
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
 msgid ""
 msgstr ""
-"Project-Id-Version: PROJECT VERSION\n"
-"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-04-29 13:43+0200\n"
-"PO-Revision-Date: 2023-04-14 14:57+0000\n"
-"Last-Translator: Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023\n"
-"Language: ru\n"
-"Language-Team: Russian "
-"(https://app.transifex.com/12rambau/teams/166811/ru/)\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) "
-"|| (n%100>=11 && n%100<=14)? 2 : 3);\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.0\n"
 
 #: docs/conf.py:94
 msgid "Click to expand"


### PR DESCRIPTION
See thread in #1801 – automatic update from transifex-integration bot have random changes in metadata content and order that are just noise.

With this the bot should do the PR and pre-commit-ci should hopefully push a second commit that remove all churn in metadata.