### PR TITLE
Bolder bigger headings

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
@@ -6,13 +6,14 @@ html {
   // base font size - applied at body/html level
   --pst-font-size-base: 1rem;
 
-  // heading font sizes based on bootstrap sizing
-  --pst-font-size-h1: 2.5rem;
-  --pst-font-size-h2: 2rem;
+  // heading font sizes based on a medium contrast type scale
+  // - see: https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/97#issuecomment-2310531483
+  --pst-font-size-h1: 2.625rem;
+  --pst-font-size-h2: 2.125rem;
   --pst-font-size-h3: 1.75rem;
   --pst-font-size-h4: 1.5rem;
   --pst-font-size-h5: 1.25rem;
-  --pst-font-size-h6: 1.1rem;
+  --pst-font-size-h6: 1rem;
 
   // smaller than heading font sizes
   --pst-font-size-milli: 0.9rem;
@@ -28,7 +29,7 @@ html {
 
   // Font weights
   --pst-font-weight-caption: 300;
-  --pst-font-weight-heading: 400;
+  --pst-font-weight-heading: 600;
 
   // Font family
   // These are adapted from https://systemfontstack.com/ */


### PR DESCRIPTION
This PR:

- Increases heading (h1, h2, h3, etc) font weight from 400 to 600
  - Why? To make headings stand out better from the body text
- Increases h1 and h2 font size, slightly decreases h6 size
  - Why? Brings the headings into better alignment with standard typographic scales. See https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/97.

Closes https://github.com/Quansight-Labs/czi-scientific-python-mgmt/issues/97.

### Before/after screenshots

| Before | After |
| ---- | ---- |
| ![](https://github.com/user-attachments/assets/a5be530a-f7c9-4b13-a580-e28b0340c3cd) | ![](https://github.com/user-attachments/assets/6dc8cad8-f325-47bc-bd45-25259df8ec16) |

