### PR TITLE
MAINT: Upload nightly wheels and run packaging on PRs and pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,11 +7,8 @@ on:
     types:
       - published
   schedule:
-    - cron: "0 2 * * *"  # at 2AM UTC
+    - cron: "0 2 * * *" # at 2AM UTC
   pull_request:
-    branches:
-      - main
-  push:
     branches:
       - main
   workflow_dispatch:
@@ -73,7 +70,7 @@ jobs:
         if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'
 
       - name: "Publish PST package to scientific-python-nightly-wheels 🚀"
-        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc  # 0.5.0
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc # 0.5.0
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: "Unzip artifact"
         run: |
-          tar xf dist/*.tar.gz --strip-components=1
+          tar xvf dist/*.tar.gz --strip-components=1
 
       - name: "Publish PST package to PyPI 🚀"
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,14 @@ on:
   release:
     types:
       - published
+  schedule:
+    - cron: "0 2 * * *"  # at 2AM UTC
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 env:
@@ -63,3 +71,10 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         # only publish if this is a published release by pydata
         if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'
+
+      - name: "Publish PST package to scientific-python-nightly-wheels 🚀"
+        uses: scientific-python/upload-nightly-action@b67d7fcc0396e1128a474d1ab2b48aa94680f9fc  # 0.5.0
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
+        if: github.repository_owner == 'pydata' && github.event_name == 'schedule'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,6 @@ on:
       - published
   schedule:
     - cron: "0 2 * * *" # at 2AM UTC
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
It seems like it should be okay to run packaging steps on each PR and push to `main`, but we'll see if it adds a lot of overhead. Then also add a nightly wheel upload to https://anaconda.org/scientific-python-nightly-wheels.

This will require getting an Anaconda token from the appropriate folks and adding it as a secret, so marking as a draft for now.