### PR TITLE
Higher contrast table hover stripe (light mode)

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -220,7 +220,7 @@ $pst-semantic-colors: (
   ),
   "table-row-hover": (
     "bg-light": #{map-deep-get($color-palette, "violet", "200")},
-    "bg-dark": #{map-deep-get($color-palette, "violet", "600")},
+    "bg-dark": #{map-deep-get($color-palette, "violet", "700")},
   ),
   "table-inner-border": (
     "light": #{map-deep-get($color-palette, "gray", "200")},

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -219,7 +219,7 @@ $pst-semantic-colors: (
     "dark": #{map-deep-get($color-palette, "foundation", "white")},
   ),
   "table-row-hover": (
-    "bg-light": #{map-deep-get($color-palette, "violet", "300")},
+    "bg-light": #{map-deep-get($color-palette, "violet", "200")},
     "bg-dark": #{map-deep-get($color-palette, "violet", "600")},
   ),
   "table-inner-border": (


### PR DESCRIPTION
This pull request:

- changes the background hover color on tables to improve legibility
- differs from the [design system](https://www.figma.com/design/SnLFWtSKEBLYrtLHbs4TSE/PyData-Sphinx-Theme-Design-System-(Community)?node-id=3312-493), but I think it looks better, plus it steps up the hover background/foreground contrast in light mode to meet WCAG AAA.

Note: once #2059 is merged, this will only affect `.dataframe` classes 

### After screenshot

![](https://github.com/user-attachments/assets/75c5049f-db2a-41eb-b327-e186320d7eb5)
![](https://github.com/user-attachments/assets/75434c18-1928-4c6d-96bc-97135e865e1d)


### Before screenshot

![](https://github.com/user-attachments/assets/603b6bae-7e30-48b4-a5a8-51fbf4e29859)
![](https://github.com/user-attachments/assets/c49c3f62-c1e3-475e-8049-cd96b87212c3)
