### PR TITLE
[MAINT] Bump version to 0.16.2dev0

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -17,7 +17,7 @@ from sphinx.errors import ExtensionError
 from . import edit_this_page, logo, pygments, short_link, toctree, translator, utils
 
 
-__version__ = "0.16.1"
+__version__ = "0.16.2dev0"
 
 
 def update_config(app):


### PR DESCRIPTION
This PR fixes an issue with the locator in the `test_version_switcher_highlighting` test, which should allow #2133 to pass automated tests.

Note that this test is not run by CI, but that should be addressed in #2133. To test, please run this manually.

(Sorry about the extra PR - I don't have permissions to push to the branch in #2133). cc @trallard 