### PR TITLE
MAINT - Update actions/workflows SHAs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -118,7 +118,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
@@ -174,7 +174,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
         with:
           # 3.12 is not supported by py-spy yet
           python-version: "3.11"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -46,7 +46,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           pandoc: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -90,7 +90,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
@@ -128,7 +128,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
 
       - name: "Check for broken links 🔗"
         run: python -Im tox run -e docs-linkcheck

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   prerelease:
     # only run this workflow for pydata owned repositories (avoid forks)
-    if: github.repository_owner == 'pydata'
+    # if: github.repository_owner == 'pydata'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,7 +16,7 @@ permissions: {}
 jobs:
   prerelease:
     # only run this workflow for pydata owned repositories (avoid forks)
-    # if: github.repository_owner == 'pydata'
+    if: github.repository_owner == 'pydata'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -63,6 +63,7 @@ jobs:
 
       # Run tests on the built package (which will be later uploaded to PyPI)
       - name: "Install PST from wheel and test"
+        if: matrix.python-version == '3.9'
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
         run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           # calling with --installpkg so we can use the already built package
           tox run -e py312-tests-no-cov \
-          --installpkg "${ BAIPP_DIST }"/*.whl \
+          --installpkg ${ BAIPP_DIST }/*.whl \
           -- --deselect tests/test_build.py::test_translations
 
       # If either the docs build or the tests resulted in an error, create an issue to note it

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -63,13 +63,13 @@ jobs:
 
       # Run tests on the built package (which will be later uploaded to PyPI)
       - name: "Install PST from wheel and test"
-        if: matrix.python-version == '3.9'
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
         run: |
+          dist_loc="${BAIPP_DIST}"
           # calling with --installpkg so we can use the already built package
           tox run -e py312-tests-no-cov \
-          --installpkg ${ BAIPP_DIST }/*.whl \
+          --installpkg $dist_loc/*.whl \
           -- --deselect tests/test_build.py::test_translations
 
       # If either the docs build or the tests resulted in an error, create an issue to note it

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -61,22 +61,15 @@ jobs:
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
 
-      - name: "Get PST version"
-        run: |
-          python -Im pip install -e .
-          # Get the version of the package
-          PST_VERSION=$(python -c "import pydata_sphinx_theme; print(pydata_sphinx_theme.__version__)")
-          echo "PST_VERSION=$PST_VERSION" >> $GITHUB_ENV
-
       # Run tests on the built package (which will be later uploaded to PyPI)
       - name: "Install PST from wheel and test"
+        if: matrix.python-version == '3.9'
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
-          PST_VERSION: ${{ env.PST_VERSION }}
         run: |
           # calling with --installpkg so we can use the already built package
           tox run -e py312-tests-no-cov \
-          --installpkg "${BAIPP_DIST}"/pydata_sphinx_theme-"${PST_VERSION}"-py3-none-any.whl \
+          --installpkg "${ BAIPP_DIST }"/*.whl \
           -- --deselect tests/test_build.py::test_translations
 
       # If either the docs build or the tests resulted in an error, create an issue to note it

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@01731d0cc57768b9eff1c97f38909932ecd7e7d1
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,22 +55,14 @@ jobs:
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
 
-      - name: "Get PST version"
-        run: |
-          python -Im pip install -e .
-          # Get the version of the package
-          PST_VERSION=$(python -c "import pydata_sphinx_theme; print(pydata_sphinx_theme.__version__)")
-          echo "PST_VERSION=$PST_VERSION" >> $GITHUB_ENV
-
       # Run tests on the built package (which will be later uploaded to PyPI)
       - name: "Install PST from wheel and test"
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
-          PST_VERSION: ${{ env.PST_VERSION }}
         run: |
           # calling with --installpkg so we can use the already built package
           tox run -e py312-tests-no-cov \
-          --installpkg "${BAIPP_DIST}"/pydata_sphinx_theme-"${PST_VERSION}"-py3-none-any.whl \
+          --installpkg "${ BAIPP_DIST }"/*.whl \
           -- --deselect tests/test_build.py::test_translations
 
   release-PST:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,18 +18,16 @@ permissions:
 jobs:
   # calls our general CI workflows (tests, coverage, profile, etc.)
   tests:
-    # TODO @trallard: replace SHA after merge to main
     # Important: make sure to update the SHA after making any changes to the CI workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@417d83135293eca5a3bbec100fece34467ced065
+    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@4a1e7898d6c92dade5e489684277ab4ffd0eb053
     # needed for the coverage action
     permissions:
       contents: write
       pull-requests: write
       # calls our docs workflow (build docs, check broken links, lighthouse)
   docs:
-    # TODO @trallard: replace SHA after merge to main
     # Important: make sure to update the SHA after making any changes to the docs workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@417d83135293eca5a3bbec100fece34467ced065
+    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@4a1e7898d6c92dade5e489684277ab4ffd0eb053
 
   build-package:
     name: "Build & verify PST package"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,24 @@ jobs:
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
 
+      - name: "Get PST version"
+        run: |
+          python -Im pip install -e .
+          # Get the version of the package
+          PST_VERSION=$(python -c "import pydata_sphinx_theme; print(pydata_sphinx_theme.__version__)")
+          echo "PST_VERSION=$PST_VERSION" >> $GITHUB_ENV
+
+      # Run tests on the built package (which will be later uploaded to PyPI)
+      - name: "Install PST from wheel and test"
+        env:
+          BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
+          PST_VERSION: ${{ env.PST_VERSION }}
+        run: |
+          # calling with --installpkg so we can use the already built package
+          tox run -e py312-tests-no-cov \
+          --installpkg "${BAIPP_DIST}"/pydata_sphinx_theme-"${PST_VERSION}"-py3-none-any.whl \
+          -- --deselect tests/test_build.py::test_translations
+
   release-PST:
     runs-on: ubuntu-latest
     needs: [build-package]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,9 +60,10 @@ jobs:
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
         run: |
+          dist_loc="${BAIPP_DIST}"
           # calling with --installpkg so we can use the already built package
           tox run -e py312-tests-no-cov \
-          --installpkg "${ BAIPP_DIST }"/*.whl \
+          --installpkg $dist_loc/*.whl \
           -- --deselect tests/test_build.py::test_translations
 
   release-PST:


### PR DESCRIPTION
This follows https://github.com/pydata/pydata-sphinx-theme/pull/2077 as our actions and workflows needed re-pinning after merging this branch. Included:

- **:pushpin: Pin our actions to a concrete SHA**
- **:construction_worker: Add test to publish workflow**
