### PR TITLE
FIX - Crash in translator when using a non HTML builder

### DIFF
--- a/src/pydata_sphinx_theme/translator.py
+++ b/src/pydata_sphinx_theme/translator.py
@@ -81,8 +81,11 @@ def setup_translators(app: Sphinx):
     defined in ``BootstrapHTML5TranslatorMixin``.
     This way we can retain the original translator's
     behavior and configuration, and _only_ add the extra bootstrap rules.
-    If we don't detect an HTML-based translator, then we do nothing.
+    If we don't detect an HTML-based builder, then we do nothing.
     """
+    # Skip builders that are not HTML
+    if app.builder.format != "html":
+        return
     if not app.registry.translators.items():
         try:
             default_translator_class = app.builder.default_translator_class
@@ -101,10 +104,6 @@ def setup_translators(app: Sphinx):
         app.set_translator(app.builder.name, translator, override=True)
     else:
         for name, klass in app.registry.translators.items():
-            if app.builder.format != "html":
-                # Skip translators that are not HTML
-                continue
-
             translator = types.new_class(
                 "BootstrapHTML5Translator",
                 (


### PR DESCRIPTION
This change skips the transpator setup if the builder is not targeting `html` as the format.

In our readthedocs config, we use `formats: all` which besides HTML also builds PDF using the `latex` builder, causing the following error:

```py
Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyglotaran-extras/conda/latest/lib/python3.10/site-packages/pydata_sphinx_theme/translator.py", line 44, in visit_table
    self._table_row_indices.append(0)
AttributeError: 'BootstrapHTML5Translator' object has no attribute '_table_row_indices'
```

This builder has the `default_translator_class` defined, but it is not compatible with the `BootstrapHTML5TranslatorMixin` and thus causes the `AttributeError` above.

This can be prevented by first checking if the builder uses the `html` format, which is true for the `html` and `singlehtml` builders.

Since the builder format does not change and is independent of the translator, it makes sense to lift it out of the loop over translators.