### PR TITLE
BUG - GH action workflows fixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,7 +84,6 @@ jobs:
           else
             python -Im tox run -e compile,py$(echo ${{ matrix.python-version }} | tr -d .)-tests
           fi
-      - run: ls -la 
       - name: "Upload coverage data to GH artifacts 📤"
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && matrix.sphinx-version == 'dev'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,6 +84,7 @@ jobs:
           else
             python -Im tox run -e compile,py$(echo ${{ matrix.python-version }} | tr -d .)-tests
           fi
+      - run: ls -la 
       - name: "Upload coverage data to GH artifacts 📤"
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && matrix.sphinx-version == 'dev'
         uses: actions/upload-artifact@v4
@@ -91,6 +92,7 @@ jobs:
           name: coverage-data-${{ matrix.python-version }}
           path: .coverage
           if-no-files-found: ignore
+          include-hidden-files: true
 
   # Only run accessibility tests on the latest Python version (3.12) and Ubuntu
   a11y-tests:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -178,9 +178,11 @@ jobs:
           runs: 3 # Multiple runs to reduce variance
 
   coverage:
-    name: "check coverage"
+    name: "Check coverage"
     needs: run-pytest
     runs-on: ubuntu-latest
+    # avoid running this on schedule, releases, or workflow_call
+    if: github.event.workflow_run.event != 'schedule' && github.event.workflow_run.event != 'release' && github.event.workflow_run.event != 'workflow_call'
     permissions:
       contents: write
       pull-requests: write
@@ -221,8 +223,6 @@ jobs:
       - name: "Coverage comment 💬"
         uses: py-cov-action/python-coverage-comment-action@v3
         id: coverage_comment
-        # avoid running this on schedule or releases
-        if: github.event.workflow_run.event != 'schedule' && github.event.workflow_run.event != 'release'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,10 @@ jobs:
   # calls our general CI workflow (tests, build docs, etc.)
   tests:
     uses: ./.github/workflows/CI.yml
+    # needed for the coverage action
+    permissions:
+      contents: write
+      pull-requests: write
 
   build-package:
     name: "Build & verify PST package"


### PR DESCRIPTION
There are a couple of fixes in this PR:

1. The publish action has been failing due to the permissions needed by the coverage action (see https://github.com/pydata/pydata-sphinx-theme/actions/runs/10659690328/workflow). This should add the missing permissions for that specific workflow - note this is needed as when the workflow is not triggered from a Pull Request then the coverage data is pushed to a branch in the repo (but the main CI workflow still needs PR permissions 🤷🏽‍♀️, permissions are weird).
2. There is a breaking change in the `upload-artifact` action which is making our workflows fail now