### PR TITLE
ENH - Allow setting show_nav_level per page

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/sidebar-nav-bs.html
@@ -1,11 +1,12 @@
 {# Displays the TOC-subtree for pages nested under the currently active top-level TOCtree element. #}
+{% set show_nav_level = meta['html_theme.show_nav_level'] if (meta is defined and meta is not none and 'html_theme.show_nav_level' in meta) else theme_show_nav_level %}
 <nav class="bd-docs-nav bd-links"
      aria-label="{{ _('Section Navigation') }}">
   <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
   <div class="bd-toc-item navbar-nav">
     {{- generate_toctree_html(
       "sidebar",
-      show_nav_level=theme_show_nav_level | int,
+      show_nav_level=show_nav_level | int,
       maxdepth=theme_navigation_depth | int,
       collapse=theme_collapse_navigation | tobool,
       includehidden=theme_sidebar_includehidden | tobool,


### PR DESCRIPTION
On our page we would like to collapse the sidebar TOCs down to their `:caption:` elements as described [in the PyData Theme docs](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/navigation.html#collapse-entire-toctree-captions-parts).

However, we would like to do this only on a single page. Currently this can only be set as a global theme option.

This PR adds the possibility of setting this per-page via the page metadata [as described in the docs](https://pydata-sphinx-theme.readthedocs.io/en/stable/community/topics/page-metadata.html):

```md
---
html_theme.show_nav_level: 0
---
```