### PR TITLE
MAINT - Bump node version (22.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
 build-backend = "sphinx_theme_builder"
 
 [tool.sphinx-theme-builder]
-node-version = "16.13.2"
+node-version = "22.9.0"
 theme-name = "pydata_sphinx_theme"
 additional-compiled-static-assets = [
   "webpack-macros.html",
@@ -53,7 +53,7 @@ classifiers = [
 [project.optional-dependencies]
 doc = [
   "numpydoc",
-  "linkify-it-py",         # for link shortening
+  "linkify-it-py", # for link shortening
   "rich",
   "sphinxext-rediraffe",
   "sphinx-sitemap",
@@ -105,6 +105,7 @@ fix = true
 ignore = [
   "E501", # line too long | Black take care of it
   "D107", # Missing docstring in `__init__` | set the docstring in the class
+
 ]
 ignore-init-module-imports = true
 select = ["E", "F", "W", "I", "D", "RUF"]


### PR DESCRIPTION
We currently use `node.js 16` for PST, which has long been out of LTS.

This PR bumps node to v22, which is the _Current_ version and will soon be moved to _Active_.

Ref: https://nodejs.org/en/about/previous-releases