### PR TITLE
bump CI pins (python, stylelint)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,7 +79,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pandoc: true
 
-      - name: "Run tests ✅"
+      - name: "Run tests"
         shell: bash
         run: |
           # this will compile the assets and translations then run the tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -79,6 +79,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           pandoc: true
 
+      - name: "Cache Playwright browsers 🎭"
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~\AppData\Local\ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
+
       - name: "Run tests"
         shell: bash
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,12 +44,12 @@ jobs:
         # ubuntu-24.04==latest
         # windows-2022==latest
         os: ["ubuntu-latest", "ubuntu-22.04", "macos-14", "windows-latest"]
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.14"]
         sphinx-version: [""]
         include:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
             sphinx-version: "6.1"
             # newest Python version with the newest Sphinx version
           - os: ubuntu-latest
@@ -57,12 +57,12 @@ jobs:
             # Sphinx HEAD
             sphinx-version: "dev"
         exclude:
-          # Python 3.9 is not supported on macOS 14 - https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+          # Python 3.10 is not supported on arm64 darwin - https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
           - os: macos-14
-            python-version: "3.9"
+            python-version: "3.10"
           # do not need all the tests so will limit to the latest versions of Python
           - os: ubuntu-24.04
-            python-version: "3.9"
+            python-version: "3.10"
           - os: ubuntu-24.04
             python-version: "3.10"
     runs-on: ${{ matrix.os }}
@@ -84,11 +84,11 @@ jobs:
         run: |
           # this will compile the assets and translations then run the tests
           # check if there is a specific Sphinx version to test with
-          # example substitution: tox run -e compile-assets,i18n-compile,py39-sphinx61-tests
+          # example substitution: tox run -e compile-assets,i18n-compile,py310-sphinx61-tests
           if [ -n "${{matrix.sphinx-version}}" ]; then
             python -Im tox run -e compile-assets,i18n-compile,py$(echo ${{ matrix.python-version }} | tr -d .)-sphinx$(echo ${{ matrix.sphinx-version }} | tr -d .)-tests
           # if not we use the default version
-          # example substitution: tox run -e compile-assets,i18n-compile,py39-tests
+          # example substitution: tox run -e compile-assets,i18n-compile,py310-tests
           else
             python -Im tox run -e compile-assets,i18n-compile,py$(echo ${{ matrix.python-version }} | tr -d .)-tests
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
             python-version: "3.10"
-            sphinx-version: "6.1"
+            sphinx-version: "7.0"
             # newest Python version with the newest Sphinx version
           - os: ubuntu-latest
             python-version: "3.14"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1" # Make tools pretty
-  DEFAULT_PYTHON_VERSION: "3.12" # keep in sync with tox.ini
+  DEFAULT_PYTHON_VERSION: "3.14" # keep in sync with tox.ini
   PIP_DISABLE_PIP_VERSION_CHECK: "1" # Don't check for pip updates
 
 permissions: {}
@@ -53,7 +53,7 @@ jobs:
             sphinx-version: "6.1"
             # newest Python version with the newest Sphinx version
           - os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.14"
             # Sphinx HEAD
             sphinx-version: "dev"
         exclude:
@@ -94,7 +94,7 @@ jobs:
           fi
 
       - name: "Upload coverage data to GH artifacts 📤"
-        if: matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest' && matrix.sphinx-version == 'dev'
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest' && matrix.sphinx-version == 'dev'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: coverage-data-${{ matrix.python-version }}
@@ -183,12 +183,12 @@ jobs:
       - name: "Setup CI environment 🛠"
         uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@469e90895696e21b765121e952d84ea82c71410c
         with:
-          # 3.12 is not supported by py-spy yet
-          python-version: "3.11"
+          # 3.14 is not supported by py-spy yet
+          python-version: "3.13"
 
       - name: "Run profiling with py-spy 🕵️‍♂️"
         # profiling needs to be run as sudo
-        run: python -m tox run -e py311-profile-docs -- -o docbuild_profile.svg
+        run: python -m tox run -e py313-profile-docs -- -o docbuild_profile.svg
         continue-on-error: true
 
       - name: "Upload profiling data to GH artifacts 📤"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -21,6 +21,9 @@ env:
 permissions: {}
 
 on:
+  pull_request:
+    branches:
+      - "*"
   # workflow_run:
   #   workflows: [continuous-integration]
   #   types: [completed]

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: "Run accessibility tests with playwright 🎭"
         # build PST, build docs, then run a11y-tests
-        run: python -Im tox run -e a11y-tests-${{ matrix.browser }}
+        run: python -Im tox run -e compile-assets,i18n-compile,py314-docs,a11y-tests-${{ matrix.browser }}
 
       - name: "Upload Playwright traces, if any 🐾"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: "Run accessibility tests with playwright 🎭"
         # build PST, build docs, then run a11y-tests
-        run: python -Im tox run -e compile-assets,i18n-compile,py312-docs,a11y-tests-${{ matrix.browser }}
+        run: python -Im tox run -e a11y-tests-${{ matrix.browser }}
 
       - name: "Upload Playwright traces, if any 🐾"
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -15,7 +15,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1" # Make tools pretty
-  DEFAULT_PYTHON_VERSION: "3.12" # keep in sync with tox.ini
+  DEFAULT_PYTHON_VERSION: "3.14" # keep in sync with tox.ini
   PIP_DISABLE_PIP_VERSION_CHECK: "1" # Don't check for pip updates
 
 permissions: {}

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -21,12 +21,9 @@ env:
 permissions: {}
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - "*"
+  workflow_run:
+    workflows: [continuous-integration]
+    types: [completed]
   # allows this to be used as a composite action in other workflows
   workflow_call:
   # allow manual triggering of the workflow, while debugging

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -21,9 +21,9 @@ env:
 permissions: {}
 
 on:
-  workflow_run:
-    workflows: [continuous-integration]
-    types: [completed]
+  # workflow_run:
+  #   workflows: [continuous-integration]
+  #   types: [completed]
   # allows this to be used as a composite action in other workflows
   workflow_call:
   # allow manual triggering of the workflow, while debugging

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
             python-version: "3.10"
-            sphinx-version: "6.1" # sphinx 6.1 requires python >=3.8
+            sphinx-version: "7.0"
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository 🛎"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   FORCE_COLOR: "1" # Make tools pretty
-  DEFAULT_PYTHON_VERSION: "3.12" # keep in sync with tox.ini
+  DEFAULT_PYTHON_VERSION: "3.14" # keep in sync with tox.ini
   PIP_DISABLE_PIP_VERSION_CHECK: "1" # Don't check for pip updates
 
 # disable all permissions by default

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,12 +46,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.14"]
         include:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
-            python-version: "3.9"
-            sphinx-version: "6.1"
+            python-version: "3.10"
+            sphinx-version: "6.1" # sphinx 6.1 requires python >=3.8
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository 🛎"
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: |
           # check if there is a specific Sphinx version to build with
-          # example substitution: tox run -e py39-sphinx61-docs
+          # example substitution: tox run -e py310-sphinx61-docs
           if [ -n "${{matrix.sphinx-version}}" ]; then
             python -Im tox run -e py$(echo ${{ matrix.python-version }} | tr -d .)-sphinx$(echo ${{ matrix.sphinx-version }} | tr -d .)-docs
           # build with the default Sphinx version

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.13"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - name: "Checkout repository 🛎"
@@ -53,17 +53,17 @@ jobs:
 
       - name: "Build and inspect package 📦"
         uses: hynek/build-and-inspect-python-package@c52c3a4710070b50470d903818a7b25115dcd076 # 2.13.0
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         id: baipp
 
       - run: echo Packages can be found at "${BAIPP_DIST}"
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
 
       # Run tests on the built package (which will be later uploaded to PyPI)
       - name: "Install PST from wheel and test"
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "Setup Python 🐍"
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # 5.6.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - run: python -Im pip install tox-uv
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,6 +1,10 @@
 # Performs static analysis in GitHub actions with https://github.com/woodruffw/zizmor
 name: Zizmor
 
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/examples/generated/
-docs/api/
 warnings.txt
 
 # PyBuilder

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,15 +56,15 @@ repos:
       - id: remove-metadata
 
   - repo: "https://github.com/thibaudcolas/pre-commit-stylelint"
-    rev: v16.25.0
+    rev: v16.26.1
     hooks:
       - id: stylelint
         # automatically fix .scss files where possible
         args: [--fix]
         additional_dependencies:
           # stylelint itself needs to be here when using additional_dependencies.
-          - stylelint@16.5.0
-          - stylelint-config-standard-scss@13.1.0
+          - stylelint@16.26.1
+          - stylelint-config-standard-scss@16.0.0
 
   - repo: "https://github.com/pre-commit/pre-commit-hooks"
     rev: v6.0.0

--- a/docs/_static/gallery.yaml
+++ b/docs/_static/gallery.yaml
@@ -23,7 +23,7 @@
   img-bottom: ../_static/gallery/jupyter.png
 - title: Jupyter Book
   link-alt: Jupyter Book docs
-  link: https://jupyterbook.org/en/stable/intro.html
+  link: https://jupyterbook.org/v1/intro.html
   img-bottom: ../_static/gallery/jupyter_book.png
 - title: Matplotlib
   link-alt: Matplotlib docs

--- a/docs/community/topics/manual-dev.md
+++ b/docs/community/topics/manual-dev.md
@@ -17,7 +17,7 @@ To do so, use a tool like [conda](https://docs.conda.io/en/latest/), [mamba](htt
 
 Before you start, ensure that you have the following installed:
 
-- Python >= 3.9
+- Python >= 3.10
 - [Pandoc](https://pandoc.org/): we use `nbsphinx` to support notebook (`.ipynb`) files in the documentation, which requires [installing Pandoc](https://pandoc.org/installing.html) at a system level (or within a Conda environment).
 
 ## Clone the repository locally

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,7 +290,11 @@ autodoc_member_order = "groupwise"
 
 # -- Options for autoapi -------------------------------------------------------
 autoapi_type = "python"
-autoapi_dirs = [str(Path(__file__).parent.parent / "src" / "pydata_sphinx_theme")]
+# Use absolute path to ensure AutoAPI can find the source code in all environments
+_autoapi_source = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "src", "pydata_sphinx_theme")
+)
+autoapi_dirs = [_autoapi_source]
 autoapi_keep_files = True
 autoapi_root = "api"
 autoapi_member_order = "groupwise"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,8 @@ author = "PyData Community"
 # -- General configuration ---------------------------------------------------
 
 extensions = [
+    # AutoAPI must run early to generate API files before other extensions
+    "autoapi.extension",
     "sphinx.ext.napoleon",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
@@ -39,7 +41,6 @@ extensions = [
     "sphinxext.rediraffe",
     "sphinx_design",
     "sphinx_copybutton",
-    "autoapi.extension",
     # custom extentions
     "_extension.gallery_directive",
     "_extension.component_directive",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,11 +321,6 @@ nitpick_ignore_regex = [
     ("token", r"(suite|expression|target)"),
 ]
 
-# Suppress autosummary warnings for external urllib.parse documentation
-suppress_warnings = [
-    "autosummary.stub_file_not_found",  # silence urllib.parse autosummary stub warnings
-]
-
 # -- application setup -------------------------------------------------------
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,6 +316,11 @@ nitpick_ignore_regex = [
     ("token", r"(suite|expression|target)"),
 ]
 
+# Suppress autosummary warnings for external urllib.parse documentation
+suppress_warnings = [
+    "autosummary.stub_file_not_found",  # silence urllib.parse autosummary stub warnings
+]
+
 # -- application setup -------------------------------------------------------
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -290,7 +290,7 @@ autodoc_member_order = "groupwise"
 
 # -- Options for autoapi -------------------------------------------------------
 autoapi_type = "python"
-autoapi_dirs = ["../src/pydata_sphinx_theme"]
+autoapi_dirs = [str(Path(__file__).parent.parent / "src" / "pydata_sphinx_theme")]
 autoapi_keep_files = True
 autoapi_root = "api"
 autoapi_member_order = "groupwise"

--- a/docs/examples/gallery.md
+++ b/docs/examples/gallery.md
@@ -53,9 +53,6 @@ Thanks for your support!
 - title: itom measurement and simulation software
   link-alt: itom documentation
   link: https://itom-project.github.io/latest/docs/index.html
-- title: MegEngine
-  link-alt: MegEngine docs
-  link: https://www.megengine.org.cn/doc/stable/en/index.html
 - title: movement
   link-alt: movement docs
   link: https://movement.neuroinformatics.dev

--- a/docs/user_guide/accessibility.md
+++ b/docs/user_guide/accessibility.md
@@ -139,7 +139,7 @@ There are also a few browser extensions that some of the maintainers of this
 theme use when working to make websites more accessible. Some of these include:
 
 - [Accessibility Insights for Web](https://accessibilityinsights.io/docs/web/overview/)
-- [Axe DevTools](https://www.deque.com/axe/browser-extensions/)
+- [Axe DevTools](https://www.deque.com/axe/devtools/extension/)
 - [WAVE](https://wave.webaim.org/extension/)
 
 We have also found [Polypane](https://polypane.app/) to be a great tool (but it

--- a/docs/user_guide/styling.rst
+++ b/docs/user_guide/styling.rst
@@ -3,7 +3,7 @@ Theme variables and CSS
 =======================
 
 .. _pydata-css-variables: https://github.com/pydata/pydata-sphinx-theme/tree/main/src/pydata_sphinx_theme/assets/styles/variables
-.. _css-variable-help: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascading_variables/Using_CSS_custom_properties
+.. _css-variable-help: https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Cascading_variables/Using_custom_properties
 
 This section covers a few ways that you can control the look and feel of your theme via your own CSS and theme variables.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "sphinx-theme-builder @ git+https://github.com/pradyunsg/sphinx-theme-builder.git@main"
+  "sphinx-theme-builder>=0.3.2"
 ]
 build-backend = "sphinx_theme_builder"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ ignore = "H006,J018,T003,H025"
 
 [tool.pytest.ini_options]
 markers = "a11y: mark a test as an accessibility test"
+addopts = "--durations=10"
 
 [tool.coverage.run]
 source = ["pydata_sphinx_theme"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,14 +53,14 @@ classifiers = [
 
 [project.optional-dependencies]
 doc = [
-  "astroid>=3", # fix for sphinx.autoapi and read the docs, should be reverted at a later date - see issue #2125
+  "astroid>=3,!=4.0.3", # fix for sphinx.autoapi and read the docs, should be reverted at a later date - see issue #2125
   "numpydoc",
   "linkify-it-py", # for link shortening
   "rich",
   "sphinxext-rediraffe",
   # TODO: unpin sphinx-sitemap once a solution is offered for https://github.com/jdillard/sphinx-sitemap/issues/109
   "sphinx-sitemap<2.7.0",
-  "sphinx-autoapi>=3.0.0",
+  "sphinx-autoapi==3.6.1",
   # For examples section
   "myst-parser",
   "ablog>=0.11.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "pydata-sphinx-theme"
 description = "Bootstrap-based Sphinx theme from the PyData community"
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
   "sphinx>=6.1",
   "beautifulsoup4",
@@ -37,10 +37,11 @@ maintainers = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Framework :: Sphinx",
   "Framework :: Sphinx :: Theme",
   "License :: OSI Approved :: BSD License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "sphinx>=6.1",
+  "sphinx>=7.0",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "Babel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "sphinx>=7.0",
+  "sphinx>=7.0,<9",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "Babel",

--- a/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
+++ b/src/pydata_sphinx_theme/assets/styles/abstracts/_links.scss
@@ -67,7 +67,7 @@ $link-hover-decoration-thickness: string.unquote(
 // TODO: @trallard to improve focus styles in subsequent PR
 @mixin link-style-default {
   // So that really long links don't spill out of their container
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   color: var(--pst-color-link);
 
   @include link-decoration;

--- a/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_versionmodified.scss
@@ -8,7 +8,6 @@ div.versionremoved {
   overflow: hidden;
 
   /* break-inside has replaced page-break-inside and is widely usable since 2019 */
-  page-break-inside: avoid;
   break-inside: avoid;
   border-left: 0.2rem solid;
   border-color: var(--pst-color-info);

--- a/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_admonitions.scss
@@ -12,7 +12,6 @@ div.admonition,
   overflow: hidden;
 
   /* break-inside has replaced page-break-inside and is widely usable since 2019 */
-  page-break-inside: avoid;
   break-inside: avoid;
   border-left: $admonition-left-border-width solid;
   border-color: var(--pst-color-info);

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -279,18 +279,16 @@ $pst-semantic-colors: (
   }
 
   // assign the "duplicate" colors (ones that just reference other variables)
-  & {
-    // From 0.16.1, the preferred variable for headings is --pst-color-heading
-    // if you have --pst-heading-color, this variable will be used, otherwise the default
-    // --pst-color-heading will be used
-    --pst-color-heading: var(--pst-color-text-base);
-    --pst-color-link: var(--pst-color-primary);
-    --pst-color-link-hover: var(--pst-color-secondary);
-    --pst-color-table-outer-border: var(--pst-color-surface);
-    --pst-color-table-heading-bg: var(--pst-color-surface);
-    --pst-color-table-row-zebra-high-bg: var(--pst-color-on-background);
-    --pst-color-table-row-zebra-low-bg: var(--pst-color-surface);
-  }
+  // From 0.16.1, the preferred variable for headings is --pst-color-heading
+  // if you have --pst-heading-color, this variable will be used, otherwise the default
+  // --pst-color-heading will be used
+  --pst-color-heading: var(--pst-color-text-base);
+  --pst-color-link: var(--pst-color-primary);
+  --pst-color-link-hover: var(--pst-color-secondary);
+  --pst-color-table-outer-border: var(--pst-color-surface);
+  --pst-color-table-heading-bg: var(--pst-color-surface);
+  --pst-color-table-row-zebra-high-bg: var(--pst-color-on-background);
+  --pst-color-table-row-zebra-low-bg: var(--pst-color-surface);
 
   // adapt to light/dark-specific content
   @if $mode == "light" {

--- a/tests/warning_list.txt
+++ b/tests/warning_list.txt
@@ -1,13 +1,1 @@
-WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.count'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.index'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.DefragResultBytes.count'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.DefragResultBytes.index'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.ParseResult.count'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.ParseResult.index'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.ParseResultBytes.count'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.ParseResultBytes.index'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.SplitResult.count'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.SplitResult.index'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.SplitResultBytes.count'. Check your autosummary_generate setting.
-WARNING: autosummary: stub file not found 'urllib.parse.SplitResultBytes.index'. Check your autosummary_generate setting.
 ERROR: Unexpected indentation.

--- a/tests/warning_list.txt
+++ b/tests/warning_list.txt
@@ -1,1 +1,13 @@
+WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.count'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.DefragResult.index'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.DefragResultBytes.count'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.DefragResultBytes.index'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.ParseResult.count'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.ParseResult.index'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.ParseResultBytes.count'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.ParseResultBytes.index'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.SplitResult.count'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.SplitResult.index'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.SplitResultBytes.count'. Check your autosummary_generate setting.
+WARNING: autosummary: stub file not found 'urllib.parse.SplitResultBytes.index'. Check your autosummary_generate setting.
 ERROR: Unexpected indentation.

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ commands =
     bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
     bash -c 'test -d docs/_build/html/ && echo "--- Directory exists ---" || exit -1'
     a11y-tests{,-chromium}: pytest -m "a11y" --maxfail=1 --browser=chromium {posargs:--tracing=retain-on-failure}
-    a11y-tests-firefox: pytest -m --maxfail=5 "a11y" --browser=firefox {posargs:--tracing=retain-on-failure}
+    a11y-tests-firefox: pytest -m "a11y" --maxfail=5 --browser=firefox {posargs:--tracing=retain-on-failure}
 
 # build PST documentation with the default or a specific Sphinx version
 # since we are building the documentation we install the packaged dev version of PST

--- a/tox.ini
+++ b/tox.ini
@@ -150,6 +150,7 @@ depends =
     compile-assets,
     i18n-compile
 commands =
+    pip freeze
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt {posargs}
     python tests/utils/check_warnings.py
 

--- a/tox.ini
+++ b/tox.ini
@@ -115,9 +115,25 @@ set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 extras = {[testenv:docs-no-checks]extras}
 deps =
     py310-sphinx70-docs: sphinx~=7.0.0
+depends =
+    compile-assets,
+    i18n-compile
 commands =
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt
     python tests/utils/check_warnings.py
+
+# build the docs without checking for warnings
+# tox run -e docs-no-checks
+[testenv:docs-no-checks]
+description = "Build documentation without checking for warnings"
+extras = doc
+package = editable
+set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
+depends =
+    compile-assets,
+    i18n-compile
+commands =
+    sphinx-build {posargs:audit}/site {posargs:audit}/_build
 
 # recommended for local development, this command will build the PST documentation
 # with the default Sphinx version and the PST installed in editable mode
@@ -129,6 +145,9 @@ set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 # keep this in sync across all docs environments
 extras = {[testenv:docs-no-checks]extras}
 package = editable
+depends =
+    compile-assets,
+    i18n-compile
 commands =
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt {posargs}
     python tests/utils/check_warnings.py
@@ -147,6 +166,9 @@ deps =
     sphinx-theme-builder[cli] @ git+https://github.com/pradyunsg/sphinx-theme-builder.git@main
 # suppress Py3.11's new "can't debug frozen modules" warning
 set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
+depends =
+    compile-assets,
+    i18n-compile
 commands =
     docs-live-theme: stb serve docs --open-browser --re-ignore=locale|api|_build|\.jupyterlite\.doit\.db
     docs-live: sphinx-autobuild docs/ docs/_build/html --open-browser --re-ignore=locale|api|_build|\.jupyterlite\.doit\.db
@@ -155,9 +177,14 @@ commands =
 # tox run -e docs-linkcheck
 [testenv:docs-linkcheck]
 description = "Check external links in the documentation"
-extras = {[testenv:docs-no-checks]extras}
+extras = doc
 allowlist_externals = bash
 basepython = py314
+package = editable
+set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
+depends =
+    compile-assets,
+    i18n-compile
 commands =
     sphinx-build -b linkcheck docs/ docs/_build/linkcheck -w warnings.txt --keep-going -q
     bash -c "echo 'Linkcheck complete; see docs/_build/linkcheck/output.txt for any errors'"

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ allowlist_externals=
     playwright
     bash
 commands =
-    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps --quiet; else playwright install --quiet; fi'
+    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
     py3{10,11,12,13,14}{,-sphinx70,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
     py3{10,11,12,13,14}{,-sphinx70,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
 
@@ -99,7 +99,7 @@ allowlist_externals=
     playwright
     bash
 commands =
-    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps --quiet; else playwright install --quiet; fi'
+    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
     a11y-tests{,-chromium}: pytest -m "a11y" --browser=chromium {posargs:--tracing=retain-on-failure}
     a11y-tests-firefox: pytest -m "a11y" --browser=firefox {posargs:--tracing=retain-on-failure}
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,11 +53,11 @@ commands =
 # the tests without `compile-assets,i18n-compile`, for example:
 # tox run -e py310-tests
 # run tests with a specific Sphinx version
-# tox run -e compile-assets,i18n-compile,py310-sphinx61-tests
+# tox run -e compile-assets,i18n-compile,py310-sphinx70-tests
 # run tests without coverage
 # tox run -e compile-assets,i18n-compile,py310-tests-no-cov
 # by default we will retain playwright traces on failure
-[testenv:py3{10,11,12,13,14}{,-sphinx61,-sphinxdev,}-tests{,-no-cov}]
+[testenv:py3{10,11,12,13,14}{,-sphinx70,-sphinxdev,}-tests{,-no-cov}]
 description = "Run tests Python and Sphinx versions. If a Sphinx version is specified, it will use that version vs the default in pyproject.toml"
 # need to ensure the package is installed in editable mode
 package = editable
@@ -66,7 +66,7 @@ extras =
 pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 deps =
     coverage[toml]
-    py310-sphinx61-tests: sphinx~=6.1.0
+    py310-sphinx70-tests: sphinx~=7.0.0
     py314-sphinxdev: sphinx[test] @ git+https://github.com/sphinx-doc/sphinx.git@master
 depends =
     compile-assets,
@@ -76,8 +76,8 @@ allowlist_externals=
     bash
 commands =
     bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
-    py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
-    py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{9,10,11,12}{,-sphinx70,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{9,10,11,12}{,-sphinx70,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
 
 # run accessibility tests with Playwright and axe-core
 # compiling the assets is needed before running the tests
@@ -106,15 +106,15 @@ commands =
 # build PST documentation with the default or a specific Sphinx version
 # since we are building the documentation we install the packaged dev version of PST
 # tox run -e py310-docs
-# tox run -e py310-sphinx61-docs
-[testenv:py3{10,14}{,-sphinx61}-docs]
+# tox run -e py310-sphinx70-docs
+[testenv:py3{10,14}{,-sphinx70}-docs]
 description = build the documentation and place in docs/_build/html
 # suppress Py3.11's new "can't debug frozen modules" warning
 set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 # keep this in sync across all docs environments
 extras = {[testenv:docs-no-checks]extras}
 deps =
-    py310-sphinx61-docs: sphinx~=6.1.0
+    py310-sphinx70-docs: sphinx~=7.0.0
 commands =
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt
     python tests/utils/check_warnings.py

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ allowlist_externals=
     playwright
     bash
 commands =
-    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
+    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps --quiet; else playwright install --quiet; fi'
     py3{10,11,12,13,14}{,-sphinx70,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
     py3{10,11,12,13,14}{,-sphinx70,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
 
@@ -99,7 +99,7 @@ allowlist_externals=
     playwright
     bash
 commands =
-    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
+    bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps --quiet; else playwright install --quiet; fi'
     a11y-tests{,-chromium}: pytest -m "a11y" --browser=chromium {posargs:--tracing=retain-on-failure}
     a11y-tests-firefox: pytest -m "a11y" --browser=firefox {posargs:--tracing=retain-on-failure}
 

--- a/tox.ini
+++ b/tox.ini
@@ -76,8 +76,8 @@ allowlist_externals=
     bash
 commands =
     bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
-    py3{9,10,11,12}{,-sphinx70,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
-    py3{9,10,11,12}{,-sphinx70,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{10,11,12,13,14}{,-sphinx70,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{10,11,12,13,14}{,-sphinx70,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
 
 # run accessibility tests with Playwright and axe-core
 # compiling the assets is needed before running the tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 min_version = 4
 # list of environments to run by default with tox run
-# using Python 3.12 as the default, this needs to be kept in line with
+# using Python 3.14 as the default, this needs to be kept in line with
 # .github/actions/set-dev-env/action.yml (default Python version)
 env_list =
     lint,
@@ -57,7 +57,7 @@ commands =
 # run tests without coverage
 # tox run -e compile-assets,i18n-compile,py310-tests-no-cov
 # by default we will retain playwright traces on failure
-[testenv:py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests{,-no-cov}]
+[testenv:py3{10,11,12,13,14}{,-sphinx61,-sphinxdev,}-tests{,-no-cov}]
 description = "Run tests Python and Sphinx versions. If a Sphinx version is specified, it will use that version vs the default in pyproject.toml"
 # need to ensure the package is installed in editable mode
 package = editable

--- a/tox.ini
+++ b/tox.ini
@@ -100,8 +100,9 @@ allowlist_externals=
     bash
 commands =
     bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
-    a11y-tests{,-chromium}: pytest -m "a11y" --browser=chromium {posargs:--tracing=retain-on-failure}
-    a11y-tests-firefox: pytest -m "a11y" --browser=firefox {posargs:--tracing=retain-on-failure}
+    bash -c 'test -d docs/_build/html/ && echo "--- Directory exists ---" || exit -1'
+    a11y-tests{,-chromium}: pytest -m "a11y" --maxfail=1 --browser=chromium {posargs:--tracing=retain-on-failure}
+    a11y-tests-firefox: pytest -m --maxfail=5 "a11y" --browser=firefox {posargs:--tracing=retain-on-failure}
 
 # build PST documentation with the default or a specific Sphinx version
 # since we are building the documentation we install the packaged dev version of PST

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,7 @@ depends =
     i18n-compile
 commands =
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt
+    sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt
     python tests/utils/check_warnings.py
 
 # build the docs without checking for warnings

--- a/tox.ini
+++ b/tox.ini
@@ -115,6 +115,7 @@ set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 extras = {[testenv:docs-no-checks]extras}
 deps =
     py310-sphinx70-docs: sphinx~=7.0.0
+    py310-sphinx70-docs: astroid>=3.0
 depends =
     compile-assets,
     i18n-compile

--- a/tox.ini
+++ b/tox.ini
@@ -7,22 +7,22 @@ env_list =
     lint,
     compile-assets,
     i18n-compile,
-    py312-docs,
-    py312-tests,
+    py314-docs,
+    py314-tests,
     a11y-tests
 
 # convenience label for running tests with a given Python version, aimed at
 # helping contributors run common tasks without needing to call all the steps
 # For example to run the tests: tox run -m tests
 labels =
-    tests = compile-assets, i18n-compile, py312-tests
-    a11y = compile-assets, i18n-compile, py312-docs, a11y-tests
+    tests = compile-assets, i18n-compile, py314-tests
+    a11y = compile-assets, i18n-compile, py314-docs, a11y-tests
     i18n = i18n-extract, i18n-compile
     live-server = compile-assets, i18n-compile, docs-live
 
 # general tox env configuration
-# these can be run with any py3{9,12} version, for example:
-# tox run -e py39-lint
+# these can be run with any py3{10,14} version, for example:
+# tox run -e py310-lint
 [testenv]
 deps =
     lint: pre-commit
@@ -41,21 +41,21 @@ commands =
     # can substitute the target directory with any other directory by calling:
     # tox run -e docs-no-checks -- path/to/other/directory
     docs-no-checks: sphinx-build {posargs:audit}/site {posargs:audit}/_build
-    # example tox run -e py39-profile-docs -- -o profile.svg -n 100
+    # example tox run -e py310-profile-docs -- -o profile.svg -n 100
     profile-docs: python ./tools/profile.py {posargs}
 
 # tests can be ran with or without coverage (see examples below),
 # it is recommended to run compile-assets before running tests
 # i18n-compile MUST be run before running tests
 # (see examples below),
-# tox run -e compile-assets,i18n-compile,py39-tests
+# tox run -e compile-assets,i18n-compile,py310-tests
 # if you want to skip the assets and translations compilation step you can run
 # the tests without `compile-assets,i18n-compile`, for example:
-# tox run -e py39-tests
+# tox run -e py310-tests
 # run tests with a specific Sphinx version
-# tox run -e compile-assets,i18n-compile,py39-sphinx61-tests
+# tox run -e compile-assets,i18n-compile,py310-sphinx61-tests
 # run tests without coverage
-# tox run -e compile-assets,i18n-compile,py39-tests-no-cov
+# tox run -e compile-assets,i18n-compile,py310-tests-no-cov
 # by default we will retain playwright traces on failure
 [testenv:py3{9,10,11,12}{,-sphinx61,-sphinxdev,}-tests{,-no-cov}]
 description = "Run tests Python and Sphinx versions. If a Sphinx version is specified, it will use that version vs the default in pyproject.toml"
@@ -66,8 +66,8 @@ extras =
 pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 deps =
     coverage[toml]
-    py39-sphinx61-tests: sphinx~=6.1.0
-    py312-sphinxdev: sphinx[test] @ git+https://github.com/sphinx-doc/sphinx.git@master
+    py310-sphinx61-tests: sphinx~=6.1.0
+    py314-sphinxdev: sphinx[test] @ git+https://github.com/sphinx-doc/sphinx.git@master
 depends =
     compile-assets,
     i18n-compile
@@ -81,20 +81,20 @@ commands =
 
 # run accessibility tests with Playwright and axe-core
 # compiling the assets is needed before running the tests
-# tox run -e compile,py312-docs,a11y-tests
+# tox run -e compile,py314-docs,a11y-tests
 # by default we will retain playwright traces on failure and run the tests on chromium
 # to run the tests on firefox you can call:
-# tox run -e compile,py312-docs,a11y-tests-firefox
+# tox run -e compile,py314-docs,a11y-tests-firefox
 [testenv:a11y-tests{-chromium,-firefox}]
 description = "run accessibility tests with Playwright and axe-core"
-base_python = py312 # keep in sync with tests.yml
+base_python = py314 # keep in sync with tests.yml
 pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 extras =
     test # install dependencies, includes pytest-playwright - defined in pyproject.toml
 depends =
     compile-assets,
     i18n-compile
-    py312-docs
+    py314-docs
 allowlist_externals=
     playwright
     bash
@@ -105,16 +105,16 @@ commands =
 
 # build PST documentation with the default or a specific Sphinx version
 # since we are building the documentation we install the packaged dev version of PST
-# tox run -e py39-docs
-# tox run -e py39-sphinx61-docs
-[testenv:py3{9,12,13}{,-sphinx61}-docs]
+# tox run -e py310-docs
+# tox run -e py310-sphinx61-docs
+[testenv:py3{10,14}{,-sphinx61}-docs]
 description = build the documentation and place in docs/_build/html
 # suppress Py3.11's new "can't debug frozen modules" warning
 set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 # keep this in sync across all docs environments
 extras = {[testenv:docs-no-checks]extras}
 deps =
-    py39-sphinx61-docs: sphinx~=6.1.0
+    py310-sphinx61-docs: sphinx~=6.1.0
 commands =
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt
     python tests/utils/check_warnings.py
@@ -157,7 +157,7 @@ commands =
 description = "Check external links in the documentation"
 extras = {[testenv:docs-no-checks]extras}
 allowlist_externals = bash
-basepython = py313
+basepython = py314
 commands =
     sphinx-build -b linkcheck docs/ docs/_build/linkcheck -w warnings.txt --keep-going -q
     bash -c "echo 'Linkcheck complete; see docs/_build/linkcheck/output.txt for any errors'"

--- a/tox.ini
+++ b/tox.ini
@@ -164,7 +164,7 @@ extras =
     dev
 package = editable
 deps =
-    sphinx-theme-builder[cli] @ git+https://github.com/pradyunsg/sphinx-theme-builder.git@main
+    sphinx-theme-builder[cli]
 # suppress Py3.11's new "can't debug frozen modules" warning
 set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 depends =

--- a/tox.ini
+++ b/tox.ini
@@ -115,12 +115,11 @@ set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 extras = {[testenv:docs-no-checks]extras}
 deps =
     py310-sphinx70-docs: sphinx~=7.0.0
-    py310-sphinx70-docs: astroid>=3.0
+    py310-sphinx70-docs: astroid>=3.0,!=4.0.3
 depends =
     compile-assets,
     i18n-compile
 commands =
-    sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt
     python tests/utils/check_warnings.py
 
@@ -151,7 +150,6 @@ depends =
     compile-assets,
     i18n-compile
 commands =
-    pip freeze
     sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt {posargs}
     python tests/utils/check_warnings.py
 


### PR DESCRIPTION
New minimum Python version is 3.10. Also attempts to fix the pre-commit stylelint errors seen on #2289 (https://results.pre-commit.ci/run/github/130237506/1767538915.I8lmr_qeSqKcFKaqC56AcQ)
