### PR TITLE
Remove macos 13

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,14 +33,7 @@ jobs:
       matrix:
         # macos-14==latest
         # ubuntu-20.04==latest
-        os:
-          [
-            "ubuntu-latest",
-            "ubuntu-24.04",
-            "macos-14",
-            "macos-13",
-            "windows-latest",
-          ]
+        os: ["ubuntu-latest", "ubuntu-24.04", "macos-14", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         sphinx-version: [""]
         include:


### PR DESCRIPTION
It keeps failing as brew cannot install graphviz without also installing python 3.12 which conflict with the existing python install when linking 2to3.

I don't think it is worth testing this on that many macos and linux platform, as it's mostly a theme, so the risk of having a production system fail because of a bug on macos is low.