### PR TITLE
Unique Playwright trace names to avoid collisions

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -60,5 +60,5 @@ jobs:
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6
         if: ${{ failure() }}
         with:
-          name: playwright-traces
+          name: playwright-traces-${{ matrix.os }}-${{ matrix.browser }}
           path: test-results/


### PR DESCRIPTION
I think this is what caused the following error message in [one of the failing checks](https://github.com/pydata/pydata-sphinx-theme/actions/runs/13705550329/job/38329838641#step:5:22) for #2151:

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

<!-- readthedocs-preview pydata-sphinx-theme start -->
----
📚 Documentation preview 📚: https://pydata-sphinx-theme--2161.org.readthedocs.build/en/2161/

<!-- readthedocs-preview pydata-sphinx-theme end -->