### PR TITLE
In-line math alignment

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -19,6 +19,7 @@ div.math {
 // Inline-only
 span.math {
   display: inline-flex;
+  align-items: baseline;
 }
 
 // Block-level only


### PR DESCRIPTION
Hello,

I encountered a problem with math's rendering on pages produced by [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html). It does not occur on their documentation web-page, but does occur when I build documentation of my project.

Here is misaligned version:

<img width="355" height="58" alt="Screenshot 2025-08-28 at 17 23 39" src="https://github.com/user-attachments/assets/a233273b-cfbc-4c77-a086-2d4f894b75ca" />

Here is version that is build with proposed change:

<img width="262" height="43" alt="Screenshot 2025-08-28 at 17 24 00" src="https://github.com/user-attachments/assets/76c0f298-b936-4f97-8392-ce6f0f35c0d0" />

I do not have experience with css styling, perhaps proposed solution is not an adequate one.

I would be grateful if someone with more experience can comment on this topic.

Best,
Andrey
