### PR TITLE
MAINT - Updates to CI workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,6 +102,13 @@ jobs:
           if-no-files-found: ignore
           include-hidden-files: true
 
+      - name: "Upload Playwright traces, if any 🐾"
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6
+        if: ${{ failure() }}
+        with:
+          name: playwright-traces-${{ matrix.os }}-${{ matrix.python-version }}
+          path: test-results/
+
   coverage:
     name: "Check coverage"
     needs: run-pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       # calls our docs workflow (build docs, check broken links, lighthouse)
   docs:
     # Important: make sure to update the SHA after making any changes to the docs workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@ac57147185b6f9400cafbcd852e04345e5e841b7
+    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@3e74810e3ad3778c179f3f836409540e0a3bf0f1
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
 

--- a/docs/community/inspiration.md
+++ b/docs/community/inspiration.md
@@ -7,7 +7,7 @@ When making new decisions about design and UI/UX, we often consult these themes 
 :grid-columns: 1 2 2 3
 :class-container: text-center
 - title: "**GitBook**"
-  link: https://docs.gitbook.com/
+  link: https://gitbook.com/docs/
   image: ../_static/inspiration/GitBook-Icon-Dark.svg
 - title: "**Metaflow**"
   image: https://raw.githubusercontent.com/Netflix/metaflow/refs/heads/master/docs/metaflow.svg

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -379,7 +379,7 @@ linkcheck_ignore = [
     # get a 403 on CI
     "https://canvas.workday.com/styles/tokens/type",
     "https://unsplash.com/",
-    r"https://www.gnu.org/software/gettext/.*",
+    r"https?://www.gnu.org/software/gettext/.*",
 ]
 
 linkcheck_allowed_redirects = {

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ commands =
 # tox run -e compile-assets,i18n-compile,py39-sphinx61-tests
 # run tests without coverage
 # tox run -e compile-assets,i18n-compile,py39-tests-no-cov
+# by default we will retain playwright traces on failure
 [testenv:py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests{,-no-cov}]
 description = "Run tests Python and Sphinx versions. If a Sphinx version is specified, it will use that version vs the default in pyproject.toml"
 # need to ensure the package is installed in editable mode
@@ -75,8 +76,8 @@ allowlist_externals=
     bash
 commands =
     bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
-    py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs}
-    py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs}
+    py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
 
 # run accessibility tests with Playwright and axe-core
 # compiling the assets is needed before running the tests


### PR DESCRIPTION
This PR adds the following:

- Adds missing traces from https://github.com/pydata/pydata-sphinx-theme/issues/2175
- Updates the `docs` workflow pinned SHA following https://github.com/pydata/pydata-sphinx-theme/pull/2204 (this should be the last change we need to fix the `publish` workflow and have nightly releases back up again)
- Updates the `regex` to skip URL checks for `gnu` URLS

Closes https://github.com/pydata/pydata-sphinx-theme/issues/2175