### PR TITLE
Fix display of mermaid diagrams in dark mode

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/extensions/_mermaid.scss
+++ b/src/pydata_sphinx_theme/assets/styles/extensions/_mermaid.scss
@@ -1,0 +1,9 @@
+/**
+ * sphinxcontrib-mermaid
+ * ref: https://github.com/mgaitan/sphinxcontrib-mermaid
+ */
+
+/* Style the diagram such that it has a dark mode */
+html[data-theme="dark"] pre.mermaid > svg {
+  filter: brightness(0.8) invert(0.82) contrast(1.2);
+}


### PR DESCRIPTION
Closes: #2249

The handling is completely analoguous to the existing handling of graphviz [here](https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/assets/styles/extensions/_graphviz.scss).