### PR TITLE
Move CSS block out of SCSS vars file

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_bootstrap.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_bootstrap.scss
@@ -13,3 +13,7 @@
   max-width: unset;
   width: unset;
 }
+
+.btn {
+  --bs-btn-focus-box-shadow: #{$btn-focus-box-shadow};
+}

--- a/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
@@ -31,7 +31,3 @@ $focus-ring-box-shadow: 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color
 // outline creates the same style of focus ring, it just uses CSS outline instead of box shadow
 $focus-ring-outline: $focus-ring-color solid $focus-ring-width;
 $btn-focus-box-shadow: $focus-ring-box-shadow;
-
-.btn {
-  --bs-btn-focus-box-shadow: #{$btn-focus-box-shadow};
-}


### PR DESCRIPTION
I think files like `variables.scss` should probably only contain Sass variables and not CSS variables. At least, that's what [Bootstrap's variables.scss](https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss) file does, as far as I can tell.

