### PR TITLE
Remove hack to fix bug with up/down keys and "More" links in sidebar

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -597,18 +597,6 @@ if (hasVersionsJSON && (hasSwitcherMenu || wantsWarningBanner)) {
   }
 }
 
-/**
- * Fix bug #1603
- */
-function fixMoreLinksInMobileSidebar() {
-  const dropdown = document.querySelector(
-    ".bd-sidebar-primary [id^=pst-nav-more-links]",
-  );
-  if (dropdown !== null) {
-    dropdown.classList.add("show");
-  }
-}
-
 /*******************************************************************************
  * Add keyboard functionality to mobile sidebars.
  *
@@ -728,5 +716,4 @@ documentReady(addTOCInteractivity);
 documentReady(setupSearchButtons);
 documentReady(initRTDObserver);
 documentReady(setupMobileSidebarKeyboardHandlers);
-documentReady(fixMoreLinksInMobileSidebar);
 documentReady(setupLiteralBlockTabStops);


### PR DESCRIPTION
The hack added in PR #1604 to fix issue #1603 is no longer needed after @Carreau's PR, [#1771 Do not generate dropdown in sidebar.](https://github.com/pydata/pydata-sphinx-theme/pull/1771)