### PR TITLE
Set treosh/lighthouse-ci-action to 12.1.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -110,7 +110,7 @@ jobs:
           DOCS_DIR: "audit"
 
       - name: "Audit with Lighthouse 🔦"
-        uses: treosh/lighthouse-ci-action@v12
+        uses: treosh/lighthouse-ci-action@12.1.0
         with:
           configPath: ".github/workflows/lighthouserc.json"
           temporaryPublicStorage: true


### PR DESCRIPTION
In the past couple of the weeks the performance score for the Lighthouse audit dropped below 0.8 and started making CI fail.

This change in the CI result was surprising because there have been very few commits to main since 3e74810e3ad3778c179f3f836409540e0a3bf0f1, and none that should have affected the Lighthouse performance score.

Looking for a culprit, I noticed that the `v12` tag for `treosh/lighthouse-ci-action` was updated 2 weeks ago, pointing the tag from Lighthouse version 12.1.0 to 12.6.0, which one can see in the [treosh/lighthouse-ci-action releases](https://github.com/treosh/lighthouse-ci-action/tags). There are a good number of changes between those two versions, as shown in the [Lighthouse releases].(https://github.com/GoogleChrome/lighthouse/releases), but I haven't yet identified which of them may have affected the score.

But before investigating too deeply, the easiest thing we can do to test this hypothesis is to downgrade the version of the GitHub action, and see if that fixes CI.

