### PR TITLE
chore: bump gh workflow references to latest commit (again)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       # calls our docs workflow (build docs, check broken links, lighthouse)
   docs:
     # Important: make sure to update the SHA after making any changes to the docs workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@469e90895696e21b765121e952d84ea82c71410c
+    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@e8db643b990df73812cf9397bc0f8cfa1164e4d3
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
 


### PR DESCRIPTION
forgot one reference in gh-2321