### PR TITLE
CI - Update coverage workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,7 +110,7 @@ jobs:
           path: test-results/
 
   coverage:
-    name: "Check coverage"
+    name: "check coverage"
     needs: run-pytest
     runs-on: ubuntu-latest
     # avoid running this on schedule, releases, workflow_call, or workflow_dispatch
@@ -161,7 +161,7 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@d1ff8fbb5ff80feedb3faa0f6d7b424f417ad0e1
         id: coverage_comment
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: "Store Pull Request comment to be posted 📤"
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1


### PR DESCRIPTION
The `check-coverage` workflow has been failing due to token permissions. 
This PR aims to fix this.

Ref: https://github.com/pydata/pydata-sphinx-theme/actions/runs/15561326728/job/43814581627