### PR TITLE
Increase horizontal whitespace between navbar icon links

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_icon-links.scss
@@ -27,7 +27,7 @@
 ul.navbar-icon-links {
   display: flex;
   flex-flow: row wrap;
-  column-gap: 1rem;
+  column-gap: $nav-icon-column-gap;
   justify-content: space-evenly;
   align-items: center;
   padding-left: 0;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -65,7 +65,7 @@
 
   .navbar-header-items__end,
   .navbar-header-items__center {
-    column-gap: 1rem;
+    column-gap: $nav-icon-column-gap;
   }
 
   // A little smaller because this is displayed by default on mobile

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -37,3 +37,8 @@ $admonition-border-radius: 0.25rem;
 $focus-ring-radius: 0.125rem; // 2px at 100% zoom and 16px base font.
 
 $navbar-link-padding-y: 0.25rem;
+
+// Ensure that there is no overlap of bumper disks (smallest circle that
+// contains the bounding box of the interactive element).
+// - https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/81#issuecomment-2251325783
+$nav-icon-column-gap: 1.12rem;


### PR DESCRIPTION
Fixes external issue: https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/81

This PR increases the horizontal gap between the navbar icons slightly (1rem to 1.12rem) to align better with accessibility guidelines. The idea is to make sure that the circle targets (pink) do not overlap:

<img width="473" alt="visualization of circle targets shows that with code changes in this PR, the circle targets no longer overlap" src="https://github.com/user-attachments/assets/b73bdd30-a984-4d50-9787-cf8814c6d232">

It would be nice if we could rework the navbar icon links to have a known hit area at build time (hit area being the union of width, height, and padding). That way we could calculate the [needed horizontal and vertical margins](https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/81#issuecomment-2251325783) with SCSS, like so: 

```scss
@mixin enclosing-circle-margin($hit-area-width, $hit-area-height) {
  // the diagonal of the hit area rectangle is also the diameter of the minimum enclosing circle
  $hit-area-diagonal: math.hypot($hit-area-width, $hit-area-height);
  $mx: ($hit-area-diagonal - $hit-area-width) / 2;
  $my: ($hit-area-diagonal - $hit-area-height) / 2;

  margin: $my $mx;
}
```

But that will have to be for another time.