### PR TITLE
Fix error when back-to-top button is disabled

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
+++ b/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
@@ -39,6 +39,7 @@ function backToTop() {
 
 function showBackToTop() {
   var btn = document.getElementById("pst-back-to-top");
+  if (!btn) return;
   var header = document
     .getElementsByClassName("bd-header")[0]
     .getBoundingClientRect();


### PR DESCRIPTION
An error occurs when the back-to-top button is disabled.

```
bootstrap.js:49 Uncaught TypeError: Cannot read properties of null (reading 'style')
    at bootstrap.js:49:11
```

When the back-to-top button is disabled, `btn` becomes null, and the script still attempts to access it.
This pull request fixes the issue by returning early when the back-to-top button is not present.

Fixes #1950
