### PR TITLE
fix: apply hover color to inline code when link is hoverd

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_code.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_code.scss
@@ -59,10 +59,10 @@ code.literal {
 
 a > code {
   color: var(--pst-color-link-higher-contrast);
+}
 
-  &:hover {
-    color: var(--pst-color-link-hover);
-  }
+a:hover > code {
+  color: var(--pst-color-link-hover);
 }
 
 // Minimum opacity needed for linenos to be WCAG AA conformant


### PR DESCRIPTION
This pull request fixes the hover behavior of inline code inside links.

Previously, the hover color was applied only when the inline code itself was hovered.
Now, it is applied when the parent link is hovered.

Fixes #2188