### PR TITLE
MAINT - Add CI env check for a11y tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,6 +72,7 @@ commands =
 [testenv:a11y-tests]
 description = run accessibility tests with Playwright and axe-core
 base_python = py312 # keep in sync with tests.yml
+pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 extras = 
     test
     a11y
@@ -80,7 +81,7 @@ depends =
     py312-docs
 allowlist_externals=playwright
 commands = 
-    playwright install 
+    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
     pytest -m "a11y" {posargs}
 
 # build PST documentation with the default or a specific Sphinx version


### PR DESCRIPTION
Raised in https://github.com/pydata/pydata-sphinx-theme/issues/1906 - while this is working as is, it might be best to ensure we have all the dependencies in CI. 

For more context, this comes as most people will have some of the dependencies through the installation of Playwright and browsers locally, but some might go missing in isolated CI environments.