### PR TITLE
Fix Sphinx dev error linkcheck_allowed_redirects

### DIFF
--- a/tests/sites/base/conf.py
+++ b/tests/sites/base/conf.py
@@ -21,3 +21,6 @@ html_sourcelink_suffix = ""
 
 # Base options, we can add other key/vals later
 html_sidebars = {"section1/index": ["sidebar-nav-bs.html"]}
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/breadcrumbs/conf.py
+++ b/tests/sites/breadcrumbs/conf.py
@@ -30,3 +30,6 @@ html_theme_options = {
     "secondary_sidebar_items": ["breadcrumbs"],
     "article_header_start": ["breadcrumbs"],
 }
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/colors/conf.py
+++ b/tests/sites/colors/conf.py
@@ -17,3 +17,6 @@ extensions = []
 html_theme = "pydata_sphinx_theme"
 html_copy_source = True
 html_sourcelink_suffix = ""
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/deprecated/conf.py
+++ b/tests/sites/deprecated/conf.py
@@ -27,3 +27,6 @@ html_theme_options = {
 }
 
 html_sidebars = {"section1/index": ["sidebar-nav-bs.html"]}
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/sidebars/conf.py
+++ b/tests/sites/sidebars/conf.py
@@ -14,3 +14,6 @@ html_theme = "pydata_sphinx_theme"
 html_sidebars = {
     "section2/no-sidebar": [],  # Turn off primary/left sidebar
 }
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/test_included_toc/conf.py
+++ b/tests/sites/test_included_toc/conf.py
@@ -13,3 +13,6 @@ root_doc = "index"
 # -- Options for HTML output -------------------------------------------------
 
 html_theme = "pydata_sphinx_theme"
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/test_navbar_no_in_page_headers/conf.py
+++ b/tests/sites/test_navbar_no_in_page_headers/conf.py
@@ -14,3 +14,6 @@ html_theme = "pydata_sphinx_theme"
 
 html_copy_source = True
 html_sourcelink_suffix = ""
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/version_switcher/conf.py
+++ b/tests/sites/version_switcher/conf.py
@@ -20,3 +20,6 @@ html_theme_options = {
     },
     "navbar_start": ["navbar-logo", "version-switcher"],
 }
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}


### PR DESCRIPTION
Tests against the latest/dev Sphinx version have been seeing:

> WARNING: The config value `linkcheck_allowed_redirects' has type `NoneType'; expected `dict'.

While this is probably a [regression on Sphinx's end](https://github.com/sphinx-doc/sphinx/issues/13462), this PR is also a reasonable change on our end because it makes sense to set the conf.py variable, `linkcheck_allowed_redirects` to an empty dictionary for our test sites.