### PR TITLE
docs: fix example gallery screenshot for scikit-learn

### DIFF
--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -51,7 +51,7 @@
   img-bottom: ../_static/gallery/scipy.png
 - title: scikit-learn
   link-alt: scikit-learn docs
-  link: https://scikit-learn.org/
+  link: https://scikit-learn.org/stable/
   img-bottom: ../_static/gallery/scikit-learn.png
 - title: SEPAL
   link-alt: SEPAL docs


### PR DESCRIPTION
Follow up #1985, there seems to something wrong with the generated screenshot, probably because the root has a canonical link that points to stable. Sorry for the mistake.

| Before | After |
| :----: | :---: |
| ![image](https://github.com/user-attachments/assets/b40e6741-e74f-46ed-882c-b2850eeacf1b) | ![image](https://github.com/user-attachments/assets/41081b68-5e64-4968-8511-f8bf0e7b2ed2) |