### PR TITLE
CI Bump scientific-python/upload-nightly-action from 0.6.0 to 0.6.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
         if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'
 
       - name: "Publish PST package to scientific-python-nightly-wheels 🚀"
-        uses: scientific-python/upload-nightly-action@ccf29c805b5d0c1dc31fa97fcdb962be074cade3 # 0.6.0
+        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}


### PR DESCRIPTION
Resolves https://github.com/scientific-python/upload-nightly-action/issues/106

* scientific-python/upload-nightly-action v0.6.1 fixes a breaking bug in v0.6.0.
   - c.f. https://github.com/scientific-python/upload-nightly-action/releases/tag/0.6.1