### PR TITLE
A11Y - Add visual indicator for tabs hover

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_sphinx_design.scss
@@ -207,6 +207,8 @@ html[data-theme="light"] {
     &:not(:checked, :focus-visible) + label:hover {
       border-color: transparent;
       color: var(--pst-color-secondary);
+      text-decoration-line: underline;
+      text-decoration-thickness: $link-hover-decoration-thickness;
     }
   }
 


### PR DESCRIPTION
Only changing color is not visually distinctive enough, adding an underline with same size as link underline thickness.

See Quansight-Labs/czi-scientific-python-mgmt#79