### PR TITLE
Add py313-docs to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -107,7 +107,7 @@ commands =
 # since we are building the documentation we install the packaged dev version of PST
 # tox run -e py39-docs
 # tox run -e py39-sphinx61-docs
-[testenv:py3{9,12}{,-sphinx61}-docs]
+[testenv:py3{9,12,13}{,-sphinx61}-docs]
 description = build the documentation and place in docs/_build/html
 # suppress Py3.11's new "can't debug frozen modules" warning
 set_env = PYDEVD_DISABLE_FILE_VALIDATION=1


### PR DESCRIPTION
This PR attempts to add `py313-docs` to the tox.ini file.

I noticed that our GitHub actions do not seem to actually build the docs for Python 3.13, even though our [docs workflow file has 3.13 in the python version matrix](https://github.com/pydata/pydata-sphinx-theme/blob/fa93485b033309407083afd02715c33c2f11888e/.github/workflows/docs.yml#L49). For example, if you read the log for the following job, you'll see that it doesn't output enough stuff if it had really built the docs: https://github.com/pydata/pydata-sphinx-theme/actions/runs/15825397396/job/44604165608?pr=2223#step:4:36



