### PR TITLE
Fix Read the Docs preview builds

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -20,3 +20,6 @@ python:
   install:
     - method: pip
       path: .[doc]
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
GitHub CI checks are failing because Read the Docs recently required providing the path to the Sphinx configuration file.

We'll know that this PR works if the GitHub check passes.