### PR TITLE
Remove shortcut indicator search dialog on small screens

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -61,9 +61,13 @@
 
   // Shows off the keyboard shortcuts for the button
   .search-button__kbd-shortcut {
-    display: flex;
+    display: none;
     margin-inline-end: 0.5rem;
     color: var(--pst-color-border);
+
+    @include media-breakpoint-up(lg) {
+      display: flex;
+    }
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_search.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_search.scss
@@ -65,7 +65,7 @@
     margin-inline-end: 0.5rem;
     color: var(--pst-color-border);
 
-    @include media-breakpoint-up(lg) {
+    @include media-breakpoint-up(md) {
       display: flex;
     }
   }


### PR DESCRIPTION
Closes #1944.

Alternative to #1945. While #1945 removes the shortcut completely, I've [suggested that it actually has value](https://github.com/pydata/pydata-sphinx-theme/pull/1945#issuecomment-2268537495) and should only be removed on smaller screens. That's what this PR implements. It shows the shortcuts if the window size is at least "md" i.e. >=768px (I figured, this is a reasonable threshold - see discussion below, but if you think other values are better, that's perfectly fine).

Search on small screens (IPhone Pro Max size)
![image](https://github.com/user-attachments/assets/0a35f8bb-024e-4dda-9f1b-84012665baa5)


The minimum width with shortcuts is illustrated in the following screenshot. With this the search field is large enough that the shortcut on the right is not cluttering/distracting from the "Search the docs ..." message. On the other end, I'd consider that size about the minimum size a user would give a browser window to read docs. If the window size is smaller, it's unlikely that the user is using a "large" device with a keyboard attached, and hence the shortcut is not needed.
![image](https://github.com/user-attachments/assets/e4865315-fe0f-49db-91d6-f10d9e05c0eb)
