### PR TITLE
docs: update note formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and use as follows:
 
 And that's it!
 
-> [!NOTE]  
+> [!NOTE]
 > This theme may not work with the latest major versions of Sphinx, especially
 > if they have only recently been released. Please give us a few months of
 > time to work out any bugs and changes when new releases are made.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ and use as follows:
 
 And that's it!
 
-> **Note**
+> [!NOTE]  
 > This theme may not work with the latest major versions of Sphinx, especially
 > if they have only recently been released. Please give us a few months of
 > time to work out any bugs and changes when new releases are made.


### PR DESCRIPTION
THe way Github parse markdown to generate admonition have been changed as explained in https://github.com/orgs/community/discussions/16925. The trick used by @choldgraf was not working anymore.