### PR TITLE
Change pandoc action

### DIFF
--- a/.github/actions/set-dev-env/action.yml
+++ b/.github/actions/set-dev-env/action.yml
@@ -25,8 +25,8 @@ runs:
     - run: python -Im pip install tox-uv
       shell: bash
 
-    # waiting for https://github.com/nikeee/setup-pandoc/pull/8
-    # using 12rambau fork until then
     - name: "Install pandoc 📝"
-      uses: 12rambau/setup-pandoc@test
+      uses: r-lib/actions/setup-pandoc@v2
+      with:
+        pandoc-version: "latest"
       if: ${{ inputs.pandoc }} == true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -146,11 +146,11 @@ jobs:
         shell: bash
         run: |
           # check if there is a specific Sphinx version to build with
-          # example substitution: tox run -e docs-py39-sphinx61-docs
+          # example substitution: tox run -e py39-sphinx61-docs
           if [ -n "${{matrix.sphinx-version}}" ]; then
             python -Im tox run -e py$(echo ${{ matrix.python-version }} | tr -d .)-sphinx$(echo ${{ matrix.sphinx-version }} | tr -d .)-docs
-          # build with the default Sphinx version 
-          # example substitution: tox run -e docs-py312-docs
+          # build with the default Sphinx version
+          # example substitution: tox run -e py312-docs
           else
             python -Im tox run -e py$(echo ${{ matrix.python-version }} | tr -d .)-docs
           fi


### PR DESCRIPTION
switches to use a pandoc action that is well-maintained.  The prior one was a fork of this one, providing extra functionality that we don't really need (e.g. working on non-debian runners). 

I also snuck in a couple of typo fixes in the comments of `CI.yaml`