### PR TITLE
BUG - Remove schedule trigger for comment action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -229,6 +229,8 @@ jobs:
       - name: "Coverage comment 💬"
         uses: py-cov-action/python-coverage-comment-action@v3
         id: coverage_comment
+        # avoid running this on schedule or releases
+        if: github.event.workflow_run.event != 'schedule' || github.event.workflow_run.event != 'release'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -230,7 +230,7 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@v3
         id: coverage_comment
         # avoid running this on schedule or releases
-        if: github.event.workflow_run.event != 'schedule' || github.event.workflow_run.event != 'release'
+        if: github.event.workflow_run.event != 'schedule' && github.event.workflow_run.event != 'release'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  # calls our tests workflow
+  # calls our general CI workflow (tests, build docs, etc.)
   tests:
     uses: ./.github/workflows/CI.yml
 


### PR DESCRIPTION
The `publish-to-pypi` workflow has failed due to the coverage comment action since there is no PR or separate coverage branch.

This PR prevents the comment workflow from triggering in such cases and during releases to avoid potential hiccups.