### PR TITLE
avoid having exactly one item under More dropdown

### DIFF
--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -238,7 +238,14 @@ def add_toctree_functions(
         nav_item = "nav-item"
         nav_link = "nav-link"
         dropdown_item = "dropdown-item"
-        for link in links_data[:n_links_before_dropdown]:
+        if len(links_data) <= n_links_before_dropdown + 1:
+            # max items without a dropdown is n + 1,
+            # the cutoff counting the dropdown itself.
+            # avoids having a dropdown with exactly one item
+            dropdown_cutoff = n_links_before_dropdown + 1
+        else:
+            dropdown_cutoff = n_links_before_dropdown
+        for link in links_data[:dropdown_cutoff]:
             links_html.append(
                 boilerplate.format(
                     active="current active" if link.is_current else "",
@@ -249,7 +256,7 @@ def add_toctree_functions(
                     title=link.title,
                 )
             )
-        for link in links_data[n_links_before_dropdown:]:
+        for link in links_data[dropdown_cutoff:]:
             links_dropdown.append(
                 boilerplate.format(
                     active="current active" if link.is_current else "",


### PR DESCRIPTION
closes #2246

only draw navbar dropdown if it would actually decrease the number of top-level navbar items (n items >= n_links_before_dropdown + 2), avoiding a dropdown with only one item in it when `len(items) == n + 1`.

Cases:

- nav items <= n_links_before_dropdown + 1: no dropdown (max items: n + 1)
- nav items >= n_linnks_before_dropdown + 2: always n + 1 items (last is More dropdown), dropdown always has at least two items (no change)

