### PR TITLE
MAINT: Reenable parallel write safety

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -291,4 +291,4 @@ def setup(app: Sphinx) -> Dict[str, str]:
     # Include component templates
     app.config.templates_path.append(str(theme_path / "components"))
 
-    return {"parallel_read_safe": True, "parallel_write_safe": False}
+    return {"parallel_read_safe": True, "parallel_write_safe": True}


### PR DESCRIPTION
See https://github.com/scipy/scipy/pull/20897. TL;DR is that the problem was always with reading in parallel, not writing. And the bug is really in Sphinx.

It would be good to detect and clean this up in PST somehow perhaps as well -- maybe with a warning if a top-level / root page ever shows up as a child? This *might* only be an issue when building in parallel, still not totally clear to me why things were okay in the serial case.

I think any additional changes could be made in a follow-up PR probably.

closes #1643 