### PR TITLE
Do not linkcheck npm as it may be blocked on CI.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -380,6 +380,7 @@ linkcheck_ignore = [
     "https://canvas.workday.com/styles/tokens/type",
     "https://unsplash.com/",
     r"https?://www.gnu.org/software/gettext/.*",
+    r"https://www.npmjs.com/.*",
 ]
 
 linkcheck_allowed_redirects = {


### PR DESCRIPTION
This should get rid of some of the current failures.