### PR TITLE
Bump minimum sphinx version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
-  "sphinx>=5",
+  "sphinx>=6.1",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "Babel",


### PR DESCRIPTION
As far as I can tell we already implicitely requires 6.1 as this this what CI files are saying.

That woudl roughly put us in line with https://scientific-python.org/specs/spec-0000/

We could likely also bump docutils to 0.19+.