### PR TITLE
Remove backwards-compatible text-decoration-skip rule

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -41,10 +41,8 @@ $link-hover-decoration-thickness: unquote("max(3px, .1875rem, .12em)") !default;
 @mixin link-decoration-hover {
   @if $link-hover-decoration-thickness {
     text-decoration-thickness: $link-hover-decoration-thickness;
-    // Disable ink skipping on underlines on hover. Browsers haven't
-    // standardised on this part of the spec yet, so set both properties
-    text-decoration-skip-ink: none; // Chromium, Firefox
-    text-decoration-skip: none; // Safari
+    // Disable ink skipping on underlines on hover.
+    text-decoration-skip-ink: none;
   }
 }
 


### PR DESCRIPTION
Fixes #1684.

[text-decoration-skip-ink was added in Safari 15.4 (March 2022)](https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes#CSS)

We do not need to keep text-decoration-skip.