### PR TITLE
Apply modal pattern to search box pop-up

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -194,7 +194,7 @@ var findSearchInput = () => {
     } else {
       // must be at least one persistent form, use the first persistent one
       form = document.querySelector(
-        "div:not(.search-button__search-container) > form.bd-search",
+        ":not(.search-button__search-container) > form.bd-search",
       );
     }
     return form.querySelector("input");
@@ -212,18 +212,26 @@ var toggleSearchField = () => {
 
   // if the input field is the hidden one (the one associated with the
   // search button) then toggle the button state (to show/hide the field)
-  let searchPopupWrapper = document.querySelector(".search-button__wrapper");
-  let hiddenInput = searchPopupWrapper.querySelector("input");
+  let searchDialog = document.querySelector(".search-button__search-container");
+  let hiddenInput = searchDialog.querySelector("input");
   if (input === hiddenInput) {
-    searchPopupWrapper.classList.toggle("show");
-  }
-  // when toggling off the search field, remove its focus
-  if (document.activeElement === input) {
-    input.blur();
+    if (searchDialog.open) {
+      searchDialog.close();
+    } else {
+      // Note: browsers should focus the input field inside the modal dialog
+      // automatically when it is opened.
+      searchDialog.showModal();
+    }
   } else {
-    input.focus();
-    input.select();
-    input.scrollIntoView({ block: "center" });
+    // if the input field is not the hidden one, then toggle its focus state
+
+    if (document.activeElement === input) {
+      input.blur();
+    } else {
+      input.focus();
+      input.select();
+      input.scrollIntoView({ block: "center" });
+    }
   }
 };
 
@@ -295,11 +303,27 @@ var setupSearchButtons = () => {
     btn.onclick = toggleSearchField;
   });
 
-  // Add the search button overlay event callback
-  let overlay = document.querySelector(".search-button__overlay");
-  if (overlay) {
-    overlay.onclick = toggleSearchField;
-  }
+  // If user clicks outside the search modal dialog, then close it.
+  const searchDialog = document.querySelector(
+    ".search-button__search-container",
+  );
+  searchDialog.addEventListener("click", (event) => {
+    if (!searchDialog.open) {
+      return;
+    }
+
+    const { left, right, top, bottom } = searchDialog.getBoundingClientRect();
+    // 0, 0 means top left
+    const clickWasOutsideDialog =
+      event.clientX < left ||
+      right < event.clientX ||
+      event.clientY < top ||
+      bottom < event.clientY;
+
+    if (clickWasOutsideDialog) {
+      searchDialog.close();
+    }
+  });
 };
 
 /*******************************************************************************

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -208,12 +208,14 @@ var findSearchInput = () => {
  */
 var toggleSearchField = () => {
   // Find the search input to highlight
-  let input = findSearchInput();
+  const input = findSearchInput();
 
   // if the input field is the hidden one (the one associated with the
   // search button) then toggle the button state (to show/hide the field)
-  let searchDialog = document.querySelector(".search-button__search-container");
-  let hiddenInput = searchDialog.querySelector("input");
+  const searchDialog = document.querySelector(
+    ".search-button__search-container",
+  );
+  const hiddenInput = searchDialog.querySelector("input");
   if (input === hiddenInput) {
     if (searchDialog.open) {
       searchDialog.close();

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -305,12 +305,17 @@ var setupSearchButtons = () => {
 
   // If user clicks outside the search modal dialog, then close it.
   const searchDialog = document.getElementById("pst-search-dialog");
+  // Dialog click handler includes clicks on dialog ::backdrop.
   searchDialog.addEventListener("click", (event) => {
     if (!searchDialog.open) {
       return;
     }
 
+    // Dialog.getBoundingClientRect() does not include ::backdrop. (This is the
+    // trick that allows us to determine if click was inside or outside of the
+    // dialog: click handler includes backdrop, getBoundingClientRect does not.)
     const { left, right, top, bottom } = searchDialog.getBoundingClientRect();
+
     // 0, 0 means top left
     const clickWasOutsideDialog =
       event.clientX < left ||

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -194,7 +194,7 @@ var findSearchInput = () => {
     } else {
       // must be at least one persistent form, use the first persistent one
       form = document.querySelector(
-        ":not(.search-button__search-container) > form.bd-search",
+        ":not(#pst-search-dialog) > form.bd-search",
       );
     }
     return form.querySelector("input");
@@ -212,9 +212,7 @@ var toggleSearchField = () => {
 
   // if the input field is the hidden one (the one associated with the
   // search button) then toggle the button state (to show/hide the field)
-  const searchDialog = document.querySelector(
-    ".search-button__search-container",
-  );
+  const searchDialog = document.getElementById("pst-search-dialog");
   const hiddenInput = searchDialog.querySelector("input");
   if (input === hiddenInput) {
     if (searchDialog.open) {
@@ -306,9 +304,7 @@ var setupSearchButtons = () => {
   });
 
   // If user clicks outside the search modal dialog, then close it.
-  const searchDialog = document.querySelector(
-    ".search-button__search-container",
-  );
+  const searchDialog = document.getElementById("pst-search-dialog");
   searchDialog.addEventListener("click", (event) => {
     if (!searchDialog.open) {
       return;

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -78,7 +78,7 @@
 /**
  * The search pop-up <dialog>
  */
-.search-button__search-container {
+#pst-search-dialog {
   display: none;
 
   &[open] {

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -76,7 +76,7 @@
 }
 
 /**
- * The search pop-up <dialog>
+ * The search modal <dialog>
  */
 #pst-search-dialog {
   display: none;

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -16,6 +16,15 @@
     color: var(--pst-color-text-muted);
   }
 
+  // Hoist the focus ring from the input field to its parent
+  &:focus-within {
+    box-shadow: $focus-ring-box-shadow;
+
+    input:focus {
+      box-shadow: none;
+    }
+  }
+
   .icon {
     position: absolute;
     color: var(--pst-color-border);
@@ -28,7 +37,15 @@
     color: var(--pst-color-text-muted);
   }
 
-  input {
+  label {
+    display: flex;
+  }
+
+  input.form-control {
+    background-color: var(--pst-color-background);
+    color: var(--pst-color-text-base);
+    border: none;
+
     // Inner-text of the search bar
     &::placeholder {
       color: var(--pst-color-text-muted);
@@ -39,46 +56,36 @@
     &::-webkit-search-decoration {
       appearance: none;
     }
+
+    &:focus,
+    &:focus-visible {
+      color: var(--pst-color-text-muted);
+    }
   }
 
   // Shows off the keyboard shortcuts for the button
   .search-button__kbd-shortcut {
     display: flex;
-    position: absolute;
-    right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: var(--pst-color-border);
-  }
-}
-
-.form-control {
-  background-color: var(--pst-color-background);
-  color: var(--pst-color-text-base);
-
-  &:focus,
-  &:focus-visible {
-    border: none;
-    background-color: var(--pst-color-background);
-    color: var(--pst-color-text-muted);
   }
 }
 
 /**
  * Search button - located in the navbar
  */
-
-// Search link icon should be a bit bigger since it is separate from icon links
 .search-button i {
+  // Search link icon should be a bit bigger since it is separate from icon links
   font-size: 1.3rem;
 }
 
-// __search-container will only show up when we use the search pop-up bar
-.search-button__search-container,
-.search-button__overlay {
+/**
+ * The search pop-up <dialog>
+ */
+.search-button__search-container {
   display: none;
-}
 
-.search-button__wrapper.show {
-  .search-button__search-container {
+  &[open] {
     display: flex;
 
     // Center in middle of screen just underneath header
@@ -91,30 +98,24 @@
     margin-top: 0.5rem;
     width: 90%;
     max-width: 800px;
-  }
+    background-color: transparent;
+    padding: $focus-ring-width;
+    border: none;
 
-  .search-button__overlay {
-    display: flex;
-    position: fixed;
-    z-index: $zindex-modal-backdrop;
-    background-color: black;
-    opacity: 0.5;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-  }
+    &::backdrop {
+      background-color: black;
+      opacity: 0.5;
+    }
 
-  form.bd-search {
-    flex-grow: 1;
-    padding-top: 0;
-    padding-bottom: 0;
-  }
+    form.bd-search {
+      flex-grow: 1;
 
-  // Font and input text a bit bigger
-  svg,
-  input {
-    font-size: var(--pst-font-size-icon);
+      // Font and input text a bit bigger
+      svg,
+      input {
+        font-size: var(--pst-font-size-icon);
+      }
+    }
   }
 }
 
@@ -141,7 +142,7 @@
     border-radius: $search-button-border-radius;
   }
 
-  // The keyboard shotcut text
+  // The keyboard shortcut text
   .search-button__default-text {
     font-size: var(--bs-nav-link-font-size);
     font-weight: var(--bs-nav-link-font-weight);

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -37,10 +37,6 @@
     color: var(--pst-color-text-muted);
   }
 
-  label {
-    display: flex;
-  }
-
   input.form-control {
     background-color: var(--pst-color-background);
     color: var(--pst-color-text-base);

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-field.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-field.html
@@ -2,13 +2,12 @@
 <form class="bd-search d-flex align-items-center"
       action="{{ pathto('search') }}"
       method="get">
-  <label for="{{ search_input_id }}"
-         aria-label="{{ theme_search_bar_text }}"><i class="fa-solid fa-magnifying-glass"></i></label>
+  <i class="fa-solid fa-magnifying-glass"></i>
   <input type="search"
          class="form-control"
          name="q"
-         id="{{ search_input_id }}"
          placeholder="{{ theme_search_bar_text }}"
+         aria-label="{{ theme_search_bar_text }}"
          autocomplete="off"
          autocorrect="off"
          autocapitalize="off"

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-field.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-field.html
@@ -2,13 +2,13 @@
 <form class="bd-search d-flex align-items-center"
       action="{{ pathto('search') }}"
       method="get">
-  <i class="fa-solid fa-magnifying-glass"></i>
+  <label for="{{ search_input_id }}"
+         aria-label="{{ theme_search_bar_text }}"><i class="fa-solid fa-magnifying-glass"></i></label>
   <input type="search"
          class="form-control"
          name="q"
-         id="search-input"
+         id="{{ search_input_id }}"
          placeholder="{{ theme_search_bar_text }}"
-         aria-label="{{ theme_search_bar_text }}"
          autocomplete="off"
          autocorrect="off"
          autocapitalize="off"

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -63,7 +63,7 @@
           id="pst-secondary-sidebar-checkbox"/>
   <label class="overlay overlay-secondary" for="pst-secondary-sidebar-checkbox"></label>
   {# A search field pop-up that will only show when the search button is clicked #}
-  <dialog class="search-button__search-container">
+  <dialog class="#pst-search-dialog">
     {% include "../components/search-field.html" %}
   </dialog>
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -63,7 +63,7 @@
           id="pst-secondary-sidebar-checkbox"/>
   <label class="overlay overlay-secondary" for="pst-secondary-sidebar-checkbox"></label>
   {# A search field pop-up that will only show when the search button is clicked #}
-  <dialog class="pst-search-dialog">
+  <dialog id="pst-search-dialog">
     {% include "../components/search-field.html" %}
   </dialog>
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -63,10 +63,10 @@
           id="pst-secondary-sidebar-checkbox"/>
   <label class="overlay overlay-secondary" for="pst-secondary-sidebar-checkbox"></label>
   {# A search field pop-up that will only show when the search button is clicked #}
-  <div class="search-button__wrapper">
-    <div class="search-button__overlay"></div>
-    <div class="search-button__search-container">{% include "../components/search-field.html" %}</div>
-  </div>
+  <dialog class="search-button__search-container">
+    {%- set search_input_id="search-input-hidden" -%}
+    {% include "../components/search-field.html" %}
+  </dialog>
 
   {% include "sections/announcement.html" %}
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -63,7 +63,7 @@
           id="pst-secondary-sidebar-checkbox"/>
   <label class="overlay overlay-secondary" for="pst-secondary-sidebar-checkbox"></label>
   {# A search field pop-up that will only show when the search button is clicked #}
-  <dialog class="#pst-search-dialog">
+  <dialog class="pst-search-dialog">
     {% include "../components/search-field.html" %}
   </dialog>
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -64,7 +64,6 @@
   <label class="overlay overlay-secondary" for="pst-secondary-sidebar-checkbox"></label>
   {# A search field pop-up that will only show when the search button is clicked #}
   <dialog class="search-button__search-container">
-    {%- set search_input_id="search-input-hidden" -%}
     {% include "../components/search-field.html" %}
   </dialog>
 

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html
@@ -9,6 +9,7 @@
         <p>{% trans %}Please activate JavaScript to enable the search functionality.{% endtrans %}</p>
       </div>
     </noscript>
+    {%- set search_input_id="search-input-results-page" -%}
     {% include "../components/search-field.html" %}
     <div id="search-results"></div>
   </div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html
@@ -9,7 +9,6 @@
         <p>{% trans %}Please activate JavaScript to enable the search functionality.{% endtrans %}</p>
       </div>
     </noscript>
-    {%- set search_input_id="search-input-results-page" -%}
     {% include "../components/search-field.html" %}
     <div id="search-results"></div>
   </div>


### PR DESCRIPTION
Closes external issue https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/83.

### Summary

This PR implements the pop-up search field as an HTML-native `<dialog>`. This somewhat simplifies our implementation and brings accessibility affordances with it.

I also introduced a couple visual changes, which fix #1714.

#### Before

<img width="942" alt="Before this PR, there is a border around the input element and its parent, so you have two borders that bump against each other on the top, bottom, and right sides." src="https://github.com/user-attachments/assets/006b7a75-435f-4dc1-84b8-9cf7875b822d">

<img width="942" alt="Before this PR, the focus ring was just around the input element when it was focus, not the entire search bar." src="https://github.com/user-attachments/assets/4fbd2061-8ef7-4f70-a7a2-af013b9edc34">


#### After

<img width="942" alt="This PR removes the border around the input element, so that there is only one border, around the parent element, which is the same as around the entire search bar." src="https://github.com/user-attachments/assets/82a0c612-4e4e-46d0-b08c-d0cc6e4a9310">

<img width="942" alt="This PR puts the focus ring around the entire search bar when the input element is focused rather than just around the input element itself. To my eyes this looks more natural." src="https://github.com/user-attachments/assets/9ebb4e04-8a44-425e-b01b-3166a7b928c8">



### Test plan

I tested this in Firefox, Chrome, and Safari on my Mac. I also tested it in Ubuntu + Firefox.

TODO:

- [ ] Test on Windows

There are at least six different presentations of the search input field that need to be tested:

1. Search modal on homepage
2. Search input box on search results page
3. Persistent search field at /examples/persistent-search-field.html
4. Mobile: search modal on homepage
5. Mobile: search input box on search results page
6. **BROKEN**. Mobile: persistent search field

As the persistent search is currently broken in production, it's also broken in this PR. How so? On the persistent search field example page, if you click the search button in the nav bar, or you press the keyboard shortcut (Ctrl + K), neither of those actions does anything because the "persistent" search field is hidden behind the mobile sidebar which only opens up if you click the hamburger icon.
