### PR TITLE
Change the border color of tabs to --pst-color-border

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -186,9 +186,7 @@ html[data-theme="light"] {
     // Active tab label
     &:checked + label {
       border-style: solid solid none;
-      border-color: var(--pst-color-border) var(--pst-color-border)
-        transparent; // top LR bottom
-
+      border-color: var(--pst-color-border) var(--pst-color-border) transparent; // top LR bottom
       border-width: 0.125rem 0.125rem 0;
       border-radius: 0.125rem 0.125rem 0 0;
       background-color: var(--pst-color-on-background);

--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -186,7 +186,7 @@ html[data-theme="light"] {
     // Active tab label
     &:checked + label {
       border-style: solid solid none;
-      border-color: var(--pst-color-primary) var(--pst-color-primary)
+      border-color: var(--pst-color-border) var(--pst-color-border)
         transparent; // top LR bottom
 
       border-width: 0.125rem 0.125rem 0;
@@ -227,7 +227,7 @@ html[data-theme="light"] {
 
   // panel
   .sd-tab-content {
-    border: 0.125rem solid var(--pst-color-primary);
+    border: 0.125rem solid var(--pst-color-border);
     border-radius: 0.1875rem;
     box-shadow: unset;
     padding: 0.625rem;


### PR DESCRIPTION
#1555 added a border around tabs. It uses `--pst-color-primary`:
![grafik](https://github.com/pydata/pydata-sphinx-theme/assets/2836374/6a036233-565c-464e-aa5a-602a1f7ba4e1)

IMHO primary color gives too much weight on the border. In this PR, suggest to change the color to `--pst-color-border`:
![grafik](https://github.com/pydata/pydata-sphinx-theme/assets/2836374/56249de4-b6c7-4a9e-b0fa-c4de59c3d679)
