### PR TITLE
Remove Ctrl-K shortcut indicator from modal

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-field.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-field.html
@@ -12,5 +12,4 @@
          autocorrect="off"
          autocapitalize="off"
          spellcheck="false"/>
-  <span class="search-button__kbd-shortcut"><kbd class="kbd-shortcut__modifier">Ctrl</kbd>+<kbd>K</kbd></span>
 </form>


### PR DESCRIPTION
The shortcut is already present on the navbar button that will show the modal, thus it is likely unnecessary on the modal itself.

As pointed out in #1944, this is also super crowded on mobile, so less element is actually cleaner.

This also remove Ctrl-K from the search field on the search page, but again, It is likely unnecessary there, as the user is already on the search page.

In general I think removing is better than having it as an option as it is less maintenance.

Closes #1944