### PR TITLE
Highlight headings when the user navigates to them

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_article.scss
@@ -31,6 +31,23 @@
           padding-top: 1.5rem;
           padding-left: 2rem;
         }
+
+        // If the user clicks a TOC link or opens a URL that goes directly to a
+        // section of the article, then highlight the heading for that section.
+        // The rule is written this way because Sphinx puts ids on sections
+        // rather than headings.
+        :target > :is(h1, h2, h3, h4, h5, h5) {
+          background-color: var(--pst-color-target);
+        }
+
+        // If an inline element has padding, then it can take up more height
+        // than its parent. This becomes really apparent when highlighting the
+        // parent element, i.e., setting its background color to
+        // `var(--pst-color-target)`. In that case, the inline element extends
+        // outside the highlighted area and it looks bad.
+        :is(h1, h2, h3, h4, h5, h6) > code {
+          display: inline-block;
+        }
       }
     }
   }


### PR DESCRIPTION
We already highlight targets on the page if they are API references:

https://github.com/pydata/pydata-sphinx-theme/blob/ed331af8f46b164e2e432205ac6a1cd22caf95f6/src/pydata_sphinx_theme/assets/styles/content/_api.scss#L97-L101

which you can see in action on the [Kitchen Sink - API](https://pydata-sphinx-theme.readthedocs.io/en/latest/examples/kitchen-sink/api.html) page.

This pull request extends this functionality to other headings.

### How to test

1. Visit the preview build of the docs
2. Go to any page that is not an API reference doc
3. Click on in-page TOC links that take you to specific sections in the article (these kinds of links are also known anchor links or hash links, and they have a "#" symbol in the URL)
4. Observe that the heading for that section is highlighted
5. In particular, check how it looks on the Kitchen Sink Admonitions page

### Screenshots

![](https://github.com/user-attachments/assets/7115842f-1561-4106-8d6d-7cbe0d1096cf)

![image](https://github.com/user-attachments/assets/6a9b5401-eccc-4cc2-aa24-fc07bf9456cf)