### PR TITLE
Fix miscellaneous issues with CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ name: continuous-integration
 # Repeated pushes to a PR will cancel all previous builds, while multiple
 # merges to main will not cancel.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -2,13 +2,15 @@
 
 name: a11y-tests
 
-# Concurrency group that uses the workflow name and PR number if available
+# Dynamic concurrency group that uses the workflow name and PR number if available
 # or commit SHA as a fallback. If a new build is triggered under that
 # concurrency group while a previous build is running it will be canceled.
 # Repeated pushes to a PR will cancel all previous builds, while multiple
 # merges to main will not cancel.
+# Note we add the prefix `a11y-` to avoid race conditions when called from other workflows
+# for example when called from the CI workflow
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: a11y-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,13 +7,15 @@
 
 name: docs-checks
 
-# Concurrency group that uses the workflow name and PR number if available
+# Dynamic concurrency group that uses the workflow name and PR number if available
 # or commit SHA as a fallback. If a new build is triggered under that
 # concurrency group while a previous build is running it will be canceled.
 # Repeated pushes to a PR will cancel all previous builds, while multiple
 # merges to main will not cancel.
+# Note we add the prefix `docs-` to avoid race conditions when called from other workflows
+# for example when called from the CI workflow
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: docs-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: "Install uv 📦"
         uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a
+        with:
+          version: "latest"
 
       - name: "Run zizmor 🕵️‍♂️"
         run: uvx zizmor --format sarif . > results.sarif

--- a/docs/community/topics/accessibility.md
+++ b/docs/community/topics/accessibility.md
@@ -44,11 +44,10 @@ use the following tools:
 
 - GitHub Actions to provision machines in the cloud
 - `tox` to install the needed dependencies on those machines
-- `Pytest` with the Playwright plug-in to run the tests.
+- `pytest` with the Playwright plug-in to run the tests.
 
-Look for the string "accessibility" in the file
-[CI.yml](https://github.com/pydata/pydata-sphinx-theme/blob/main/.github/workflows/a11y.yml)
-to find how we have configured GitHub Actions.
+You can check out the [a11y.yml](https://github.com/pydata/pydata-sphinx-theme/blob/main/.github/workflows/a11y.yml)
+file to find how we have configured GitHub Actions.
 
 ## Known limitations and manual auditing
 

--- a/docs/community/topics/accessibility.md
+++ b/docs/community/topics/accessibility.md
@@ -47,7 +47,7 @@ use the following tools:
 - `Pytest` with the Playwright plug-in to run the tests.
 
 Look for the string "accessibility" in the file
-[CI.yml](https://github.com/pydata/pydata-sphinx-theme/blob/main/.github/workflows/CI.yml)
+[CI.yml](https://github.com/pydata/pydata-sphinx-theme/blob/main/.github/workflows/a11y.yml)
 to find how we have configured GitHub Actions.
 
 ## Known limitations and manual auditing

--- a/docs/user_guide/theme-elements.md
+++ b/docs/user_guide/theme-elements.md
@@ -44,7 +44,7 @@ You can add a link to equations like the one above {eq}`My label` and {eq}`My la
 
 ## Code blocks
 
-Code block styling is inspired by [GitHub's code block style](https://primer.style/components/markdown) and also has support for Code Block captions/titles.
+Code block styling is inspired by [GitHub's code block style](https://primer.style/product/getting-started/rails/components/markdown/) and also has support for Code Block captions/titles.
 See [the Sphinx documentation on code blocks](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-code-block) for more information.
 
 ```python

--- a/tox.ini
+++ b/tox.ini
@@ -152,6 +152,7 @@ commands =
 description = "Check external links in the documentation"
 extras = {[testenv:docs-no-checks]extras}
 allowlist_externals = bash
+basepython = py313
 commands =
     sphinx-build -b linkcheck docs/ docs/_build/linkcheck -w warnings.txt --keep-going -q
     bash -c "echo 'Linkcheck complete; see docs/_build/linkcheck/output.txt for any errors'"


### PR DESCRIPTION
This PR follows up on recent updates to our CI workflows:

- **:arrow_up: Bump Python version for linkcheck task** this avoids an issue that has been breaking this workflow with previous versions
- **:wrench: Update concurrency groups to avoid race conditions**: currently there is a race condition between the `coverage` and `release` workflows due to how I set the concurrency group
- **:memo: Update docs reference to CI workflows**: missed this before when I split the `a11y` workflows from `CI`


Note: I will need to follow up with a PR to update the SHAs for our workflows.