### PR TITLE
fix perms in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   # calls our tests workflow
   tests:
+    permissions:
+      pull-requests: write
+      contents: write
     uses: ./.github/workflows/tests.yml
 
   build-package:


### PR DESCRIPTION
@Carreau and @trallard the PyPI publish workflow is broken again, this time by the new coverage action.  The Coverage step inside `tests.yml` needs `contents: write, pull-requests: write` permissions. That means we need to grant those permissions to *the entire tests workflow* when that workflow is called from within another action (in this case, the `publish.yml` action).

This PR will do that (as a quick-fix to allow us to get the release out) and I'll self-merge this if necessary later today, to facilitate a timely release.  But IMO a better solution is to separate the `test` and `coverage` actions into separate workflows, so that:

- on PRs, `test` and `coverage` get run
- when releases are tagged, `test` and `publish` get run (but not `coverage`)

WDYT?