### PR TITLE
Add new intermittent warning for building docs offline

### DIFF
--- a/tests/intermittent_warning_list.txt
+++ b/tests/intermittent_warning_list.txt
@@ -1,2 +1,4 @@
 WARNING: Cell printed to stderr:
 Matplotlib is building the font cache; this may take a moment.
+WARNING: failed to reach any of the inventories with the following issues:
+intersphinx inventory


### PR DESCRIPTION
The power went out in my house last night and then trying to build the docs failed (`tox run -e docs-dev`).

It looks like the intersphinx extension tries to make a network request when building the docs and emits a warning if it cannot  make the request because the Internet connection is down.

So this PR adds those warnings to the intermittent warnings file.