### PR TITLE
MAINT - Update pre-commit hooks and config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,15 +21,12 @@ repos:
         # exclude the pytest-regressions folder tests/test_ally
         exclude: .+\.html|webpack\.config\.js|tests/test_a11y/
 
-  - repo: "https://github.com/psf/black"
-    rev: 24.10.0
-    hooks:
-      - id: black
-
   - repo: "https://github.com/astral-sh/ruff-pre-commit"
     rev: "v0.7.2"
     hooks:
       - id: ruff
+        args: [--exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: "https://github.com/asottile/pyupgrade"
     rev: v3.19.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,11 @@ ci:
 # Fix the node version to avoid a GLIBC error
 # ref: https://stackoverflow.com/questions/71939099/bitbucket-pipeline-error-installing-pre-commit-ts-lint/71940852#71940852
 default_language_version:
-  node: 16.14.2
+  node: 22.9.0
 
 repos:
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: "https://github.com/pycontribs/mirrors-prettier"
+    rev: v3.3.3
     hooks:
       - id: prettier
         # Exclude the HTML, since it doesn't understand Jinja2
@@ -21,29 +21,29 @@ repos:
         # exclude the pytest-regressions folder tests/test_ally
         exclude: .+\.html|webpack\.config\.js|tests/test_a11y/
 
-  - repo: https://github.com/psf/black
+  - repo: "https://github.com/psf/black"
     rev: 24.10.0
     hooks:
       - id: black
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
+  - repo: "https://github.com/astral-sh/ruff-pre-commit"
     rev: "v0.7.2"
     hooks:
       - id: ruff
 
-  - repo: https://github.com/asottile/pyupgrade
+  - repo: "https://github.com/asottile/pyupgrade"
     rev: v3.19.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
-  - repo: https://github.com/Riverside-Healthcare/djLint
+  - repo: "https://github.com/Riverside-Healthcare/djLint"
     rev: v1.35.4
     hooks:
       - id: djlint-jinja
         types_or: ["html"]
 
-  - repo: https://github.com/PyCQA/doc8
+  - repo: "https://github.com/PyCQA/doc8"
     rev: v1.1.2
     hooks:
       - id: doc8
@@ -53,12 +53,12 @@ repos:
     hooks:
       - id: nbstripout
 
-  - repo: https://github.com/mondeja/pre-commit-po-hooks
+  - repo: "https://github.com/mondeja/pre-commit-po-hooks"
     rev: v1.7.3
     hooks:
       - id: remove-metadata
 
-  - repo: https://github.com/thibaudcolas/pre-commit-stylelint
+  - repo: "https://github.com/thibaudcolas/pre-commit-stylelint"
     rev: v16.10.0
     hooks:
       - id: stylelint
@@ -68,3 +68,9 @@ repos:
           # stylelint itself needs to be here when using additional_dependencies.
           - stylelint@16.5.0
           - stylelint-config-standard-scss@13.1.0
+
+  - repo: "https://github.com/pre-commit/pre-commit-hooks"
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer

--- a/docs/_extension/component_directive.py
+++ b/docs/_extension/component_directive.py
@@ -6,6 +6,7 @@ GitHub file.
 """
 
 import re
+
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -13,6 +14,7 @@ from docutils import nodes
 from sphinx.application import Sphinx
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
+
 
 logger = logging.getLogger(__name__)
 

--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -19,6 +19,7 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from yaml import safe_load
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,6 +8,7 @@ https://www.sphinx-doc.org/en/master/usage/configuration.html
 # -- Path setup --------------------------------------------------------------
 import os
 import sys
+
 from pathlib import Path
 from typing import Any, Dict
 
@@ -15,6 +16,7 @@ from sphinx.application import Sphinx
 from sphinx.locale import _
 
 import pydata_sphinx_theme
+
 
 sys.path.append(str(Path(".").resolve()))
 

--- a/docs/examples/pydata.ipynb
+++ b/docs/examples/pydata.ipynb
@@ -29,6 +29,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "\n",
+    "\n",
     "rng = np.random.default_rng(seed=15485863)\n",
     "data = rng.standard_normal((100, 26))\n",
     "df = pd.DataFrame(data, columns=list(string.ascii_lowercase))\n",
@@ -51,7 +52,9 @@
     "import ipywidgets as widgets\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "\n",
     "from IPython.display import display\n",
+    "\n",
     "\n",
     "tab = widgets.Tab()\n",
     "\n",
@@ -65,9 +68,9 @@
     "\n",
     "# render in output widgets\n",
     "with widget_images:\n",
-    "    display(pd.DataFrame(np.random.randn(10,10)))\n",
+    "    display(pd.DataFrame(np.random.randn(10, 10)))\n",
     "with widget_annotations:\n",
-    "    display(pd.DataFrame(np.random.randn(10,10)))\n",
+    "    display(pd.DataFrame(np.random.randn(10, 10)))\n",
     "\n",
     "tab.children = [widget_images, widget_annotations]\n",
     "tab.titles = [\"Images\", \"Annotations\"]\n",
@@ -89,6 +92,7 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
+    "\n",
     "\n",
     "fig, ax = plt.subplots()\n",
     "ax.scatter(df[\"a\"], df[\"b\"], c=df[\"b\"], s=3)"
@@ -125,10 +129,13 @@
     "import plotly.express as px\n",
     "import plotly.io as pio\n",
     "\n",
+    "\n",
     "pio.renderers.default = \"notebook\"\n",
     "\n",
     "df = px.data.iris()\n",
-    "fig = px.scatter(df, x=\"sepal_width\", y=\"sepal_length\", color=\"species\", size=\"sepal_length\")\n",
+    "fig = px.scatter(\n",
+    "    df, x=\"sepal_width\", y=\"sepal_length\", color=\"species\", size=\"sepal_length\"\n",
+    ")\n",
     "fig"
    ]
   },
@@ -149,11 +156,10 @@
    "source": [
     "import xarray as xr\n",
     "\n",
+    "\n",
     "data = xr.DataArray(\n",
-    "        np.random.randn(2, 3),\n",
-    "        dims=(\"x\", \"y\"),\n",
-    "        coords={\"x\": [10, 20]}, attrs={\"foo\": \"bar\"}\n",
-    "      )\n",
+    "    np.random.randn(2, 3), dims=(\"x\", \"y\"), coords={\"x\": [10, 20]}, attrs={\"foo\": \"bar\"}\n",
+    ")\n",
     "data"
    ]
   },
@@ -174,8 +180,9 @@
    "source": [
     "from ipyleaflet import Map, basemaps\n",
     "\n",
+    "\n",
     "# display a map centered on France\n",
-    "m = Map(basemap=basemaps.Esri.WorldImagery,  zoom=5, center=[46.21, 2.21])\n",
+    "m = Map(basemap=basemaps.Esri.WorldImagery, zoom=5, center=[46.21, 2.21])\n",
     "m"
    ]
   }

--- a/docs/scripts/generate_collaborators_gallery.py
+++ b/docs/scripts/generate_collaborators_gallery.py
@@ -2,10 +2,12 @@
 
 import json
 import shlex
+
 from pathlib import Path
 from subprocess import run
 
 from yaml import dump
+
 
 COLLABORATORS_API = "https://api.github.com/repos/pydata/pydata-sphinx-theme/collaborators?affiliation=direct"
 

--- a/docs/scripts/update_kitchen_sink.py
+++ b/docs/scripts/update_kitchen_sink.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from urllib.request import urlopen
 
+
 EXTRA_MESSAGE = """\
 .. note::
 

--- a/docs/user_guide/layout.rst
+++ b/docs/user_guide/layout.rst
@@ -593,4 +593,3 @@ Please find here the full list of keys you can use in the ``html_theme_options``
 .. include:: ../../src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
     :code: ini
     :class: highlight-ini
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,11 +100,16 @@ ignore = ["D001"] # we follow a 1 line = 1 paragraph style
 
 [tool.ruff]
 fix = true
+# keep consistent with black
+line-length = 88
+indent-width = 4
 
 [tool.ruff.lint]
 ignore = [
-  "E501", # line too long | Black take care of it
   "D107", # Missing docstring in `__init__` | set the docstring in the class
+  "D205", # 1 blank line required between summary line and description,
+  "D212",
+  "W291", # let pre-commit handle trailing whitespace
 
 ]
 ignore-init-module-imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,10 @@ docstring-quotes = "double"
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.ruff.lint.isort]
+lines-between-types = 1
+lines-after-imports = 2
+
 [tool.djlint]
 profile = "jinja"
 extension = "html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ indent-width = 4
 ignore = [
   "D107", # Missing docstring in `__init__` | set the docstring in the class
   "D205", # 1 blank line required between summary line and description,
-  "D212",
+  "D212",  # docstring summary must be on first physical line
   "W291", # let pre-commit handle trailing whitespace
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,7 @@ ignore = [
   "W291", # let pre-commit handle trailing whitespace
 
 ]
-ignore-init-module-imports = true
-select = ["E", "F", "W", "I", "D", "RUF"]
+select = ["E", "F", "W", "I", "D", "RUF", "G"]
 
 [tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -1,18 +1,21 @@
 """Bootstrap-based sphinx theme from the PyData community."""
 
 import json
+
 from functools import partial
 from pathlib import Path
 from typing import Dict
 from urllib.parse import urlparse
 
 import requests
+
 from requests.exceptions import ConnectionError, HTTPError, RetryError
 from sphinx.application import Sphinx
 from sphinx.builders.dirhtml import DirectoryHTMLBuilder
 from sphinx.errors import ExtensionError
 
 from . import edit_this_page, logo, pygments, short_link, toctree, translator, utils
+
 
 __version__ = "0.16.1dev0"
 

--- a/src/pydata_sphinx_theme/edit_this_page.py
+++ b/src/pydata_sphinx_theme/edit_this_page.py
@@ -1,6 +1,7 @@
 """Create an "edit this page" url compatible with bitbucket, gitlab and github."""
 
 import jinja2
+
 from sphinx.application import Sphinx
 from sphinx.errors import ExtensionError
 

--- a/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ca/LC_MESSAGES/sphinx.po
@@ -2,11 +2,11 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Cristhian Rivera, 2024
 # Oriol Abril-Pla <oriol.abril.pla@gmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 

--- a/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/cs/LC_MESSAGES/sphinx.po
@@ -181,4 +181,3 @@ msgstr "Navigace na stránce"
 
 #~ msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 #~ msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
-

--- a/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/en/LC_MESSAGES/sphinx.po
@@ -182,4 +182,3 @@ msgstr ""
 
 #~ msgid "light/dark"
 #~ msgstr ""
-

--- a/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/es/LC_MESSAGES/sphinx.po
@@ -2,13 +2,13 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2023
 # Cristhian Rivera, 2024
 # Felipe Moreno, 2024
 # Tania Allard, 2024
-# 
+#
 msgid ""
 msgstr ""
 

--- a/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/fr/LC_MESSAGES/sphinx.po
@@ -2,11 +2,11 @@
 # Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
-# 
+#
 # Translators:
 # Rambaud Pierrick <pierrick.rambaud49@gmail.com>, 2024
 # Denis Bitouzé <dbitouze@wanadoo.fr>, 2024
-# 
+#
 msgid ""
 msgstr ""
 

--- a/src/pydata_sphinx_theme/locale/it/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/it/LC_MESSAGES/sphinx.po
@@ -184,4 +184,3 @@ msgstr "Navigazione del sito"
 
 #~ msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 #~ msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
-

--- a/src/pydata_sphinx_theme/locale/ja/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ja/LC_MESSAGES/sphinx.po
@@ -186,4 +186,3 @@ msgstr "サイトナビゲーション"
 
 #~ msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 #~ msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
-

--- a/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/ru/LC_MESSAGES/sphinx.po
@@ -181,4 +181,3 @@ msgstr "Навигация по сайту"
 
 #~ msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 #~ msgstr "© <a href=\\\"%(path)s\\\">Копирайт</a> %(copyright)s."
-

--- a/src/pydata_sphinx_theme/locale/sphinx.pot
+++ b/src/pydata_sphinx_theme/locale/sphinx.pot
@@ -169,4 +169,3 @@ msgstr ""
 #: src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html:3
 msgid "Site navigation"
 msgstr ""
-

--- a/src/pydata_sphinx_theme/locale/zh/LC_MESSAGES/sphinx.po
+++ b/src/pydata_sphinx_theme/locale/zh/LC_MESSAGES/sphinx.po
@@ -184,4 +184,3 @@ msgstr "网页导航"
 
 #~ msgid "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
 #~ msgstr "© <a href=\"%(path)s\">Copyright</a> %(copyright)s."
-

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/search-button-field.html
@@ -1,5 +1,5 @@
 {# Displays a search field image that opens a search overlay when clicked. #}
-{# 
+{#
     As this function will only work when JavaScript is enabled,
     we add a class that will hide it if js is disable.
 #}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -17,8 +17,8 @@
     document.documentElement.dataset.mode = localStorage.getItem("mode") || "{{ default_mode }}";
     document.documentElement.dataset.theme = localStorage.getItem("theme") || "{{ default_mode }}";
   </script>
-  <!-- 
-    this give us a css class that will be invisible only if js is disabled 
+  <!--
+    this give us a css class that will be invisible only if js is disabled
   -->
   <noscript>
     <style>

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -8,6 +8,7 @@ from typing import Iterator, List, Tuple, Union
 from urllib.parse import urlparse
 
 import sphinx
+
 from bs4 import BeautifulSoup
 from docutils import nodes
 from docutils.nodes import Node

--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -6,6 +6,7 @@ from sphinx.application import Sphinx
 from sphinx.ext.autosummary import autosummary_table
 from sphinx.util import logging
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/pydata_sphinx_theme/utils.py
+++ b/src/pydata_sphinx_theme/utils.py
@@ -3,6 +3,7 @@
 import copy
 import os
 import re
+
 from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 from docutils.nodes import Node
@@ -158,9 +159,11 @@ def _get_matching_sidebar_items(
     for pattern, sidebar_items in sidebars.items():
         if matching.patmatch(pagename, pattern):
             if matched and _has_wildcard(pattern) and _has_wildcard(matched):
-                SPHINX_LOGGER.warning(
-                    f"Page {pagename} matches two wildcard patterns in secondary_sidebar_items: {matched} and {pattern}"
-                ),
+                (
+                    SPHINX_LOGGER.warning(
+                        f"Page {pagename} matches two wildcard patterns in secondary_sidebar_items: {matched} and {pattern}"
+                    ),
+                )
 
             matched = pattern
             secondary_sidebar_items = sidebar_items

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import re
 import time
+
 from http.client import HTTPConnection
 from os import environ
 from pathlib import Path
@@ -11,9 +12,11 @@ from typing import Callable
 
 import pytest
 import sphinx
+
 from bs4 import BeautifulSoup
 from sphinx.testing.util import SphinxTestApp
 from typing_extensions import Self
+
 
 pytest_plugins = "sphinx.testing.fixtures"
 

--- a/tests/test_a11y.py
+++ b/tests/test_a11y.py
@@ -4,9 +4,11 @@ from urllib.parse import urljoin
 
 import pytest
 
+
 # Using importorskip to ensure these tests are only loaded if Playwright is installed.
 playwright = pytest.importorskip("playwright")
 from playwright.sync_api import Page, expect  # noqa: E402
+
 
 # Important note: automated accessibility scans can only find a fraction of
 # potential accessibility issues.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,12 +1,14 @@
 """All the tests performed in the pydata-sphinx-theme test suite."""
 
 import re
+
 from pathlib import Path
 
 import pytest
 import sphinx.errors
 
 from pydata_sphinx_theme.utils import escape_ansi
+
 
 COMMON_CONF_OVERRIDES = dict(
     surface_warnings=True,

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 
 import pytest
 
+
 try:
     from pathlib import UnsupportedOperation  # added in Py 3.13
 except ImportError:
@@ -14,6 +15,7 @@ except ImportError:
 # Using importorskip to ensure these tests are only loaded if Playwright is installed.
 playwright = pytest.importorskip("playwright")
 from playwright.sync_api import Page, expect  # noqa: E402
+
 
 repo_path = Path(__file__).parents[1]
 test_sites_dir = repo_path / "docs" / "_build" / "html" / "playwright_tests"

--- a/tests/utils/check_warnings.py
+++ b/tests/utils/check_warnings.py
@@ -1,11 +1,13 @@
 """Check the list of warnings produced by a doc build."""
 
 import sys
+
 from pathlib import Path
 
 from colorama import Fore, init
 
 from pydata_sphinx_theme.utils import escape_ansi
+
 
 # init colors for all plateforms
 init()

--- a/tools/divergent_links.py
+++ b/tools/divergent_links.py
@@ -18,11 +18,13 @@ How to fix (give the links different names):
 
 import os
 import sys
+
 from collections import defaultdict
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
 from rich import print
+
 
 # when looking at inconsistent links across pages,
 # a number of text is recurrent and appear on many pages.

--- a/tools/profile.py
+++ b/tools/profile.py
@@ -15,6 +15,7 @@ import argparse
 import shutil as sh
 import subprocess
 import tempfile
+
 from pathlib import Path
 from textwrap import dedent
 
@@ -30,7 +31,6 @@ def profile_docs(output: str = "profile.svg", n_extra_pages: int = 50) -> None:
     base_site_path = Path("tests/sites/base")
 
     with tempfile.TemporaryDirectory() as tmpdir:
-
         # copy over the base test site to the temporary folder
         target_path = Path(tmpdir) / base_site_path
         sh.copytree(base_site_path, target_path)

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ skip_install =
 package = editable
 commands =
     lint: pre-commit run -a
-    compile-assets: stb compile  # bundle JavaScript and Sass 
+    compile-assets: stb compile  # bundle JavaScript and Sass
     # can substitute the target directory with any other directory by calling:
     # tox run -e docs-no-checks -- path/to/other/directory
     docs-no-checks: sphinx-build {posargs:audit}/site {posargs:audit}/_build
@@ -46,11 +46,11 @@ commands =
     profile-docs: python ./tools/profile.py {posargs}
 
 # tests can be ran with or without coverage (see examples below),
-# it is recommended to run compile-assets before running tests 
-# i18n-compile MUST be run before running tests 
+# it is recommended to run compile-assets before running tests
+# i18n-compile MUST be run before running tests
 # (see examples below),
 # tox run -e compile-assets,i18n-compile,py39-tests
-# if you want to skip the assets and translations compilation step you can run 
+# if you want to skip the assets and translations compilation step you can run
 # the tests without `compile-assets,i18n-compile`, for example:
 # tox run -e py39-tests
 # run tests with a specific Sphinx version
@@ -67,7 +67,7 @@ deps =
     coverage[toml]
     py39-sphinx61-tests: sphinx~=6.1.0
     py312-sphinxdev: sphinx[test] @ git+https://github.com/sphinx-doc/sphinx.git@master
-depends = 
+depends =
     compile-assets,
     i18n-compile
 commands =
@@ -126,7 +126,7 @@ commands =
     python tests/utils/check_warnings.py
 
 # build the docs with live-reload, if you are working on the docs only (no theme changes) the best option is to call
-# tox run -e docs-live 
+# tox run -e docs-live
 # this will only watch the docs directory and rebuild the docs when changes are detected
 # if you are working on the theme (HTML, jinja templates, JS, CSS) and the docs, you can call
 # tox run -e docs-live-theme
@@ -145,7 +145,7 @@ commands =
 
 # extract translatable files into the POT file and update locale PO files
 # tox run -e i18n-extract
-# this will update all locales, to update a single locale you can 
+# this will update all locales, to update a single locale you can
 # pass the locale code, for example to update the Spanish locale only:
 # tox run -e i18n-extract -- --locale=es
 [testenv:i18n-extract]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,8 +107,8 @@ module.exports = {
   output: {
     filename: "scripts/[name].js",
     path: staticPath,
-    // clean webpack assets at the beginning of the build - except for 
-    // files we need to explicitly keep 
+    // clean webpack assets at the beginning of the build - except for
+    // files we need to explicitly keep
     clean: {
       keep(asset) {
         const filesToKeep = ["styles/theme.css", ".gitignore"];


### PR DESCRIPTION
While working on another PR, I noticed some additions that would be beneficial here, so I decided to clean our pre-commit hooks and configuration.

So that you know, I will open a separate follow-up PR with the actual fixes to make the review easier.

Notable items:

- Since we are using `ruff`, it did not make sense to have `black` separately as ruff is compatible with `black`
- Added pre-commits to deal with imports, trailing whitespace, and end-of-file-fixer
- Replaces the unmaintained and archived `prettier` hook

Closes https://github.com/pydata/pydata-sphinx-theme/issues/1880 
Closes https://github.com/pydata/pydata-sphinx-theme/issues/2047