### PR TITLE
Suppress 'rtd-footer-container' if not being built on ReadTheDocs

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/sidebar-primary.html
@@ -37,7 +37,9 @@
       <div class="sidebar-primary-item">{%- include sidebartemplate %}</div>
     {%- endfor %}
   </div>
-  {# add the rtd flyout in the sidebar if existing #}
-  <div id="rtd-footer-container"></div>
+  {# add the rtd flyout in the sidebar if building on rtd #}
+  {% if READTHEDOCS %}
+    <div id="rtd-footer-container"></div>
+  {% endif %}
 {% endif %}
 {% endblock docs_sidebar %}

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -69,6 +69,4 @@
  </div>
  <div class="sidebar-primary-items__end sidebar-primary__section">
  </div>
- <div id="rtd-footer-container">
- </div>
 </div>


### PR DESCRIPTION
This PR attempts to fix https://github.com/pydata/pydata-sphinx-theme/issues/1794 and possibly https://github.com/pydata/pydata-sphinx-theme/issues/1238 by not including the rtd-footer-container div if the site is not being built on ReadTheDocs. 

This uses the same {% if READTHEDOCS %} as the [ethical ads html](https://github.com/pydata/pydata-sphinx-theme/blob/c24b4b493ef0c64d250f363e20c0f70595ce8b10/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-ethical-ads.html).