### PR TITLE
Import Bootstrap after importing our variable overrides

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/pydata-sphinx-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/pydata-sphinx-theme.scss
@@ -1,4 +1,5 @@
 // Import all of Bootstrap scss
+@import "variables/bootstrap";
 @import "~bootstrap/scss/bootstrap";
 
 // Import FontAwesome from _node_modules
@@ -8,7 +9,6 @@
 @import "~@fortawesome/fontawesome-free/scss/brands";
 
 // Variables
-@import "variables/bootstrap";
 @import "variables/layout";
 @import "variables/fonts";
 @import "variables/icons";


### PR DESCRIPTION
Fixes https://github.com/pydata/pydata-sphinx-theme/issues/2022.

This also fixes another issue that I had noticed when clicking links in the "More" dropdown. Screenshots:

- Fixed: ![](https://github.com/user-attachments/assets/060fa3fe-2ce8-4311-b127-7821ddbbdadc)
- Broken: ![](https://github.com/user-attachments/assets/f1de59b9-e6a6-485f-8e83-22a3548de94f)
