### PR TITLE
Fix url shortening for gitlab, and more test for github

### DIFF
--- a/src/pydata_sphinx_theme/short_link.py
+++ b/src/pydata_sphinx_theme/short_link.py
@@ -63,7 +63,6 @@ class ShortenLinkTransform(SphinxPostTransform):
             the reformated url title
         """
         path = uri.path
-
         if path == "":
             # plain url passed, return platform only
             return self.platform
@@ -99,12 +98,18 @@ class ShortenLinkTransform(SphinxPostTransform):
                 map(uri.path.__contains__, ["issues", "merge_requests"])
             ):
                 group_and_subgroups, parts, *_ = path.split("/-/")
-                parts = parts.split("/")
-                url_type, element_number, *_ = parts
-                if url_type == "issues":
-                    text = f"{group_and_subgroups}#{element_number}"
-                elif url_type == "merge_requests":
-                    text = f"{group_and_subgroups}!{element_number}"
+                parts = parts.rstrip("/")
+                if "/" not in parts:
+                    text = f"{group_and_subgroups}/{parts}"
+                else:
+                    parts = parts.split("/")
+                    url_type, element_number, *_ = parts
+                    if not element_number:
+                        text = group_and_subgroups
+                    elif url_type == "issues":
+                        text = f"{group_and_subgroups}#{element_number}"
+                    elif url_type == "merge_requests":
+                        text = f"{group_and_subgroups}!{element_number}"
             else:
                 # display the whole uri (after "gitlab.com/") including parameters
                 # for example "<group>/<subgroup1>/<subgroup2>/<repository>"

--- a/tests/sites/base/page1.rst
+++ b/tests/sites/base/page1.rst
@@ -24,7 +24,9 @@ Page 1
     https://gitlab.com/gitlab-org/gitlab
     https://gitlab.com/gitlab-org/gitlab/-/issues/375583
     https://gitlab.com/gitlab-org/gitlab/issues/375583
+    https://gitlab.com/gitlab-org/gitlab/-/issues/
     https://gitlab.com/gitlab-org/gitlab/issues/
+    https://gitlab.com/gitlab-org/gitlab/-/issues
     https://gitlab.com/gitlab-org/gitlab/issues
     https://gitlab.com/gitlab-org/gitlab/-/merge_requests/84669
     https://gitlab.com/gitlab-org/gitlab/-/pipelines/511894707

--- a/tests/test_build/gitlab_links.html
+++ b/tests/test_build/gitlab_links.html
@@ -15,8 +15,14 @@
   <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/issues/375583">
    gitlab-org/gitlab/issues/375583
   </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/-/issues/">
+   gitlab-org/gitlab/issues
+  </a>
   <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/issues/">
    gitlab-org/gitlab/issues/
+  </a>
+  <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/-/issues">
+   gitlab-org/gitlab/issues
   </a>
   <a class="gitlab reference external" href="https://gitlab.com/gitlab-org/gitlab/issues">
    gitlab-org/gitlab/issues

--- a/tests/test_short_url.py
+++ b/tests/test_short_url.py
@@ -15,7 +15,10 @@ class Mock:
 @pytest.mark.parametrize(
     "platform,url,expected",
     [
+        # TODO, I belive this is wrong as both github.com and github.com/github
+        # shorten to just github.
         ("github", "https://github.com", "github"),
+        ("github", "https://github.com/github", "github"),
         ("github", "https://github.com/pydata", "pydata"),
         (
             "github",
@@ -27,7 +30,13 @@ class Mock:
             "https://github.com/pydata/pydata-sphinx-theme/pull/1012",
             "pydata/pydata-sphinx-theme#1012",
         ),
+        # TODO, I belive this is wrong as both orgs/pydata/projects/2 and pydata/projects/issue/2
+        # shorten to the same
         ("github", "https://github.com/orgs/pydata/projects/2", "pydata/projects#2"),
+        ("github", "https://github.com/pydata/projects/pull/2", "pydata/projects#2"),
+        # issues and pulls are athe same, so it's ok to normalise to the same here
+        ("github", "https://github.com/pydata/projects/issues/2", "pydata/projects#2"),
+        # Gitlab
         ("gitlab", "https://gitlab.com/tezos/tezos/-/issues", "tezos/tezos/issues"),
         ("gitlab", "https://gitlab.com/tezos/tezos/issues", "tezos/tezos/issues"),
         (
@@ -36,7 +45,8 @@ class Mock:
             "gitlab-org/gitlab#375583",
         ),
         (
-            # todo, non cannonical url, needs extra parsing.
+            # TODO, non canonical url, discuss if should maybe  be shortened to
+            # gitlab-org/gitlab#375583
             "gitlab",
             "https://gitlab.com/gitlab-org/gitlab/issues/375583",
             "gitlab-org/gitlab/issues/375583",
@@ -47,7 +57,8 @@ class Mock:
             "gitlab-org/gitlab/issues",
         ),
         (
-            # todo, non cannonical url, needs extra parsing.
+            # TODO, non canonical url, discuss if should maybe  be shortened to
+            # gitlab-org/gitlab/issues (no trailing slash)
             "gitlab",
             "https://gitlab.com/gitlab-org/gitlab/issues/",
             "gitlab-org/gitlab/issues/",

--- a/tests/test_short_url.py
+++ b/tests/test_short_url.py
@@ -1,0 +1,84 @@
+"""Shortening url tests."""
+
+from urllib.parse import urlparse
+
+import pytest
+from pydata_sphinx_theme.short_link import ShortenLinkTransform
+
+
+class Mock:
+    """mock object."""
+
+    pass
+
+
+@pytest.mark.parametrize(
+    "platform,url,expected",
+    [
+        ("gitlab", "https://gitlab.com/tezos/tezos/-/issues", "tezos/tezos/issues"),
+        ("gitlab", "https://gitlab.com/tezos/tezos/issues", "tezos/tezos/issues"),
+        (
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/-/issues/375583",
+            "gitlab-org/gitlab#375583",
+        ),
+        (
+            # todo, non cannonical url, needs extra parsing.
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/issues/375583",
+            "gitlab-org/gitlab/issues/375583",
+        ),
+        (
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/-/issues/",
+            "gitlab-org/gitlab/issues",
+        ),
+        (
+            # todo, non cannonical url, needs extra parsing.
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/issues/",
+            "gitlab-org/gitlab/issues/",
+        ),
+        (
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/-/issues",
+            "gitlab-org/gitlab/issues",
+        ),
+        (
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/issues",
+            "gitlab-org/gitlab/issues",
+        ),
+        (
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/-/merge_requests/84669",
+            "gitlab-org/gitlab!84669",
+        ),
+        (
+            "gitlab",
+            "https://gitlab.com/gitlab-org/gitlab/-/pipelines/511894707",
+            "gitlab-org/gitlab/-/pipelines/511894707",
+        ),
+        (
+            "gitlab",
+            "https://gitlab.com/gitlab-com/gl-infra/production/-/issues/6788",
+            "gitlab-com/gl-infra/production#6788",
+        ),
+    ],
+)
+def test_shorten(platform, url, expected):
+    """Unit test for url shortening.
+
+    Usually you also want a build test in `test_build.py`
+    """
+    document = Mock()
+    document.settings = Mock()
+    document.settings.language_code = "en"
+    document.reporter = None
+
+    sl = ShortenLinkTransform(document)
+    sl.platform = platform
+
+    URI = urlparse(url)
+
+    assert sl.parse_url(URI) == expected

--- a/tests/test_short_url.py
+++ b/tests/test_short_url.py
@@ -15,6 +15,19 @@ class Mock:
 @pytest.mark.parametrize(
     "platform,url,expected",
     [
+        ("github", "https://github.com", "github"),
+        ("github", "https://github.com/pydata", "pydata"),
+        (
+            "github",
+            "https://github.com/pydata/pydata-sphinx-theme",
+            "pydata/pydata-sphinx-theme",
+        ),
+        (
+            "github",
+            "https://github.com/pydata/pydata-sphinx-theme/pull/1012",
+            "pydata/pydata-sphinx-theme#1012",
+        ),
+        ("github", "https://github.com/orgs/pydata/projects/2", "pydata/projects#2"),
         ("gitlab", "https://gitlab.com/tezos/tezos/-/issues", "tezos/tezos/issues"),
         ("gitlab", "https://gitlab.com/tezos/tezos/issues", "tezos/tezos/issues"),
         (


### PR DESCRIPTION
Closes #1887

Note that some non cannonical url (not having /-/) are not properly shortened.