### PR TITLE
MAINT - Install playwright for all of our tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,6 @@ doc = [
   "ipywidgets",
   "graphviz",
 ]
-test = ["pytest", "pytest-cov", "pytest-regressions", "sphinx[test]"]
 dev = [
   "pyyaml",
   "pre-commit",
@@ -90,7 +89,13 @@ dev = [
   "pandoc",
   "sphinx-theme-builder[cli]",
 ]
-a11y = ["pytest-playwright"]
+test = [
+  "pytest",
+  "pytest-cov",
+  "pytest-regressions",
+  "sphinx[test]",
+  "pytest-playwright"
+]
 i18n = ["Babel", "jinja2"]
 
 [project.entry-points]
@@ -109,7 +114,7 @@ indent-width = 4
 ignore = [
   "D107", # Missing docstring in `__init__` | set the docstring in the class
   "D205", # 1 blank line required between summary line and description,
-  "D212",  # docstring summary must be on first physical line
+  "D212", # docstring summary must be on first physical line
   "W291", # let pre-commit handle trailing whitespace
 
 ]

--- a/tests/test_a11y.py
+++ b/tests/test_a11y.py
@@ -282,17 +282,6 @@ def test_notebook_ipywidget_output_tab_stop(page: Page, url_base: str) -> None:
     assert ipywidget.evaluate("el => el.tabIndex") == 0
 
 
-def test_breadcrumb_expansion(page: Page, url_base: str) -> None:
-    """Foo."""
-    # page.goto(urljoin(url_base, "community/practices/merge.html"))
-    # expect(page.get_by_label("Breadcrumb").get_by_role("list")).to_contain_text("Merge and review policy") # noqa: E501
-    page.set_viewport_size({"width": 1440, "height": 720})
-    page.goto(urljoin(url_base, "community/topics/config.html"))
-    expect(page.get_by_label("Breadcrumb").get_by_role("list")).to_contain_text(
-        "Update Sphinx configuration during the build"
-    )
-
-
 @pytest.mark.a11y
 def test_search_as_you_type(page: Page, url_base: str) -> None:
     """Search-as-you-type feature should support keyboard navigation.

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ description = "Run tests Python and Sphinx versions. If a Sphinx version is spec
 # need to ensure the package is installed in editable mode
 package = editable
 extras =
-    test # install dependencies - defined in pyproject.toml
+    test # install dependencies, includes pytest-playwright - defined in pyproject.toml
+pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 deps =
     coverage[toml]
     py39-sphinx61-tests: sphinx~=6.1.0
@@ -70,7 +71,11 @@ deps =
 depends =
     compile-assets,
     i18n-compile
+allowlist_externals=
+    playwright
+    bash
 commands =
+    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
     py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs}
     py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs}
 
@@ -82,8 +87,7 @@ description = run accessibility tests with Playwright and axe-core
 base_python = py312 # keep in sync with tests.yml
 pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 extras =
-    test
-    a11y
+    test # install dependencies, includes pytest-playwright - defined in pyproject.toml
 depends =
     compile-assets,
     i18n-compile


### PR DESCRIPTION
Ensures playwright is always available for tests following conversations in https://github.com/pydata/pydata-sphinx-theme/pull/2119#issuecomment-2663478924

Note, however,  that the `test_version_switcher_highlighting` test is currently failing due to changes to the version switcher component (as part of recent a11y improvements) and due to RTD version switcher no longer being flushed into the sidebar (https://github.com/pydata/pydata-sphinx-theme/pull/2034).

I could try and add an alternative test that checks perhaps that we have at least a latest and a dev version in the version switcher?