### PR TITLE
bump sphinxcontrib-youtube

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ doc = [
   "sphinx-design",
   "sphinx-togglebutton",
   "jupyterlite-sphinx",
-  "sphinxcontrib-youtube<1.4",
+  "sphinxcontrib-youtube>=1.4.1",
   "sphinx-favicon>=1.0.1",
   "ipykernel",
   "nbsphinx",


### PR DESCRIPTION
This should avoid 

```
/home/runner/work/pydata-sphinx-theme/pydata-sphinx-theme/.tox/py312-docs/lib/python3.12/site-packages/sphinxcontrib/youtube/utils.py:9: RemovedInSphinx80Warning: The alias 'sphinx.util.status_iterator' is deprecated, use 'sphinx.util.display.status_iterator' instead. Check CHANGES for Sphinx API modifications.
```
showing up in our CI logs, by picking up a version that includes https://github.com/sphinx-contrib/youtube/pull/56. This could/should have been done anytime after #1413