### PR TITLE
Use a different CSS class to mark TOC levels as visible

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_toc-inpage.scss
@@ -12,7 +12,7 @@ nav.page-toc {
     display: none;
 
     // So we can manually specify a level as visible in the config
-    &.visible {
+    &.pst-show_toc_level {
       display: block;
     }
   }

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -427,7 +427,7 @@ def add_toctree_functions(
             if ul is None:
                 return
             if level <= (context["theme_show_toc_level"] + 1):
-                ul["class"] = [*ul.get("class", []), "visible"]
+                ul["class"] = [*ul.get("class", []), "pst-show_toc_level"]
             for li in ul("li", recursive=False):
                 li["class"] = [*li.get("class", []), f"toc-h{level}"]
                 add_header_level_recursive(li.find("ul", recursive=False), level + 1)


### PR DESCRIPTION
Fixes https://github.com/pydata/pydata-sphinx-theme/issues/2156.

The underlying issue was that the CSS class `visible` is targeted by Bootstrap and results in the following rule:

```
visibility: visible !important;
```

which gets applied to the `ul` elements in the secondary sidebar. This overrides the `visibility: hidden` rule set on the sidebar container element, making the links focusable via the tab key.

### How to test

1. On a desktop computer, go to a page in Read The Docs preview build. This page should have a right sidebar visible — i.e., the in-page table of contents.
2. Click near the bottom of the article and repeatedly press the tab key to observe how it moves through the links in the secondary sidebar.
3. Zoom the page, or narrow the width of your screen, until the secondary sidebar disappears.
4. Again, click near the bottom article before the article footer (which has two links to the previous and next articles)
5. Press the tab key and watch the focus move to those two previous/next footer links.
6. Keep pressing the tab key and observe that it does not go through any of the links in the sidebar. (Before this PR, the tab key would take you through the links in the sidebar, even though those links were not visible.)