### PR TITLE
Remove mention of `sidebarwidth` in config file

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -8,7 +8,6 @@ sidebars = sidebar-nav-bs.html
 
 [options]
 # General configuration
-sidebarwidth = 270
 sidebar_includehidden = True
 use_edit_page_button = False
 external_links =


### PR DESCRIPTION
This is not relevant with current theme.

Closes #2016