### PR TITLE
Fix hit area icon links buttons

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -61,21 +61,6 @@ $link-hover-decoration-thickness: string.unquote(
   color: var(--pst-color-link-hover);
 }
 
-// Hover underline for icons / non-text content
-// - Adds a bottom box-shadow - since there is no text we cannot use text-decoration.
-// - We want the side box shadow to have the same thickness as the hover underline.
-// - Use with &:hover.
-@mixin icon-hover {
-  color: var(--pst-color-link-hover);
-
-  @if $link-hover-decoration-thickness {
-    box-shadow: 0
-      $link-hover-decoration-thickness
-      0
-      var(--pst-color-link-hover);
-  }
-}
-
 // Default link styles
 // -------------------
 // Defines: default unvisited, visited, hover, and active.
@@ -203,24 +188,29 @@ $link-hover-decoration-thickness: string.unquote(
   // position is relative to this element.
   position: relative;
 
-  // Put some space between the underline and the content. Must apply to top as
-  // well as bottom so that the link is centered within the focus ring.
-  padding-block: 0.25rem;
-
-  // Pseudo-element for hover underline styles
+  // Set up pseudo-element used for hover underline styles
   &::before {
     content: "";
     display: block;
     position: absolute;
     inset: 0;
     background-color: transparent;
+
+    @if $link-hover-decoration-thickness {
+      bottom: calc(-1 * $link-hover-decoration-thickness);
+      margin: $link-hover-decoration-thickness 0;
+    }
   }
 
   &:hover {
     color: var(--pst-color-secondary);
     text-decoration: none; // override the link-style-hover mixin
     &::before {
-      border-bottom: 3px solid var(--pst-color-secondary);
+      @if $link-hover-decoration-thickness {
+        border-bottom: $link-hover-decoration-thickness
+          solid
+          var(--pst-color-secondary);
+      }
     }
   }
 

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -61,6 +61,21 @@ $link-hover-decoration-thickness: string.unquote(
   color: var(--pst-color-link-hover);
 }
 
+// Hover underline for icons / non-text content
+// - Adds a bottom box-shadow - since there is no text we cannot use text-decoration.
+// - We want the side box shadow to have the same thickness as the hover underline.
+// - Use with &:hover.
+@mixin icon-hover {
+  color: var(--pst-color-link-hover);
+
+  @if $link-hover-decoration-thickness {
+    box-shadow: 0
+      $link-hover-decoration-thickness
+      0
+      var(--pst-color-link-hover);
+  }
+}
+
 // Default link styles
 // -------------------
 // Defines: default unvisited, visited, hover, and active.
@@ -164,114 +179,54 @@ $link-hover-decoration-thickness: string.unquote(
   }
 }
 
-// Navigation bar current page link styles
-// ---------------------------------------
-// Adds a bottom underline, this leaves enough space for the hover state without
-// cluttering the navbar.
-// We want the side box shadow to have the same thickness as the hover underline
-@mixin link-navbar-current {
-  font-weight: 600;
-  color: var(--pst-color-primary);
+// Heaver navbar text and icon links
+// ---------------------------------
+// (includes light/dark mode button)
 
-  @if $link-hover-decoration-thickness {
-    border-bottom: $link-hover-decoration-thickness
-      solid
-      var(--pst-color-primary);
+// This mixin makes it possible to show hover/underline and focus/ring styles at
+// the same time. The trick is to use:
+//    - a pseudo-element with bottom border for the hover underline
+//    - a CSS outline for the focus ring.
+
+// Normally we use box-shadow for underline and outline for focus ring. But we
+// cannot apply box-shadow and outline together on the same element because the
+// border-radius value that we use to round the outline will also round the
+// box-shadow used for the underline. We also cannot use text-underline because
+// it does not work on non-text links, nor do we want to use it on text links
+// that we want to treat as blocks, such as the header nav links because the
+// underline will wrap across two lines if the link text also wraps across two
+// lines.
+@mixin link-style-block {
+  color: var(--pst-color-text-muted);
+
+  // Set position relative so that the child ::before pseudo-element's absolute
+  // position is relative to this element.
+  position: relative;
+
+  // Put some space between the underline and the content. Must apply to top as
+  // well as bottom so that the link is centered within the focus ring.
+  padding-block: 0.25rem;
+
+  // Pseudo-element for hover underline styles
+  &::before {
+    content: "";
+    display: block;
+    position: absolute;
+    inset: 0;
+    background-color: transparent;
   }
-}
 
-// Navigation bar icon links hover styles
-// --------------------------------------
-// Adds a bottom box-shadow - since there is no text we cannot use text-decoration
-// We want the side box shadow to have the same thickness as the hover underline
-@mixin icon-navbar-hover {
   &:hover {
-    color: var(--pst-color-link-hover);
-
-    @if $link-hover-decoration-thickness {
-      box-shadow: 0
-        $link-hover-decoration-thickness
-        0
-        var(--pst-color-link-hover);
-    }
-  }
-}
-
-// Mixin for links in the header (and the More dropdown toggle).
-
-// The mixin assumes it will be applied to some element X with a markup structure
-// like: X > .nav-link, or X > .dropdown-toggle.
-
-// It also assumes X.current is how the app annotates which item in the header nav
-// corresponds to the section in the docs that the user is currently reading.
-@mixin header-link {
-  // Target the child and not the parent because we want the underline in the
-  // mobile sidebar to only span the width of the text not the entire row/line.
-  > .nav-link,
-  > .dropdown-toggle {
-    border-radius: 2px;
-    color: var(--pst-color-text-muted);
-  }
-
-  > .nav-link {
-    // Set up pseudo-element for hover and current states below.
-    position: relative;
-
+    color: var(--pst-color-secondary);
+    text-decoration: none; // override the link-style-hover mixin
     &::before {
-      content: "";
-      display: block;
-      position: absolute;
-      inset: 0;
-      background-color: transparent;
-    }
-
-    // Underline on hover.
-    // - Don't use text-decoration because it will wrap across two lines if
-    //   the link text also wraps across two lines.
-    // - Use pseudo-element in order to avoid the border-radius values
-    //   rounding the edges of the underline. (And since a header link can be
-    //   both focused and hovered at the same time and we want the focus ring
-    //   but not the underline to be rounded, we cannot use a box shadow or
-    //   bottom border link element to create the underline, or else it will
-    //   be rounded and if we apply border-radius 0 then the hovered focus
-    //   ring would go from rounded to sharp. So we have to use the
-    //   pseudo-element.)
-    &:hover {
-      color: var(--pst-color-secondary);
-      text-decoration: none; // override the link-style-hover mixin
-      &::before {
-        border-bottom: 3px solid var(--pst-color-secondary);
-      }
-    }
-
-    &:focus-visible {
-      box-shadow: none; // override Bootstrap
-      outline: 3px solid var(--pst-color-accent);
-      outline-offset: 3px;
+      border-bottom: 3px solid var(--pst-color-secondary);
     }
   }
 
-  > .dropdown-toggle {
-    &:focus-visible {
-      box-shadow: $focus-ring-box-shadow;
-    }
-
-    &:hover {
-      text-decoration: none;
-      box-shadow: 0 0 0 $focus-ring-width var(--pst-color-link-hover); // purple focus ring
-      // Brighten the text on hover (muted -> base)
-      color: var(--pst-color-text-base);
-    }
-  }
-
-  &.current {
-    > .nav-link {
-      color: var(--pst-color-primary);
-
-      // Underline the current navbar item
-      &::before {
-        border-bottom: 3px solid var(--pst-color-primary);
-      }
-    }
+  &:focus-visible {
+    box-shadow: none; // override Bootstrap
+    outline: 3px solid var(--pst-color-accent);
+    outline-offset: 3px;
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_mixins.scss
@@ -57,3 +57,14 @@
     }
   }
 }
+
+// Minimum mouse hit area
+// ----------------------
+// Ensures that the element has a minimum hit area that conforms to
+// accessibility guidelines. For WCAG AA, we need 24px x 24px, see:
+// https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
+@mixin min-hit-area() {
+  box-sizing: border-box;
+  min-width: 24px;
+  min-height: 24px;
+}

--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -7,7 +7,7 @@ body {
   background-color: var(--pst-color-background);
   font-family: var(--pst-font-family-base);
   font-weight: 400;
-  line-height: 1.65;
+  line-height: $line-height-body;
   color: var(--pst-color-text-base);
   min-height: 100vh;
   display: flex;

--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -16,7 +16,7 @@
     border-radius: 0;
     border: none;
     font-size: 1rem;
-    line-height: inherit; // Bootstrap defines a separate line-height for buttons
+    line-height: inherit; // Override Bootstrap, which defines a separate line-height for buttons
     padding: 0.25rem 0; // Horizontal white space in nav bar between between items is controlled via column gap rule on the container.
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -17,11 +17,7 @@
     border: none;
     font-size: 1rem;
     line-height: inherit; // Bootstrap defines a separate line-height for buttons
-
-    // Override Bootstrap button padding-x. Whitespace in nav bar is controlled
-    // via column gap rule on the container.
-    padding-left: 0;
-    padding-right: 0;
+    padding: 0.25rem 0; // Horizontal white space in nav bar between between items is controlled via column gap rule on the container.
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -16,8 +16,11 @@
     border-radius: 0;
     border: none;
     font-size: 1rem;
-    line-height: inherit; // Override Bootstrap, which defines a separate line-height for buttons
-    padding: 0.25rem 0; // Horizontal white space in nav bar between between items is controlled via column gap rule on the container.
+    line-height: $line-height-body; // Override Boostrap, which defines a separate line-height for buttons
+    padding: $navbar-link-padding-y 0; // Horizontal white space in nav bar between items is controlled via column gap rule on the container.
+
+    // Make the navbar icon links have the same size as the navbar text links
+    height: calc(2 * $navbar-link-padding-y + $line-height-body * 1rem);
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -2,7 +2,30 @@
  * Icon links in the navbar
  */
 
-.navbar-icon-links {
+.pst-navbar-icon {
+  // Extra specificity needed for overrides
+  html & {
+    @include min-hit-area;
+    @include link-style-block;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    // Bootstrap overrides
+    border-radius: 0;
+    border: none;
+    font-size: 1rem;
+    line-height: inherit; // Bootstrap defines a separate line-height for buttons
+
+    // Override Bootstrap button padding-x. Whitespace in nav bar is controlled
+    // via column gap rule on the container.
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+
+ul.navbar-icon-links {
   display: flex;
   flex-flow: row wrap;
   column-gap: 1rem;
@@ -11,24 +34,6 @@
   padding-left: 0;
   margin-bottom: 0;
   list-style: none;
-
-  // Remove the padding so that we can define it with flexbox gap above
-  li.nav-item a.nav-link {
-    padding-left: 0;
-    padding-right: 0;
-
-    @include icon-navbar-hover;
-
-    &:focus {
-      color: inherit;
-    }
-  }
-
-  // Spacing and centering
-  a span {
-    display: flex;
-    align-items: center;
-  }
 
   // Icons styling
   i {

--- a/src/pydata_sphinx_theme/assets/styles/components/_navbar-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_navbar-links.scss
@@ -1,16 +1,10 @@
 /**
  * Navigation links in the navbar and icon links
  */
-.navbar-nav,
-.navbar-icon-links {
+ul.navbar-nav {
+  // Reduce padding of nested `ul` items a bit
   ul {
-    display: block;
-    list-style: none;
-
-    // Reduce padding of nested `ul` items a bit
-    ul {
-      padding: 0 0 0 1rem;
-    }
+    padding: 0 0 0 1rem;
   }
 
   // Navbar links - do not have an underline by default

--- a/src/pydata_sphinx_theme/assets/styles/components/_navbar-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_navbar-links.scss
@@ -16,8 +16,8 @@ ul.navbar-nav {
       display: flex;
       align-items: center;
       height: 100%;
-      padding-top: 0.25rem;
-      padding-bottom: 0.25rem;
+      padding-top: $navbar-link-padding-y;
+      padding-bottom: $navbar-link-padding-y;
 
       @include link-style-text;
     }

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -67,26 +67,8 @@
  */
 
 // Search link icon should be a bit bigger since it is separate from icon links
-.search-button {
-  display: flex;
-  align-items: center;
-  align-content: center;
-  color: var(--pst-color-text-muted);
-  padding: 0;
-  border-radius: 0;
-  border: none; // Override Bootstrap button border
-  font-size: 1rem; // Override Bootstrap button font size
-
-  // Override Bootstrap button padding-x. Whitespace in nav bar is controlled
-  // via column gap rule on the container.
-  padding-left: 0;
-  padding-right: 0;
-
-  @include icon-navbar-hover;
-
-  i {
-    font-size: 1.3rem;
-  }
+.search-button i {
+  font-size: 1.3rem;
 }
 
 // __search-container will only show up when we use the search pop-up bar

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -3,20 +3,6 @@
  */
 
 .theme-switch-button {
-  color: var(--pst-color-text-muted);
-  border-radius: 0;
-  border: none; // Override Bootstrap button border
-  font-size: 1rem; // Override Bootstrap's button font size
-
-  // Override Bootstrap button padding-x. Whitespace in nav bar is controlled
-  // via column gap rule on the container.
-  padding-left: 0;
-  padding-right: 0;
-
-  &:hover {
-    @include icon-navbar-hover;
-  }
-
   span {
     display: none;
 
@@ -32,13 +18,13 @@
 }
 
 html[data-mode="auto"] .theme-switch-button span[data-mode="auto"] {
-  display: flex;
+  display: inline;
 }
 
 html[data-mode="light"] .theme-switch-button span[data-mode="light"] {
-  display: flex;
+  display: inline;
 }
 
 html[data-mode="dark"] .theme-switch-button span[data-mode="dark"] {
-  display: flex;
+  display: inline;
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -3,7 +3,7 @@
  */
 
 .theme-switch-button {
-  span {
+  .theme-switch {
     display: none;
 
     &:active {
@@ -18,7 +18,9 @@
 }
 
 @each $mode in auto, light, dark {
-  html[data-mode="#{$mode}"] .theme-switch-button span[data-mode="#{$mode}"] {
+  html[data-mode="#{$mode}"]
+    .theme-switch-button
+    .theme-switch[data-mode="#{$mode}"] {
     display: inline; // inline needed for span height to be calculated using inherited font size and line height
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -17,14 +17,8 @@
   }
 }
 
-html[data-mode="auto"] .theme-switch-button span[data-mode="auto"] {
-  display: inline;
-}
-
-html[data-mode="light"] .theme-switch-button span[data-mode="light"] {
-  display: inline;
-}
-
-html[data-mode="dark"] .theme-switch-button span[data-mode="dark"] {
-  display: inline;
+@each $mode in auto, light, dark {
+  html[data-mode="#{$mode}"] .theme-switch-button span[data-mode="#{$mode}"] {
+    display: inline; // inline needed for span height to be calculated using inherited font size and line height
+  }
 }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-version.scss
@@ -72,6 +72,10 @@ button.version-switcher__button,
   font-size: 1.1em; // A bit smaller than other menu font
   z-index: $zindex-modal; // higher than the sidebars
 
+  // Make sure it meets WCAG target size requirement no matter the version
+  // string displayed in the button
+  @include min-hit-area;
+
   @include media-breakpoint-up($breakpoint-sidebar-primary) {
     font-size: unset;
   }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -81,7 +81,7 @@
   }
 
   // Contains the navigation links within the navbar
-  .navbar-nav {
+  ul.navbar-nav {
     display: flex;
 
     @include media-breakpoint-up($breakpoint-sidebar-primary) {
@@ -89,7 +89,7 @@
       align-items: baseline;
     }
 
-    li.nav-item {
+    > li.nav-item {
       margin-inline: 2px; // breathing room so hover and focus styles do not overlap
 
       > .nav-link {
@@ -187,19 +187,11 @@
 
   // Toggle buttons
   button.sidebar-toggle {
-    display: flex;
-    cursor: pointer;
     font-size: var(--pst-font-size-icon);
-    align-items: center;
     color: var(--pst-color-muted);
     margin-bottom: 0;
-    padding-bottom: 0.25rem;
     background-color: inherit;
-    border: none;
-
-    &:hover {
-      @include icon-hover;
-    }
+    padding: 0.5rem;
   }
 
   button.primary-toggle {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -89,21 +89,49 @@
       align-items: baseline;
     }
 
-    li.pst-header-nav-item {
+    li.nav-item {
       margin-inline: 2px; // breathing room so hover and focus styles do not overlap
+
+      > .nav-link {
+        @include link-style-block;
+
+        padding-inline: 6px;
+      }
+
+      &.current {
+        > .nav-link {
+          color: var(--pst-color-primary);
+
+          // Underline the current navbar item
+          &::before {
+            border-bottom: 3px solid var(--pst-color-primary);
+          }
+        }
+      }
+
       &.dropdown {
         margin-inline: 4px;
 
         button {
           padding-inline: 8px;
         }
-      }
 
-      a {
-        padding-inline: 6px;
-      }
+        > .dropdown-toggle {
+          border-radius: $focus-ring-radius; // make border radius the same for both hover ring and focus ring
+          color: var(--pst-color-text-muted);
 
-      @include header-link;
+          &:focus-visible {
+            box-shadow: $focus-ring-box-shadow;
+          }
+
+          &:hover {
+            text-decoration: none;
+            box-shadow: 0 0 0 $focus-ring-width var(--pst-color-link-hover); // purple focus ring
+            // Brighten the text on hover (muted -> base)
+            color: var(--pst-color-text-base);
+          }
+        }
+      }
     }
 
     li a.nav-link.dropdown-item {
@@ -169,7 +197,9 @@
     background-color: inherit;
     border: none;
 
-    @include icon-navbar-hover;
+    &:hover {
+      @include icon-hover;
+    }
   }
 
   button.primary-toggle {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -254,6 +254,7 @@ nav.bd-links {
   }
 
   ul {
+    display: block;
     list-style: none;
 
     // Reduce padding of nested `ul` items a bit

--- a/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
@@ -41,3 +41,5 @@ html {
   --pst-font-family-heading: var(--pst-font-family-base-system);
   --pst-font-family-monospace: var(--pst-font-family-monospace-system);
 }
+
+$line-height-body: 1.65;

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -35,3 +35,5 @@ $admonition-border-radius: 0.25rem;
 // In this theme, some focus rings have rounded corners while others do not.
 // This variable sets the border radius for the rounded focus rings.
 $focus-ring-radius: 0.125rem; // 2px at 100% zoom and 16px base font.
+
+$navbar-link-padding-y: 0.25rem;

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -2,7 +2,7 @@
 {%- macro icon_link_nav_item(url, icon, name, type, attributes='') -%}
   {%- if url | length > 2 %}
         <li class="nav-item">
-          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link", "rel": "noopener", "target": "_blank", "data-bs-toggle": "tooltip", "data-bs-placement": "bottom"} %}
+          {%- set attributesDefault = { "href": url, "title": name, "class": "nav-link pst-navbar-icon", "rel": "noopener", "target": "_blank", "data-bs-toggle": "tooltip", "data-bs-placement": "bottom"} %}
           {%- if attributes %}{% for key, val in attributes.items() %}
             {% set _ = attributesDefault.update(attributes) %}
           {% endfor %}{% endif -%}
@@ -16,9 +16,9 @@
             <span><i class="{{ icon }} fa-lg" aria-hidden="true"></i></span>
             <span class="sr-only">{{ name }}</span>
             {%- elif type == "local" -%}
-            <img src="{{ pathto(icon, 1) }}" class="icon-link-image" alt="{{ name }}"/>
+            <span><img src="{{ pathto(icon, 1) }}" class="icon-link-image" alt="{{ name }}"/></span>
             {%- elif type == "url" -%}
-            <img src="{{ icon }}" class="icon-link-image" alt="{{ name }}"/>
+            <span><img src="{{ icon }}" class="icon-link-image" alt="{{ name }}"/></span>
             {%- else %}
             <span>Incorrectly configured icon link. Type must be `fontawesome`, `url` or `local`.</span>
             {%- endif -%}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -13,12 +13,12 @@
           {% set attributeString = attributeString | join(" ") -%}
           <a {{ attributeString }}>
             {%- if type == "fontawesome" -%}
-            <span><i class="{{ icon }} fa-lg" aria-hidden="true"></i></span>
+            <i class="{{ icon }} fa-lg" aria-hidden="true"></i>
             <span class="sr-only">{{ name }}</span>
             {%- elif type == "local" -%}
-            <span><img src="{{ pathto(icon, 1) }}" class="icon-link-image" alt="{{ name }}"/></span>
+            <img src="{{ pathto(icon, 1) }}" class="icon-link-image" alt="{{ name }}"/>
             {%- elif type == "url" -%}
-            <span><img src="{{ icon }}" class="icon-link-image" alt="{{ name }}"/></span>
+            <img src="{{ icon }}" class="icon-link-image" alt="{{ name }}"/>
             {%- else %}
             <span>Incorrectly configured icon link. Type must be `fontawesome`, `url` or `local`.</span>
             {%- endif -%}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html
@@ -2,7 +2,7 @@
 {# As this function will only work when JavaScript is enabled, we add it through JavaScript. #}
  <script>
  document.write(`
-   <button class="btn pst-navbar-icon search-button-field search-button__button" title="{{ _('Search') }}" aria-label="{{ _('Search') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
+   <button class="btn search-button-field search-button__button" title="{{ _('Search') }}" aria-label="{{ _('Search') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
     <i class="fa-solid fa-magnifying-glass"></i>
     <span class="search-button__default-text">{{ _('Search') }}</span>
     <span class="search-button__kbd-shortcut"><kbd class="kbd-shortcut__modifier">Ctrl</kbd>+<kbd class="kbd-shortcut__modifier">K</kbd></span>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html
@@ -2,7 +2,7 @@
 {# As this function will only work when JavaScript is enabled, we add it through JavaScript. #}
  <script>
  document.write(`
-   <button class="btn navbar-btn search-button-field search-button__button" title="{{ _('Search') }}" aria-label="{{ _('Search') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
+   <button class="btn pst-navbar-icon search-button-field search-button__button" title="{{ _('Search') }}" aria-label="{{ _('Search') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
     <i class="fa-solid fa-magnifying-glass"></i>
     <span class="search-button__default-text">{{ _('Search') }}</span>
     <span class="search-button__kbd-shortcut"><kbd class="kbd-shortcut__modifier">Ctrl</kbd>+<kbd class="kbd-shortcut__modifier">K</kbd></span>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
@@ -3,7 +3,7 @@
 <script>
 document.write(`
   <button class="btn btn-sm pst-navbar-icon search-button search-button__button" title="{{ _('Search') }}" aria-label="{{ _('Search') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
-    <span><i class="fa-solid fa-magnifying-glass fa-lg"></i></span>
+    <i class="fa-solid fa-magnifying-glass fa-lg"></i>
   </button>
 `);
 </script>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button.html
@@ -2,8 +2,8 @@
 {# As this function will only work when JavaScript is enabled, we add it through JavaScript. #}
 <script>
 document.write(`
-  <button class="btn btn-sm navbar-btn search-button search-button__button" title="{{ _('Search') }}" aria-label="{{ _('Search') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
-    <i class="fa-solid fa-magnifying-glass fa-lg"></i>
+  <button class="btn btn-sm pst-navbar-icon search-button search-button__button" title="{{ _('Search') }}" aria-label="{{ _('Search') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
+    <span><i class="fa-solid fa-magnifying-glass fa-lg"></i></span>
   </button>
 `);
 </script>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -2,10 +2,10 @@
 {# As the theme switcher will only work when JavaScript is enabled, we add it through JavaScript. #}
 <script>
 document.write(`
-  <button class="btn btn-sm pst-navbar-icon theme-switch-button" title="{{ _('light/dark') }}" aria-label="{{ _('light/dark') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
-    <span class="theme-switch nav-link" data-mode="light"><i class="fa-solid fa-sun fa-lg"></i></span>
-    <span class="theme-switch nav-link" data-mode="dark"><i class="fa-solid fa-moon fa-lg"></i></span>
-    <span class="theme-switch nav-link" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg"></i></span>
+  <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button" title="{{ _('light/dark') }}" aria-label="{{ _('light/dark') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
+    <i class="theme-switch fa-solid fa-sun fa-lg" data-mode="light"></i>
+    <i class="theme-switch fa-solid fa-moon fa-lg" data-mode="dark"></i>
+    <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg" data-mode="auto"></i>
   </button>
 `);
 </script>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -2,7 +2,7 @@
 {# As the theme switcher will only work when JavaScript is enabled, we add it through JavaScript. #}
 <script>
 document.write(`
-  <button class="btn btn-sm navbar-btn theme-switch-button" title="{{ _('light/dark') }}" aria-label="{{ _('light/dark') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
+  <button class="btn btn-sm pst-navbar-icon theme-switch-button" title="{{ _('light/dark') }}" aria-label="{{ _('light/dark') }}" data-bs-placement="bottom" data-bs-toggle="tooltip">
     <span class="theme-switch nav-link" data-mode="light"><i class="fa-solid fa-sun fa-lg"></i></span>
     <span class="theme-switch nav-link" data-mode="dark"><i class="fa-solid fa-moon fa-lg"></i></span>
     <span class="theme-switch nav-link" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg"></i></span>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/version-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/version-switcher.html
@@ -7,7 +7,7 @@ document.write(`
   <div class="version-switcher__container dropdown">
     <button id="{{ button_id }}"
       type="button"
-      class="version-switcher__button btn btn-sm navbar-btn dropdown-toggle"
+      class="version-switcher__button btn btn-sm dropdown-toggle"
       data-bs-toggle="dropdown"
       aria-haspopup="listbox"
       aria-controls="{{ dropdown_id }}"

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -1,6 +1,6 @@
 {% if theme_navbar_start or theme_navbar_center or theme_navbar_end or theme_navbar_persistent %}
 <div class="bd-header__inner bd-page-width">
-  <button class="sidebar-toggle primary-toggle" aria-label="{{ _('Site navigation') }}">
+  <button class="pst-navbar-icon sidebar-toggle primary-toggle" aria-label="{{ _('Site navigation') }}">
     <span class="fa-solid fa-bars"></span>
   </button>
   {% set navbar_start, navbar_class, navbar_align = navbar_align_class() %}
@@ -40,7 +40,7 @@
   {% endfor %}
 
   {% if not remove_sidebar_secondary and secondary_sidebar_items %}
-    <button class="sidebar-toggle secondary-toggle" aria-label="{{ _('On this page') }}">
+    <button class="pst-navbar-icon sidebar-toggle secondary-toggle" aria-label="{{ _('On this page') }}">
       <span class="fa-solid fa-outdent"></span>
     </button>
   {% endif %}

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -220,17 +220,21 @@ def add_toctree_functions(
 
         links_html = []
         boilerplate = """
-            <li class="nav-item pst-header-nav-item{active}">
-              <a class="nav-link nav-{ext_int}" href="{href}">
+            <li class="{nav_item} {active}">
+              <a class="{nav_link} nav-{ext_int}" href="{href}">
                 {title}
               </a>
             </li>
             """
+        nav_item = "nav-item"
+        nav_link = "nav-link"
         for link in links_data:
             links_html.append(
                 dedent(
                     boilerplate.format(
                         active=" current active" if link.is_current else "",
+                        nav_link=nav_link,
+                        nav_item=nav_item,
                         ext_int="external" if link.is_external else "internal",
                         href=link.href,
                         title=link.title,
@@ -244,12 +248,7 @@ def add_toctree_functions(
 
         # Wrap the final few header items in a "more" dropdown
         links_dropdown = [
-            # 🐲 brittle code because it relies on the code above to build the HTML in a particular way
-            html.replace("nav-link", "nav-link dropdown-item").replace(
-                # Prevents the header-link mixin from applying to links within the dropdown
-                "pst-header-nav-item",
-                "",
-            )
+            html.replace(nav_item, "").replace(nav_link, "nav-link dropdown-item")
             for html in links_html[n_links_before_dropdown:]
         ]
 
@@ -284,7 +283,7 @@ def add_toctree_functions(
             dropdown_id = unique_html_id("pst-nav-more-links")
             links_dropdown_html = "\n".join(links_dropdown)
             out += f"""
-            <li class="nav-item dropdown pst-header-nav-item">
+            <li class="nav-item dropdown">
                 <button class="btn dropdown-toggle nav-item" type="button" data-bs-toggle="dropdown" aria-expanded="false" aria-controls="{dropdown_id}">
                     {_(dropdown_text)}
                 </button>

--- a/tests/test_build/math_header_item.html
+++ b/tests/test_build/math_header_item.html
@@ -1,4 +1,4 @@
-<li class="nav-item pst-header-nav-item current active">
+<li class="nav-item current active">
  <a class="nav-link nav-internal" href="#">
   Page
   <span class="math notranslate nohighlight">

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -1,6 +1,6 @@
 <ul aria-label="Icon Links" class="navbar-icon-links">
  <li class="nav-item">
-  <a class="nav-link" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
+  <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
    <span>
     <i aria-hidden="true" class="FACLASS fa-lg">
     </i>
@@ -11,7 +11,7 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
+  <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
    <span>
     <i aria-hidden="true" class="FADEFAULTCLASS fa-lg">
     </i>
@@ -22,20 +22,24 @@
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
-   <img alt="LOCAL FILE" class="icon-link-image" src="emptylogo.png"/>
+  <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
+   <span>
+    <img alt="LOCAL FILE" class="icon-link-image" src="emptylogo.png"/>
+   </span>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
+  <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site4.org" rel="noopener" target="_blank" title="WRONG TYPE">
    <span>
     Incorrectly configured icon link. Type must be `fontawesome`, `url` or `local`.
    </span>
   </a>
  </li>
  <li class="nav-item">
-  <a class="nav-link" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
-   <img alt="URL" class="icon-link-image" src="https://site5.org/image.svg"/>
+  <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
+   <span>
+    <img alt="URL" class="icon-link-image" src="https://site5.org/image.svg"/>
+   </span>
   </a>
  </li>
  <li class="nav-item">

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -1,10 +1,8 @@
 <ul aria-label="Icon Links" class="navbar-icon-links">
  <li class="nav-item">
   <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
-   <span>
-    <i aria-hidden="true" class="FACLASS fa-lg">
-    </i>
-   </span>
+   <i aria-hidden="true" class="FACLASS fa-lg">
+   </i>
    <span class="sr-only">
     FONTAWESOME
    </span>
@@ -12,10 +10,8 @@
  </li>
  <li class="nav-item">
   <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
-   <span>
-    <i aria-hidden="true" class="FADEFAULTCLASS fa-lg">
-    </i>
-   </span>
+   <i aria-hidden="true" class="FADEFAULTCLASS fa-lg">
+   </i>
    <span class="sr-only">
     FONTAWESOME DEFAULT
    </span>
@@ -23,9 +19,7 @@
  </li>
  <li class="nav-item">
   <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site3.org" rel="noopener" target="_blank" title="LOCAL FILE">
-   <span>
-    <img alt="LOCAL FILE" class="icon-link-image" src="emptylogo.png"/>
-   </span>
+   <img alt="LOCAL FILE" class="icon-link-image" src="emptylogo.png"/>
   </a>
  </li>
  <li class="nav-item">
@@ -37,17 +31,13 @@
  </li>
  <li class="nav-item">
   <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site5.org" rel="noopener" target="_blank" title="URL">
-   <span>
-    <img alt="URL" class="icon-link-image" src="https://site5.org/image.svg"/>
-   </span>
+   <img alt="URL" class="icon-link-image" src="https://site5.org/image.svg"/>
   </a>
  </li>
  <li class="nav-item">
   <a class="overridden classes" data-bs-placement="bottom" data-bs-toggle="tooltip" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
-   <span>
-    <i aria-hidden="true" class="FACLASS fa-lg">
-    </i>
-   </span>
+   <i aria-hidden="true" class="FACLASS fa-lg">
+   </i>
    <span class="sr-only">
     FONTAWESOME
    </span>

--- a/tests/test_build/navbar_ix.html
+++ b/tests/test_build/navbar_ix.html
@@ -2,12 +2,12 @@
  <div class="navbar-item">
   <nav>
    <ul class="bd-navbar-elements navbar-nav">
-    <li class="nav-item pst-header-nav-item">
+    <li class="nav-item">
      <a class="nav-link nav-internal" href="page1.html">
       Page 1
      </a>
     </li>
-    <li class="nav-item pst-header-nav-item">
+    <li class="nav-item">
      <a class="nav-link nav-internal" href="page2.html">
       Page
       <span class="math notranslate nohighlight">
@@ -15,12 +15,12 @@
       </span>
      </a>
     </li>
-    <li class="nav-item pst-header-nav-item">
+    <li class="nav-item">
      <a class="nav-link nav-internal" href="section1/index.html">
       Section 1 index
      </a>
     </li>
-    <li class="nav-item pst-header-nav-item">
+    <li class="nav-item">
      <a class="nav-link nav-external" href="https://google.com">
       google
      </a>

--- a/tests/test_build/navbar_switcher.html
+++ b/tests/test_build/navbar_switcher.html
@@ -3,7 +3,7 @@
   <div class="version-switcher__container dropdown">
     <button id="pst-version-switcher-button-2"
       type="button"
-      class="version-switcher__button btn btn-sm navbar-btn dropdown-toggle"
+      class="version-switcher__button btn btn-sm dropdown-toggle"
       data-bs-toggle="dropdown"
       aria-haspopup="listbox"
       aria-controls="pst-version-switcher-list-2"

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,6 +1,6 @@
 <script>
  document.write(`
-  <button class="btn btn-sm navbar-btn theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
+  <button class="btn btn-sm pst-navbar-icon theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
     <span class="theme-switch nav-link" data-mode="light"><i class="fa-solid fa-sun fa-lg"></i></span>
     <span class="theme-switch nav-link" data-mode="dark"><i class="fa-solid fa-moon fa-lg"></i></span>
     <span class="theme-switch nav-link" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg"></i></span>

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,9 +1,9 @@
 <script>
  document.write(`
-  <button class="btn btn-sm pst-navbar-icon theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
-    <span class="theme-switch nav-link" data-mode="light"><i class="fa-solid fa-sun fa-lg"></i></span>
-    <span class="theme-switch nav-link" data-mode="dark"><i class="fa-solid fa-moon fa-lg"></i></span>
-    <span class="theme-switch nav-link" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg"></i></span>
+  <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
+    <i class="theme-switch fa-solid fa-sun fa-lg" data-mode="light"></i>
+    <i class="theme-switch fa-solid fa-moon fa-lg" data-mode="dark"></i>
+    <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg" data-mode="auto"></i>
   </button>
 `);
 </script>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -35,10 +35,10 @@
    <div class="navbar-item">
     <script>
      document.write(`
-  <button class="btn btn-sm pst-navbar-icon theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
-    <span class="theme-switch nav-link" data-mode="light"><i class="fa-solid fa-sun fa-lg"></i></span>
-    <span class="theme-switch nav-link" data-mode="dark"><i class="fa-solid fa-moon fa-lg"></i></span>
-    <span class="theme-switch nav-link" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg"></i></span>
+  <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
+    <i class="theme-switch fa-solid fa-sun fa-lg" data-mode="light"></i>
+    <i class="theme-switch fa-solid fa-moon fa-lg" data-mode="dark"></i>
+    <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg" data-mode="auto"></i>
   </button>
 `);
     </script>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -4,12 +4,12 @@
    <div class="navbar-item">
     <nav>
      <ul class="bd-navbar-elements navbar-nav">
-      <li class="nav-item pst-header-nav-item">
+      <li class="nav-item">
        <a class="nav-link nav-internal" href="../page1.html">
         Page 1
        </a>
       </li>
-      <li class="nav-item pst-header-nav-item">
+      <li class="nav-item">
        <a class="nav-link nav-internal" href="../page2.html">
         Page
         <span class="math notranslate nohighlight">
@@ -17,12 +17,12 @@
         </span>
        </a>
       </li>
-      <li class="nav-item pst-header-nav-item current active">
+      <li class="nav-item current active">
        <a class="nav-link nav-internal" href="#">
         Section 1 index
        </a>
       </li>
-      <li class="nav-item pst-header-nav-item">
+      <li class="nav-item">
        <a class="nav-link nav-external" href="https://google.com">
         google
        </a>
@@ -35,7 +35,7 @@
    <div class="navbar-item">
     <script>
      document.write(`
-  <button class="btn btn-sm navbar-btn theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
+  <button class="btn btn-sm pst-navbar-icon theme-switch-button" title="light/dark" aria-label="light/dark" data-bs-placement="bottom" data-bs-toggle="tooltip">
     <span class="theme-switch nav-link" data-mode="light"><i class="fa-solid fa-sun fa-lg"></i></span>
     <span class="theme-switch nav-link" data-mode="dark"><i class="fa-solid fa-moon fa-lg"></i></span>
     <span class="theme-switch nav-link" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg"></i></span>

--- a/tests/test_build/test_navbar_no_in_page_headers.html
+++ b/tests/test_build/test_navbar_no_in_page_headers.html
@@ -1,10 +1,10 @@
 <ul class="bd-navbar-elements navbar-nav">
- <li class="nav-item pst-header-nav-item">
+ <li class="nav-item">
   <a class="nav-link nav-internal" href="page1.html">
    Page 1
   </a>
  </li>
- <li class="nav-item pst-header-nav-item">
+ <li class="nav-item">
   <a class="nav-link nav-internal" href="page2.html">
    Page 2
   </a>


### PR DESCRIPTION
Part of https://github.com/pydata/pydata-sphinx-theme/issues/1865.

Fixes external issue https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/94.

This pull request started as a simple increase of the hit area for the navbar icon links, but then I realized that with #1846 having been merged, I could do a little bit of code cleanup at the same time.