### PR TITLE
Add BrainGlobe and movement to gallery of sites using the theme

### DIFF
--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -56,6 +56,9 @@ Thanks for your support!
 - title: MegEngine
   link-alt: MegEngine docs
   link: https://www.megengine.org.cn/doc/stable/en/index.html
+- title: movement
+  link-alt: movement docs
+  link: https://movement.neuroinformatics.dev
 - title: Pastas
   link-alt: Pastas docs
   link: https://pastas.readthedocs.io/


### PR DESCRIPTION
Thanks for creating such an awesome theme!

I'm a research software engineer at the [Neuroinformatics Unit](https://neuroinformatics.dev). We build and maintain many scientific Python packages, and we use the pydata-sphinx-theme for all of them.

I've added the docs websites for two of our most popular projects—[BrainGlobe](https://brainglobe.info) and [movement](https://movement.neuroinformatics.dev)—to the `docs/examples/gallery.md` file, adhering to the alphabetical order.

Let me know in case you want me to make any changes, or if you don't wish to expand the gallery for whatever reason.

As far as I can tell, the `pre-commit` failures are unrelated to this PR (please correct me if I'm wrong).