### PR TITLE
Debug: persist credentials for Python coverage comment action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,8 +121,6 @@ jobs:
     steps:
       - name: "Checkout repository 🛎"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-        with:
-          persist-credentials: false
 
       - name: "Setup CI environment 🛠"
         uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@4a1e7898d6c92dade5e489684277ab4ffd0eb053


### PR DESCRIPTION
The `python-coverage-comment-action` started erroring on `main` with https://github.com/pydata/pydata-sphinx-theme/pull/2077. 

If you have permission, you can see that the job starts failing at PR 2077 on [page 2 of the CI.yml workflow runs for branch:main](https://github.com/pydata/pydata-sphinx-theme/actions/workflows/CI.yml?page=2&query=branch%3Amain), as shown in the following screenshot:

<img width="1294" alt="" src="https://github.com/user-attachments/assets/84244c27-898e-4090-be7e-4360d4f1a381" />

I'm inferring that the addition of `persist-credentials: false` may have caused the Python coverage comment action to fail based on the traceback in the logs.

```
subprocess.CalledProcessError: Command '('git', 'push', 'origin', 'python-coverage-comment-action-data')' returned non-zero exit status 128.

coverage_comment.subprocess.SubProcessError: fatal: could not read Username for 'https://github.com/': No such device or address
```

To me, that looks like the action's code is trying to call `git` directly via a subprocess. My guess is that calling the `git` command directly (versus using the GitHub API) relies on credentials being persisted from the [checkout action](https://github.com/actions/checkout).