### PR TITLE
chore: bump gh workflow references to latest commit

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -134,7 +134,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
@@ -190,7 +190,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
         with:
           # 3.14 is not supported by py-spy yet
           python-version: "3.13"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           pandoc: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -92,7 +92,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
@@ -129,7 +129,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
 
       - name: "Check for broken links 🔗"
         run: python -Im tox run -e docs-linkcheck

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@213af5a59dd18500fdc3b82fb49afc89a54fff33
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@e8db643b990df73812cf9397bc0f8cfa1164e4d3
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
   # calls our general CI workflows (tests, coverage, profile, etc.)
   tests:
     # Important: make sure to update the SHA after making any changes to the CI workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@213af5a59dd18500fdc3b82fb49afc89a54fff33
+    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@e8db643b990df73812cf9397bc0f8cfa1164e4d3
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
     # needed for the coverage action


### PR DESCRIPTION
Fixes "build PST docs" still building for python3.9 despite 3.9 having been dropped with 40e401c.

@Carreau I changed all the occurrences and not only publish.yml, is this okay or should it be upgraded on a case-by-case basis? Can you think of potential side-effects?

Setting milestone 0.17 because this is blocking the pipelines needed for the release.