### PR TITLE
Add scikit-learn to the example gallery

### DIFF
--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -49,6 +49,10 @@
   link-alt: SciPy docs
   link: https://docs.scipy.org/doc/scipy/
   img-bottom: ../_static/gallery/scipy.png
+- title: scikit-learn
+  link-alt: scikit-learn docs
+  link: https://scikit-learn.org/
+  img-bottom: ../_static/gallery/scikit-learn.png
 - title: SEPAL
   link-alt: SEPAL docs
   link: https://docs.sepal.io/en/latest/index.html

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -56,7 +56,4 @@ Thanks for your support!
 - title: PyVista
   link-alt: PyVista docs
   link: https://docs.pyvista.org
-- title: scikit-learn
-  link-alt: scikit-learn docs
-  link: https://scikit-learn.org/
 ```

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -32,6 +32,9 @@ Thanks for your support!
 - title: CuPy
   link-alt: CuPy docs
   link: https://docs.cupy.dev/en/stable/index.html
+- title: DecentralChain
+  link-alt: DecentralChain docs
+  link: https://docs.decentralchain.io/en/master/
 - title: Fairlearn
   link-alt: Fairlearn docs
   link: https://fairlearn.org/main/about/
@@ -44,16 +47,16 @@ Thanks for your support!
 - title: MegEngine
   link-alt: MegEngine docs
   link: https://www.megengine.org.cn/doc/stable/en/index.html
+- title: Pastas
+  link-alt: Pastas docs
+  link: https://pastas.readthedocs.io/
 - title: PhaseFieldX
   link-alt: PhaseFieldX docs
   link: https://phasefieldx.readthedocs.io/en/latest/index.html
 - title: PyVista
   link-alt: PyVista docs
   link: https://docs.pyvista.org
-- title: Pastas
-  link-alt: Pastas docs
-  link: https://pastas.readthedocs.io/
-- title: DecentralChain
-  link-alt: DecentralChain docs
-  link: https://docs.decentralchain.io/en/master/
+- title: scikit-learn
+  link-alt: scikit-learn docs
+  link: https://scikit-learn.org/
 ```

--- a/tests/warning_list.txt
+++ b/tests/warning_list.txt
@@ -10,6 +10,7 @@ WARNING: image file not readable: _static/gallery/arviz.png
 WARNING: image file not readable: _static/gallery/sepal.png
 WARNING: image file not readable: _static/gallery/matplotlib.png
 WARNING: image file not readable: _static/gallery/brightway.png
+WARNING: image file not readable: _static/gallery/scikit-learn.png
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.count'. Check your autosummary_generate setting.
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.index'. Check your autosummary_generate setting.
 WARNING: autosummary: stub file not found 'urllib.parse.DefragResultBytes.count'. Check your autosummary_generate setting.


### PR DESCRIPTION
Thanks for the amazing theme! Scikit-learn has migrated to pydata-sphinx-theme for the main website since version 1.5 (https://github.com/scikit-learn/scikit-learn/pull/29038), and the nice three-column layout has unlocked many potential improvements to our website UI/UX-wise. This PRs adds scikit-learn to the list of `Other projects using this theme`.

However though scikit-learn is not one of the earliest adopters of pydata-sphinx-theme, I'm asking if it can fit into the list of `Featured projects` as we have many quite some customizations that could be helpful for other users of the theme. Some of them include:

- [Landing page](https://scikit-learn.org/)
- [API references](https://scikit-learn.org/stable/api/index.html) (a searchable table on the index page containing all APIs while keeping the hierarchy in the primary sidebar)
- [Each API page](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html) (customizing the secondary sidebar)
- [Gallery examples](https://scikit-learn.org/stable/auto_examples/release_highlights/plot_release_highlights_1_5_0.html) (secondary sidebar customization with sphinx-gallery)
- [Platform-specific installation instructions](https://scikit-learn.org/stable/install.html#installing-the-latest-release) (CSS customizations based on tabs in sphinx-design)
- [Dropdowns](https://scikit-learn.org/stable/modules/linear_model.html#references) (anchor link for dropdown blocks; toggle-all button for Ctrl-F searching)
- Algolia search (WIP): https://github.com/scikit-learn/scikit-learn/pull/29666
- Many other CSS customizations

Looking forward to your feedback :)

*BTW some of the projects were not placed in alphabetical order as required so I reordered a bit.*