### PR TITLE
fix: default to cookieless pings for Google Analytics

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -119,6 +119,12 @@ def update_config(app):
             gid_script = f"""
                 window.dataLayer = window.dataLayer || [];
                 function gtag(){{ dataLayer.push(arguments); }}
+                gtag('consent', 'default', {{
+                    'ad_storage': 'denied',
+                    'ad_user_data': 'denied',
+                    'ad_personalization': 'denied',
+                    'analytics_storage': 'denied'
+                }});
                 gtag('js', new Date());
                 gtag('config', '{gid}');
             """

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -740,6 +740,13 @@ def test_analytics(sphinx_build_factory, provider, tags) -> None:
     tags_found = False
     for script in index_html.select("script"):
         if script.string and tags[0] in script.string and tags[1] in script.string:
+            # If the tag is found, make sure the consent mode is also there
+            if tags[0] == "gtag":
+                assert "gtag('consent', 'default', {" in script.string
+                assert "'ad_storage': 'denied'," in script.string
+                assert "'ad_user_data': 'denied'," in script.string
+                assert "'ad_personalization': 'denied'," in script.string
+                assert "'analytics_storage': 'denied'" in script.string
             tags_found = True
     assert tags_found is True
 


### PR DESCRIPTION
Follows the steps at https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#gtag.js_1 to disable browser storage for tracking. Per https://support.google.com/analytics/answer/13802165?hl=en

> When analytics_storage='denied', cookieless pings are sent to Google Analytics. No Analytics cookies are set, accessed, or read from the device. Consequently, cookieless pings are anonymized and non-identifiable Google Analytics events.

In my opinion, most folks probably don't need the more detailed tracking, but if that's not the case, a follow-up PR could add a banner that does the gtag update command to opt-in to more detailed tracking.

Closes #2288 