### PR TITLE
feat: add dismiss button to announcement banner

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
@@ -37,6 +37,13 @@
   // Ensure there is enough contrast against the background
   a {
     color: var(--pst-color-link-higher-contrast);
+
+    &:hover {
+      // applying the same style as the SD "buttons"
+      @include link-style-hover;
+
+      cursor: pointer;
+    }
   }
 
   // The "Switch to stable version" link (styled like a button)


### PR DESCRIPTION
Addresses https://github.com/pydata/pydata-sphinx-theme/issues/1384

Using essentially the same approach as was used for the version warning banner in #1763 

Some questions for the announcement banner compared to the versions:

- Do we also want to only remember it for 14 days, or just forever for a certain announcement?
- Ideally the stored dismiss state takes into account the content of the announcement, so that when you add a new announcement, all users see it?
- I am assuming that for a general announcement banner, we do _not_ want this to be version specific (i.e. remember it separately per version)

Note: I only tested it with a remote announcement that gets injected, not yet with a local snippet.