### PR TITLE
DEV -  Go back to dev - post-release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ These steps should be taken in order to create a new release![^release-refs]
 **Double check for quality-control**
 
 - [ ] There are no [open issues with a `impact: block-release` label](https://github.com/pydata/pydata-sphinx-theme/labels/impact%3A%20block-release)
+- [ ] Check wether the localization files are up-to-date, or [open a PR to update them if needed](https://pydata-sphinx-theme.readthedocs.io/en/stable/community/topics/i18n.html#compiling-the-localization-files).
 
 **Prepare the codebase for a new version**
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -14,7 +14,7 @@ from sphinx.errors import ExtensionError
 
 from . import edit_this_page, logo, pygments, short_link, toctree, translator, utils
 
-__version__ = "0.16.0"
+__version__ = "0.16.1dev0"
 
 
 def update_config(app):


### PR DESCRIPTION
Now that `v0.16.0` is out, we can return to a dev version.

Included in this PR:
- **:bookmark: Go back to dev - post-release**
- **Update release instructions to check for i18n docs** -> since I noticed while doing this release that some files were out of sync.
