### PR TITLE
Increase space between links in right sidebar to match left sidebar

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
@@ -32,7 +32,7 @@ nav.page-toc {
 
   a.nav-link {
     display: block;
-    padding: 0.125rem 0;
+    padding: $toc-item-padding-y 0;
 
     // Padding w/ negative margin so the top TOC item highlight overlaps w/ the TOC border
     padding-left: 1rem;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -237,7 +237,7 @@ nav.bd-links {
 
   li > a {
     display: block;
-    padding: 0.25rem 0.65rem;
+    padding: $toc-item-padding-y 0.65rem;
 
     @include link-sidebar;
 

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -42,3 +42,7 @@ $navbar-link-padding-y: 0.25rem;
 // contains the bounding box of the interactive element).
 // - https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/81#issuecomment-2251325783
 $nav-icon-column-gap: 1.12rem;
+
+// Determines vertical space between entries in both the section (left/primary
+// sidebar) and page (right/secondary sidebar) table of contents
+$toc-item-padding-y: 0.25rem;


### PR DESCRIPTION
For this PR, I compared the line height, font size and weight, and vertical white space between the entries in the table of contents on the left (the section table of contents) and entries in the tables of contents on the right (the "on this page" table of contents). The only discrepancy I found was that the left TOC had padding top and bottom set to 0.25rem, whereas the right TOC had top and bottom padding set to 0.125rem. 

This PR increases the padding on the right to match the left. It creates a new Sass variable and uses that variable to set top and bottom padding on both sides to 0.25rem.

Closes external issue: 

- https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/82