### PR TITLE
Various table fixes

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_tables.scss
@@ -6,9 +6,6 @@
 table {
   @include table-colors;
 
-  display: table;
-  overflow: auto;
-
   // default to table-center
   margin-left: auto;
   margin-right: auto;
@@ -33,15 +30,15 @@ table caption {
 // MyST Markdown tables use these classes to control alignment
 th,
 td {
-  &.text-align\:left {
+  &.text-left {
     text-align: left;
   }
 
-  &.text-align\:right {
+  &.text-right {
     text-align: right;
   }
 
-  &.text-align\:center {
+  &.text-center {
     text-align: center;
   }
 }
@@ -57,7 +54,7 @@ td {
 }
 
 .pst-scrollable-table-container {
-  // Put a scrollbar just below tables that are too wide to fit within the main
-  // column
+  // Put a horizontal scrollbar just below tables that are too wide to fit
+  // within the main column
   overflow-x: auto;
 }


### PR DESCRIPTION
This PR makes a few changes to the _tables.scss file:

- Matches our table alignment classes with an [update to MyST from 2021](https://github.com/executablebooks/MyST-Parser/pull/450) (version [0.16.0](https://github.com/executablebooks/MyST-Parser/releases/tag/v0.16.0))
- Removes the redundant and useless `display: table` and `overflow: auto` rules
- Updates a comment

Fixes #1804.