### PR TITLE
ENH add algolia docsearch version meta tag

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -33,6 +33,7 @@
 {%- block extrahead %}
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta name="docsearch:language" content="{{ language }}"/>
+  <meta name="docsearch:version" content="{{ version }}" />
   {%- if last_updated %}
     <meta name="docbuild:last-update" content="{{ last_updated | e }}"/>
   {%- endif %}


### PR DESCRIPTION
Fixes #1951.

With this meta tag it will be possible to filter results for specific versions using Algolia DocSearch.