### PR TITLE
[doc] Update the url example for remote html announcement banner

### DIFF
--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -38,7 +38,7 @@ For example, the following configuration tells the theme to load the ``custom-te
 
    html_theme_options = {
       ...
-      "announcement": "https://github.com/pydata/pydata-sphinx-theme/raw/main/docs/_templates/custom-template.html",
+      "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
    }
 
 Update or remove announcement banner


### PR DESCRIPTION
Adresses issue  #2265

In the following documentation page : https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html, this commit replaces the given example url "https://github.com/pydata/pydata-sphinx-theme/raw/main/docs/_templates/custom-template.html" with its redirected url "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html" (GitHub's preferred file access method) because only the second url works.