### PR TITLE
Set banner height to auto after animation

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -749,6 +749,12 @@ async function fetchRevealBannersTogether() {
   // Use the calculated height to give the revealer a non-zero height (if
   // animations allowed, the height change will animate)
   revealer.style.setProperty("height", `${height}px`);
+
+  // Wait for a bit more than 300ms (the transition duration), then set height
+  // to auto so the banner can resize if the window is resized.
+  setTimeout(() => {
+    revealer.style.setProperty("height", "auto");
+  }, 320);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Narrow banner -> more height (because of text wrapping)
Wide banner -> less height 

I missed an important detail from #1693 when reimplementing the banner animation in #1808. 

### Before this PR - screenshot

<img width="500" alt="" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/072a625b-cdd1-4e76-92e4-3b3329571d5b">

### After this PR - screenshot 

<img width="499" alt="" src="https://github.com/pydata/pydata-sphinx-theme/assets/317883/f47b783e-d7ac-42d1-aaff-261d21263faf">
