### PR TITLE
ENH - Update copyright.html to not include the html tags.

### DIFF
--- a/docs/community/practices/versions.md
+++ b/docs/community/practices/versions.md
@@ -14,6 +14,7 @@ We define "support" as testing against each of these versions so that users can 
 For example, if we made a minor release tomorrow, we'd [look at the EOL schedule for Python](https://endoflife.date/python) and support all the versions that fall within a 3.5-year window.
 
 [^1]: Our support for Python versions is inspired by [NEP 029](https://numpy.org/neps/nep-0029-deprecation_policy.html).
+
 [^2]: These policies are goals, not promises. We are a volunteer-led community with limited time. Consider these sections to be our intention, but we recognize that we may not always be able to meet these criteria if we cannot do so. We welcome contributions from others to help us more sustainably meet these goals!
 
 ## Supported Sphinx versions

--- a/docs/user_guide/theme-elements.md
+++ b/docs/user_guide/theme-elements.md
@@ -203,8 +203,11 @@ Here's a numeric footnote[^1], another one (preceded by a space) [^2], a named f
 All will end up as numbers in the rendered HTML, but in the source they look like `[^1]`, `[^2]`, `[^named]` and `[^*]`.
 
 [^1]: Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar.
+
 [^2]: Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar.
+
 [^named]: Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar.
+
 [^*]: Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar. Foo bar foo bar.
 
 ## Link shortening for git repository services

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/copyright.html
@@ -2,7 +2,7 @@
 {% if show_copyright and copyright %}
   <p class="copyright">
     {% if hasdoc('copyright') %}
-      {% trans path=pathto('copyright'), copyright=copyright|e %}© <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+      © <a href="{{ pathto('copyright') }}">{% trans copyright=copyright|e %}Copyright {{ copyright }}{% endtrans %}</a>.
       <br/>
     {% else %}
       {% trans copyright=copyright|e %}© Copyright {{ copyright }}.{% endtrans %}


### PR DESCRIPTION
I think it is a mistake to include a tags.

Note that with the exception of the `©`, the two translate blocks are almost identical, so I would also be for including the © inside the html copyright to have the same translatable strings.

Closes #1873