### PR TITLE
BUG: Ensure git is properly configured for code coverage action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,7 @@ jobs:
     needs: run-pytest
     runs-on: ubuntu-latest
     # avoid running this on schedule, releases, workflow_call, or workflow_dispatch
-    if: github.event_name != 'schedule' && github.event_name != 'release'
+    if: github.event_name != 'schedule' && github.event_name != 'release' && github.event_name != 'workflow_call' && github.event_name != 'workflow_dispatch'
     permissions:
       contents: write
       pull-requests: write
@@ -158,7 +158,8 @@ jobs:
 
         # note: we need to set the user email and name as the github-actions[bot] cannot access this context
         # ref: https://api.github.com/users/github-actions%5Bbot%5D
-      - run: |
+      - name: "Configure git committer"
+        run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # check these are set correctly

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,7 @@ jobs:
     needs: run-pytest
     runs-on: ubuntu-latest
     # avoid running this on schedule, releases, workflow_call, or workflow_dispatch
-    if: github.event_name != 'schedule' && github.event_name != 'release' && github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'schedule' && github.event_name != 'release'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,7 @@ jobs:
     needs: run-pytest
     runs-on: ubuntu-latest
     # avoid running this on schedule, releases, workflow_call, or workflow_dispatch
-    if: github.event_name != 'schedule' && github.event_name != 'release' && github.event_name != 'workflow_call' && github.event_name != 'workflow_dispatch'
+    if: github.event_name != 'schedule' && github.event_name != 'release' && github.event_name != 'workflow_dispatch'
     permissions:
       contents: write
       pull-requests: write
@@ -155,6 +155,14 @@ jobs:
           name: html-report
           path: htmlcov
         if: ${{ failure() }}
+
+        # note: we need to set the user email and name as the github-actions[bot] cannot access this context
+        # ref: https://api.github.com/users/github-actions%5Bbot%5D
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # check these are set correctly
+          git config user.name
 
       # seems we need to call this from the main CI workflow first
       - name: "Coverage comment 💬"


### PR DESCRIPTION
After reviewing the logs for the failed actions and the `python-coverage` action, I noticed that the underlying problem is that `git` configurations like `user.name` for the `github-actions[bot]` are not set automatically. 

The action passes these as environment variables when committing to the coverage branch. Still, they are not picked up in the workflow (so I might perform a bit more checking and possibly open an issue upstream).

I checked locally before pushing to the branch, and the `403` error is cleared after setting this configuration, so this will resolve our failing workflow. And this should supersede the WIP https://github.com/pydata/pydata-sphinx-theme/pull/2226 since that reverts to the action through `workflow_run` which is recommended against due to security reasons (which is why this was changed in the first place).