### PR TITLE
guard a couple (possibly null) querySelector results

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -813,7 +813,7 @@ async function fetchRevealBannersTogether() {
   // turned off animations)
   const revealer = document.querySelector(".pst-async-banner-revealer");
   if (!revealer) {
-    return
+    return;
   }
 
   // Remove the d-none (display-none) class to calculate the children heights.

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -775,7 +775,7 @@ function debounce(callback, wait) {
  */
 async function setupAnnouncementBanner() {
   const banner = document.querySelector(".bd-header-announcement");
-  const { pstAnnouncementUrl } = banner.dataset;
+  const { pstAnnouncementUrl } = banner ? banner.dataset : null;
 
   if (!pstAnnouncementUrl) {
     return;
@@ -812,6 +812,9 @@ async function fetchRevealBannersTogether() {
   // to hidden, and an animation transition on the height (unless the user has
   // turned off animations)
   const revealer = document.querySelector(".pst-async-banner-revealer");
+  if (!revealer) {
+    return
+  }
 
   // Remove the d-none (display-none) class to calculate the children heights.
   revealer.classList.remove("d-none");


### PR DESCRIPTION
when looking into the cause of #1829 I found a couple cases where `document.querySelector` might be `null` and we don't handle that very gracefully.