### PR TITLE
DOCS - Fix link

### DIFF
--- a/docs/user_guide/web-components.rst
+++ b/docs/user_guide/web-components.rst
@@ -7,9 +7,12 @@ Sphinx Design Components
 On this page, you will find user interface components such as badges, buttons,
 cards, and tabs.
 
-The components on this page are **not provided by PyData Theme**.
-They are provided by `Sphinx Design <https://sphinx-design.readthedocs.io/en/pydata-theme/index.html>`_ (a Sphinx extension).
-This means that if you wish to use the components on this page, you must install Sphinx Design separately and add it to your `conf.py`.
+.. _Sphinx Design: https://sphinx-design.readthedocs.io/en/pydata-theme/index.html
+
+The components on this page are **not provided by PyData Theme**. They are
+provided by `Sphinx Design`_ (a Sphinx extension). This means that if you wish
+to use the components on this page, you must install Sphinx Design separately
+and add it to your ``conf.py``.
 
 .. seealso::
 


### PR DESCRIPTION
First link to Sphinx Design on web components page is showing up in italics rather than a hyperlink.