### PR TITLE
When using the copybutton in code blocks, exclude copying the prompt

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,7 @@ togglebutton_hint_hide = str(_("Click to collapse"))
 # Exclude copy button from appearing over notebook cell numbers by using :not()
 # The default copybutton selector is `div.highlight pre`
 # https://github.com/executablebooks/sphinx-copybutton/blob/master/sphinx_copybutton/__init__.py#L82
+copybutton_exclude = ".linenos, .gp"
 copybutton_selector = ":not(.prompt) > div.highlight pre"
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
When I use the copybutton in code blocks, I expect to be able to paste the code into my terminal without having to delete the prompt that gets copied. This PR fixes that issue by excluding CSS classes that Pygments generates in code blocks.

See https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies