### PR TITLE
MAINT: remove packaing as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "sphinx>=5",
   "beautifulsoup4",
   "docutils!=0.17.0",
-  "packaging",
   "Babel",
   "pygments>=2.7",
   "accessible-pygments",

--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -2,8 +2,6 @@
 
 import types
 
-import sphinx
-from packaging.version import Version
 from sphinx.application import Sphinx
 from sphinx.ext.autosummary import autosummary_table
 from sphinx.util import logging
@@ -40,10 +38,7 @@ class BootstrapHTML5TranslatorMixin:
         # init the attributes
         atts = {}
 
-        if Version(sphinx.__version__) < Version("4.3"):
-            self._table_row_index = 0
-        else:
-            self._table_row_indices.append(0)
+        self._table_row_indices.append(0)
 
         # get the classes
         classes = [cls.strip(" \t\n") for cls in self.settings.table_style.split(",")]


### PR DESCRIPTION
It was only used to compared the version of sphinxm to 4.3, but we anyway require sphinx to be greater then 5 in pyprojet.toml, so it is dead code and unsused dependency.