### PR TITLE
Some linkcheck updates

### DIFF
--- a/docs/community/topics/i18n.rst
+++ b/docs/community/topics/i18n.rst
@@ -5,7 +5,7 @@ This section covers how to internationalize (I18n) and localize (L10n) the PyDat
 For details on how to localize the configurable strings in your Sphinx project, see the
 :ref:`User guide section on internationalization <user-guide-i18n>`.
 
-The PyData Sphinx Theme I18n/i10n workflows are based on `GNU Gettext <http://www.gnu.org/software/gettext/>`__
+The PyData Sphinx Theme I18n/i10n workflows are based on `GNU Gettext <https://www.gnu.org/software/gettext/>`__
 and `pybabel <https://babel.pocoo.org/en/latest/messages.html>`__ is used to keep the catalogs up to date.
 Crowd-sourced localizations are managed on `Transifex <https://explore.transifex.com/12rambau/pydata-sphinx-theme/>`__.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,8 +372,7 @@ linkcheck_ignore = [
     r"https://github.com.+?#.*",
     r"https://www.sphinx-doc.org/en/master/*/.+?#.+?",
     # sample urls
-    "http://someurl/release-0.1.0.tar-gz",
-    "http://python.py",
+    "https://someurl/release-0.1.0.tar-gz",
     # for whatever reason the Ablog index is treated as broken
     "../examples/blog/index.html",
     # get a 403 on CI
@@ -381,6 +380,7 @@ linkcheck_ignore = [
     "https://unsplash.com/",
     r"https?://www.gnu.org/software/gettext/.*",
     r"https://www.npmjs.com/.*",
+    r"https://sass-lang.com/.*",
 ]
 
 linkcheck_allowed_redirects = {
@@ -400,7 +400,6 @@ linkcheck_allowed_redirects = {
     r"https://www.sphinx-doc.org/": "https://www.sphinx-doc.org/en/master/",
     r"https://idtracker.ai/": "https://idtracker.ai/latest/",
     r"https://gitlab.com": "https://about.gitlab.com/",
-    r"http://www.yahoo.com": "https://www.yahoo.com/",
     r"https://feature-engine.readthedocs.io/": "https://feature-engine.trainindata.com/en/latest/",
     r"https://picsum.photos/": r"https://fastly.picsum.photos/",
 }

--- a/docs/examples/kitchen-sink/blocks.rst
+++ b/docs/examples/kitchen-sink/blocks.rst
@@ -169,7 +169,7 @@ https://docutils.sourceforge.io/docs/ref/rst/directives.html#parsed-literal-bloc
 .. parsed-literal::
 
     # parsed-literal test
-    curl -O http://someurl/release-0.1.0.tar-gz
+    curl -O https://someurl/release-0.1.0.tar-gz
     echo "This is an intentionally very long line because I want to make sure that we are handling scrollable code blocks correctly."
 
 Code Block

--- a/docs/user_guide/theme-elements.md
+++ b/docs/user_guide/theme-elements.md
@@ -60,7 +60,7 @@ For example, the following code:
 `````{tab-item} rST
 ````rst
 .. code-block:: python
-    :caption: python.py
+    :caption: `python.py`
 
     print("A code block with a caption.")
 ````
@@ -68,7 +68,7 @@ For example, the following code:
 `````{tab-item} Markdown
 ````md
 ```{code-block} python
-:caption: python.py
+:caption: `python.py`
 
 print("A code block with a caption.")
 ```
@@ -79,7 +79,7 @@ print("A code block with a caption.")
 results in:
 
 ```{code-block} python
-:caption: python.py
+:caption: `python.py`
 
 print("A code block with a caption.")
 ```
@@ -91,7 +91,7 @@ For example, the following code:
 `````{tab-item} rST
 ````rst
 ..  code-block:: python
-    :caption: python.py
+    :caption: `python.py`
     :linenos:
 
     print("A code block with a caption and line numbers.")
@@ -102,7 +102,7 @@ For example, the following code:
 `````{tab-item} Markdown
 ````md
 ```{code-block} python
-:caption: python.py
+:caption: `python.py`
 :linenos:
 
 print("A code block with a caption and line numbers.")
@@ -116,7 +116,7 @@ print("A code block with a caption and line numbers.")
 results in:
 
 ```{code-block} python
-:caption: python.py
+:caption: `python.py`
 :linenos:
 
 print("A code block with a caption and line numbers.")

--- a/tests/sites/version_switcher/fixture_blocks.rst
+++ b/tests/sites/version_switcher/fixture_blocks.rst
@@ -174,7 +174,7 @@ https://docutils.sourceforge.io/docs/ref/rst/directives.html#parsed-literal-bloc
 .. parsed-literal::
 
     # parsed-literal test
-    curl -O http://someurl/release-0.1.0.tar-gz
+    curl -O https://someurl/release-0.1.0.tar-gz
     echo "This is an intentionally very long line because I want to make sure that we are handling scrollable code blocks correctly."
 
 Code Block


### PR DESCRIPTION
Ignore Sass urls,
Do not allow http:, only https: even in examples.
removed unused URLs