### PR TITLE
BUG - Fix coverage workflow triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -176,7 +176,7 @@ jobs:
     needs: run-pytest
     runs-on: ubuntu-latest
     # avoid running this on schedule, releases, or workflow_call
-    if: github.event.workflow_run.event != 'schedule' && github.event.workflow_run.event != 'release' && github.event.workflow_run.event != 'workflow_call'
+    if: github.event_name != 'schedule' && github.event_name != 'release' && github.event_name != 'workflow_call'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
When trying to cut the release candidate for the theme, the `check_coverage` workflow failed; however, this is not meant to run on `release` type events.

This PR fixes the syntax so that `releases, schedules, and workflow_call` type events are properly skipped.