### PR TITLE
BUG - Fix i18n files and compilation for distribution

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
           # if not we use the default version
           # example substitution: tox run -e compile-assets,i18n-compile,py39-tests
           else
-            python -Im tox run -e compile,i18n-compile,py$(echo ${{ matrix.python-version }} | tr -d .)-tests
+            python -Im tox run -e compile-assets,i18n-compile,py$(echo ${{ matrix.python-version }} | tr -d .)-tests
           fi
       - name: "Upload coverage data to GH artifacts 📤"
         if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && matrix.sphinx-version == 'dev'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -39,6 +39,12 @@ jobs:
           # this will compile the assets then run the tests
           python -Im tox run -e compile-assets,i18n-compile,py$(echo ${{ matrix.python-version }} | tr -d .)-tests-no-cov
           echo "PYTEST_ERRORS=$?" >> $GITHUB_ENV
+      
+      - name: "Build and inspect package 📦"
+        uses: hynek/build-and-inspect-python-package@v2
+        id: baipp
+  
+      - run: echo Packages can be found at ${{ steps.baipp.outputs.dist }}
 
       # If either the docs build or the tests resulted in an error, create an issue to note it
       - name: "Create an issue if failure"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,16 @@ permissions:
 
 jobs:
   # calls our general CI workflow (tests, build docs, etc.)
-  tests:
-    uses: ./.github/workflows/CI.yml
-    # needed for the coverage action
-    permissions:
-      contents: write
-      pull-requests: write
+  # tests:
+  #   uses: ./.github/workflows/CI.yml
+  #   # needed for the coverage action
+  #   permissions:
+  #     contents: write
+  #     pull-requests: write
 
   build-package:
     name: "Build & verify PST package"
-    needs: [tests] # require tests to pass before deploy runs
+    # needs: [tests] # require tests to pass before deploy runs
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository 🛎"
@@ -38,6 +38,10 @@ jobs:
         with:
           python-version: "3.9"
           pandoc: "False"
+
+      - name: "Compile localization"
+        run:
+          tox run -e i18n-compile
 
       - name: "Build and inspect package 📦"
         uses: hynek/build-and-inspect-python-package@v2
@@ -61,14 +65,14 @@ jobs:
         run: |
           tar xvf dist/*.tar.gz --strip-components=1
 
-      - name: "Publish PST package to PyPI 🚀"
-        uses: pypa/gh-action-pypi-publish@release/v1
-        # only publish if this is a published release by pydata
-        if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'
+      # - name: "Publish PST package to PyPI 🚀"
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   # only publish if this is a published release by pydata
+      #   if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'
 
-      - name: "Publish PST package to scientific-python-nightly-wheels 🚀"
-        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
-        with:
-          artifacts_path: dist
-          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
-        if: github.repository_owner == 'pydata' && github.event_name == 'schedule'
+      # - name: "Publish PST package to scientific-python-nightly-wheels 🚀"
+      #   uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
+      #   with:
+      #     artifacts_path: dist
+      #     anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
+      #   if: github.repository_owner == 'pydata' && github.event_name == 'schedule'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,16 @@ permissions:
 
 jobs:
   # calls our general CI workflow (tests, build docs, etc.)
-  # tests:
-  #   uses: ./.github/workflows/CI.yml
-  #   # needed for the coverage action
-  #   permissions:
-  #     contents: write
-  #     pull-requests: write
+  tests:
+    uses: ./.github/workflows/CI.yml
+    # needed for the coverage action
+    permissions:
+      contents: write
+      pull-requests: write
 
   build-package:
     name: "Build & verify PST package"
-    # needs: [tests] # require tests to pass before deploy runs
+    needs: [tests] # require tests to pass before deploy runs
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository 🛎"
@@ -38,10 +38,6 @@ jobs:
         with:
           python-version: "3.9"
           pandoc: "False"
-
-      - name: "Compile localization"
-        run:
-          tox run -e i18n-compile
 
       - name: "Build and inspect package 📦"
         uses: hynek/build-and-inspect-python-package@v2
@@ -65,14 +61,14 @@ jobs:
         run: |
           tar xvf dist/*.tar.gz --strip-components=1
 
-      # - name: "Publish PST package to PyPI 🚀"
-      #   uses: pypa/gh-action-pypi-publish@release/v1
-      #   # only publish if this is a published release by pydata
-      #   if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'
+      - name: "Publish PST package to PyPI 🚀"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # only publish if this is a published release by pydata
+        if: github.repository_owner == 'pydata' && github.event_name == 'release' && github.event.action == 'published'
 
-      # - name: "Publish PST package to scientific-python-nightly-wheels 🚀"
-      #   uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
-      #   with:
-      #     artifacts_path: dist
-      #     anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
-      #   if: github.repository_owner == 'pydata' && github.event_name == 'schedule'
+      - name: "Publish PST package to scientific-python-nightly-wheels 🚀"
+        uses: scientific-python/upload-nightly-action@82396a2ed4269ba06c6b2988bb4fd568ef3c3d6b # 0.6.1
+        with:
+          artifacts_path: dist
+          anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}
+        if: github.repository_owner == 'pydata' && github.event_name == 'schedule'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include src/pydata_sphinx_theme/locale *.pot *.po *.mo

--- a/docs/community/topics/i18n.rst
+++ b/docs/community/topics/i18n.rst
@@ -82,7 +82,7 @@ file, and visible to localizers. For example:
 
    {# L10n: Navigation button at the bottom of the page #}
    <button type="button">
-      {{- _("Next page") -}}
+      {{- _('Next page') -}}
    </button>
 
 .. _updating-localization-files:

--- a/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
@@ -2,13 +2,24 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Cristhian Rivera, 2024
 # Oriol Abril-Pla <oriol.abril.pla@gmail.com>, 2024
-# 
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ca\n"
+"Language-Team: ca <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -145,11 +156,10 @@ msgstr "Fosc"
 msgid "System Settings"
 msgstr "Configuració del sistema"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "Construïda amb el <a href=\"https://pydata-sphinx-"
@@ -191,3 +201,4 @@ msgstr "Navegació del lloc"
 
 #~ msgid "light/dark"
 #~ msgstr "clar/fosc"
+

--- a/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
@@ -5,6 +5,18 @@
 #
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: cs\n"
+"Language-Team: cs <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -141,11 +153,10 @@ msgstr "Tmavý"
 msgid "System Settings"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "Vytvořeno pomocí <a href=\"https://pydata-sphinx-"

--- a/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
@@ -5,6 +5,18 @@
 #
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -139,11 +151,10 @@ msgstr ""
 msgid "System Settings"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 
@@ -181,5 +192,11 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "light/dark"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Built with the <a href=\"https://pydata-"
+#~ "sphinx-theme.readthedocs.io/en/stable/index.html\">PyData "
+#~ "Sphinx Theme</a> %(theme_version)s."
 #~ msgstr ""
 

--- a/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
@@ -2,15 +2,26 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
 # Cristhian Rivera, 2024
 # Felipe Moreno, 2024
 # Tania Allard, 2024
-# 
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: es\n"
+"Language-Team: es <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -42,8 +53,7 @@ msgstr "Error"
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/search.html:9
 msgid "Please activate JavaScript to enable the search functionality."
-msgstr ""
-"Por favor, active JavaScript para habilitar la funcionalidad de búsqueda."
+msgstr "Por favor, active JavaScript para habilitar la funcionalidad de búsqueda."
 
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/breadcrumbs.html:6
 msgid "Breadcrumb"
@@ -148,11 +158,10 @@ msgstr "Oscuro"
 msgid "System Settings"
 msgstr "Sistema"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "Construido con el <a href=\"https://pydata-sphinx-"
@@ -194,3 +203,4 @@ msgstr "Navegación del sitio"
 
 #~ msgid "light/dark"
 #~ msgstr "claro/oscuro"
+

--- a/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
@@ -2,13 +2,24 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2024
 # Denis Bitouzé <dbitouze@wanadoo.fr>, 2024
-# 
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -145,11 +156,10 @@ msgstr "Sombre"
 msgid "System Settings"
 msgstr "Paramètres système"
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "Construit avec le <a href=\"https://pydata-sphinx-"
@@ -191,3 +201,4 @@ msgstr "Navigation dans le site"
 
 #~ msgid "light/dark"
 #~ msgstr "clair/sombre"
+

--- a/src/pydata_sphinx_theme/locale/it/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/it/LC_MESSAGES/sphinx.po
@@ -5,6 +5,18 @@
 #
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: it\n"
+"Language-Team: it <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -141,11 +153,10 @@ msgstr "Scuro"
 msgid "System Settings"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "Prodotto con il tema <a href=\"https://pydata-sphinx-"

--- a/src/pydata_sphinx_theme/locale/ja/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ja/LC_MESSAGES/sphinx.po
@@ -7,6 +7,18 @@
 # Tetsuo Koyama <tkoyama010@gmail.com>, 2024
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -143,11 +155,10 @@ msgstr "ダーク"
 msgid "System Settings"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "<a href=\"https://pydata-sphinx-"

--- a/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
@@ -5,6 +5,19 @@
 #
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ru\n"
+"Language-Team: ru <LL@li.org>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -141,11 +154,10 @@ msgstr "темная"
 msgid "System Settings"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "Собрано с использованием темы <a href=\\\"https://pydata-sphinx-"

--- a/src/pydata_sphinx_theme/locale/sphinx.pot
+++ b/src/pydata_sphinx_theme/locale/sphinx.pot
@@ -4,11 +4,12 @@
 # project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: pydata-sphinx-theme 0.16.0rc0\n"
+"Project-Id-Version: pydata-sphinx-theme 0.16.1.dev0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-09-30 17:53+0100\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -150,11 +151,10 @@ msgstr ""
 msgid "System Settings"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 

--- a/src/pydata_sphinx_theme/locale/zh/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/zh/LC_MESSAGES/sphinx.po
@@ -5,6 +5,18 @@
 #
 msgid ""
 msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2024-11-18 12:43+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh\n"
+"Language-Team: zh <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.16.0\n"
 
 #: docs/conf.py:109
 msgid "Click to expand"
@@ -141,11 +153,10 @@ msgstr "暗色"
 msgid "System Settings"
 msgstr ""
 
-#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:3
+#: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html:4
 #, python-format
 msgid ""
-"Built with the <a href=\"https://pydata-sphinx-"
-"theme.readthedocs.io/en/stable/index.html\">PyData Sphinx Theme</a> "
+"Built with the <a href=\"%(PST_url)s\">PyData Sphinx Theme</a> "
 "%(theme_version)s."
 msgstr ""
 "使用 <a href=\"https://pydata-sphinx-"

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/page-toc.html
@@ -5,7 +5,7 @@
   <div
     id="{{ page_navigation_heading_id }}"
     class="page-toc tocsection onthispage">
-    <i class="fa-solid fa-list"></i> {{ _("On this page") }}
+    <i class="fa-solid fa-list"></i> {{ _('On this page') }}
   </div>
   <nav class="bd-toc-nav page-toc" aria-labelledby="{{ page_navigation_heading_id }}">
     {{ page_toc }}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html
@@ -1,4 +1,6 @@
 {# Displays the version of pydata-sphinx-theme used to build the documentation. #}
 <p class="theme-version">
-  {% trans theme_version=theme_version|e %}Built with the <a href="https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html">PyData Sphinx Theme</a> {{ theme_version }}.{% endtrans %}
+  {% trans trimmed theme_version=theme_version|e, PST_url="https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html" %}
+    Built with the <a href="{{ PST_url }}">PyData Sphinx Theme</a> {{ theme_version }}.
+  {% endtrans %}
 </p>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-version.html
@@ -1,6 +1,8 @@
 {# Displays the version of pydata-sphinx-theme used to build the documentation. #}
 <p class="theme-version">
+  <!-- # L10n: Setting the PST URL as an argument as this does not need to be localized -->
   {% trans trimmed theme_version=theme_version|e, PST_url="https://pydata-sphinx-theme.readthedocs.io/en/stable/index.html" %}
     Built with the <a href="{{ PST_url }}">PyData Sphinx Theme</a> {{ theme_version }}.
   {% endtrans %}
 </p>
+

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ env_list =
 # helping contributors run common tasks without needing to call all the steps
 # For example to run the tests: tox run -m tests
 labels =
-    tests = compile-assets, i18n-compile, py312-tests
+    tests = i18n-compile, compile-assets, py312-tests
     a11y = compile-assets, i18n-compile, py312-docs, a11y-tests
     i18n = i18n-extract, i18n-compile
     live-server = compile-assets, i18n-compile, docs-live
@@ -156,7 +156,8 @@ allowlist_externals = bash
 commands =
     # explicitly pass this as a bash command to set PST_VERSION
     bash -c "PST_VERSION=$(pip show pydata-sphinx-theme | grep Version | awk -F': ' '{print $2}') && \
-    pybabel extract . -F babel.cfg -o src/pydata_sphinx_theme/locale/sphinx.pot --project=pydata-sphinx-theme --copyright-holder='PyData developers' --version=$PST_VERSION"
+    pybabel extract . -F babel.cfg -o src/pydata_sphinx_theme/locale/sphinx.pot --keywords='_ __ l_ lazy_gettext' \
+    --project=pydata-sphinx-theme --copyright-holder='PyData developers' --version=$PST_VERSION"
     pybabel update -i src/pydata_sphinx_theme/locale/sphinx.pot -d src/pydata_sphinx_theme/locale -D sphinx {posargs}
 
 # add a new locale for translations based on the catalog template

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const dedent = require("dedent");
 const { Compilation } = require("webpack");
+const { exec } = require("child_process");
 
 /*******************************************************************************
  * Paths for various assets (sources and destinations)
@@ -23,14 +24,7 @@ const { Compilation } = require("webpack");
 
 const scriptPath = resolve(__dirname, "src/pydata_sphinx_theme/assets/scripts");
 const staticPath = resolve(__dirname, "src/pydata_sphinx_theme/theme/pydata_sphinx_theme/static");
-const { exec } = require("child_process");
 const localePath = resolve(__dirname, "src/pydata_sphinx_theme/locale");
-
-
-/*******************************************************************************
- * Compile our translation files
- */
-// exec(`pybabel compile -d ${localePath} -D sphinx`);
 
 /*******************************************************************************
  * functions to load the assets in the html head
@@ -180,7 +174,8 @@ var config = {
 };
 
 module.exports = (env, argv) => {
-  if (argv.mode === 'development') {
+  // since STB  isolates the build, we need to compile the translations here for releases
+  if (argv.mode === 'production') {
     exec(`pybabel compile -d ${localePath} -D sphinx`, (error, stdout, stderr) => {
       if (error) {
         console.error(`Error: ${error.message}`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,14 @@ const { Compilation } = require("webpack");
 
 const scriptPath = resolve(__dirname, "src/pydata_sphinx_theme/assets/scripts");
 const staticPath = resolve(__dirname, "src/pydata_sphinx_theme/theme/pydata_sphinx_theme/static");
+const { exec } = require("child_process");
+const localePath = resolve(__dirname, "src/pydata_sphinx_theme/locale");
+
+
+/*******************************************************************************
+ * Compile our translation files
+ */
+// exec(`pybabel compile -d ${localePath} -D sphinx`);
 
 /*******************************************************************************
  * functions to load the assets in the html head
@@ -96,8 +104,8 @@ const htmlWebpackPlugin = new HtmlWebpackPlugin({
   templateContent: macroTemplate,
 });
 
-module.exports = {
-  mode: "production",
+// webpack main configuration
+var config = {
   devtool: "source-map",
   entry: {
     "pydata-sphinx-theme": resolve(scriptPath, "pydata-sphinx-theme.js"),
@@ -169,4 +177,21 @@ module.exports = {
   experiments: {
     topLevelAwait: true,
   },
+};
+
+module.exports = (env, argv) => {
+  if (argv.mode === 'development') {
+    exec(`pybabel compile -d ${localePath} -D sphinx`, (error, stdout, stderr) => {
+      if (error) {
+        console.error(`Error: ${error.message}`);
+        return;
+      }
+      if (stderr) {
+        console.error(`stderr: ${stderr}`);
+        return;
+      }
+      console.log(`stdout: ${stdout}`);
+    });
+  }
+  return config;
 };


### PR DESCRIPTION
While investigating https://github.com/pydata/pydata-sphinx-theme/issues/2040 I noticed that our current release missed the updated `.mo` files.
This was a bug I introduced in https://github.com/pydata/pydata-sphinx-theme/pull/1959/ when reworking the localisation workflows.

TLD;R—Since we use `stb` to build the theme, I did not realise that compiling the i18n files had to be done within the `stb package` (I removed it from the webpack file as this was causing the infinite reload while working on our docs).

Since this was an easy miss, I added our build and inspect job to the `pre-release` workflow that runs on a chron job to check our build process periodically.

Once we merge this, we can make a small release to patch the current issue.