### PR TITLE
feat: replace theme switcher with dropdown

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
+++ b/src/pydata_sphinx_theme/assets/scripts/bootstrap.js
@@ -23,6 +23,29 @@ function TriggerTooltip() {
   });
 }
 
+/**
+ * disable theme switch tooltip while the theme switch dropdown is open
+ */
+function setupThemeSwitchDropdownTooltip() {
+  const themeSwitchContainer = document.querySelector(
+    ".theme-switch-container",
+  );
+  if (!themeSwitchContainer) return;
+
+  const themeSwitchTooltip =
+    bootstrap.Tooltip.getInstance(themeSwitchContainer);
+  if (!themeSwitchTooltip) return;
+
+  themeSwitchContainer.addEventListener("show.bs.dropdown", () => {
+    themeSwitchTooltip.hide();
+    themeSwitchTooltip.disable();
+  });
+
+  themeSwitchContainer.addEventListener("hide.bs.dropdown", () => {
+    themeSwitchTooltip.enable();
+  });
+}
+
 /*******************************************************************************
  * back to top button
  */
@@ -57,6 +80,7 @@ function showBackToTop() {
  */
 
 documentReady(TriggerTooltip);
+documentReady(setupThemeSwitchDropdownTooltip);
 documentReady(backToTop);
 documentReady(showBackToTop);
 

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -58,27 +58,27 @@ function setTheme(mode) {
 }
 
 /**
- * Change the theme option order so that clicking on the btn is always a change
- * from "auto"
+ * Update the active dropdown item based on the current color mode.
  */
-function cycleMode() {
-  const defaultMode = document.documentElement.dataset.defaultMode || "auto";
-  const currentMode = localStorage.getItem("mode") || defaultMode;
-
-  var loopArray = (arr, current) => {
-    var nextPosition = arr.indexOf(current) + 1;
-    if (nextPosition === arr.length) {
-      nextPosition = 0;
+function updateColorModeDropdown(mode) {
+  const activeClass = "active";
+  document.querySelectorAll(".theme-change-button").forEach((el) => {
+    if (el.dataset.mode === mode) {
+      el.classList.add(activeClass);
+    } else {
+      el.classList.remove(activeClass);
     }
-    return arr[nextPosition];
-  };
+  });
+}
 
-  // make sure the next theme after auto is always a change
-  var modeList = prefersDark.matches
-    ? ["auto", "light", "dark"]
-    : ["auto", "dark", "light"];
-  var newMode = loopArray(modeList, currentMode);
-  setTheme(newMode);
+/**
+ * Change the color mode based on the clicked dropdown item.
+ */
+function changeColorMode(e) {
+  const btn = e.currentTarget;
+  const mode = btn.dataset.mode;
+  setTheme(mode);
+  updateColorModeDropdown(mode);
 }
 
 /**
@@ -87,11 +87,13 @@ function cycleMode() {
 function addModeListener() {
   // the theme was set a first time using the initial mini-script
   // running setMode will ensure the use of the dark mode if auto is selected
-  setTheme(document.documentElement.dataset.mode);
+  const mode = document.documentElement.dataset.mode;
+  setTheme(mode);
+  updateColorModeDropdown(mode);
 
-  // Attach event handlers for toggling themes colors
-  document.querySelectorAll(".theme-switch-button").forEach((el) => {
-    el.addEventListener("click", cycleMode);
+  // Attach click handlers to color mode dropdown items
+  document.querySelectorAll(".theme-change-button").forEach((el) => {
+    el.addEventListener("click", changeColorMode);
   });
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -6,11 +6,6 @@
   .theme-switch {
     display: none;
 
-    &:active {
-      text-decoration: none;
-      color: var(--pst-color-link-hover);
-    }
-
     .fa-lg {
       aspect-ratio: 1 / 1;
     }

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -17,12 +17,6 @@
   }
 }
 
-.theme-change-button.active {
-  text-decoration: none;
-  color: var(--pst-color-link-hover);
-  background: none;
-}
-
 @each $mode in auto, light, dark {
   html[data-mode="#{$mode}"]
     .theme-switch-button

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -17,6 +17,12 @@
   }
 }
 
+.theme-change-button.active {
+  text-decoration: none;
+  color: var(--pst-color-link-hover);
+  background: none;
+}
+
 @each $mode in auto, light, dark {
   html[data-mode="#{$mode}"]
     .theme-switch-button

--- a/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_bootstrap.scss
@@ -19,6 +19,7 @@ $dropdown-link-hover-bg: var(--pst-color-surface);
 // scoped to different values depending on light/dark theme
 $dropdown-dark-link-hover-bg: var(--pst-color-surface);
 $dropdown-link-active-bg: var(--pst-color-surface);
+$dropdown-link-active-color: var(--pst-color-primary);
 $dropdown-dark-link-active-bg: var(--pst-color-surface);
 $focus-ring-width: 0.1875rem; // 3px at 100% zoom (0.1875 * 16px base font = 3px)
 $focus-ring-opacity: 1;

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,6 +1,6 @@
 {# Displays an icon to switch between light mode, dark mode, and auto (use browser's setting). #}
 {# As the theme switcher will only work when JavaScript is enabled, we hide it with `pst-js-only`. #}
-<div class="theme-switch-container dropdown pst-js-only">
+<div class="theme-switch-container dropdown pst-js-only" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ _('Color mode') }}">
   <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" aria-label="{{ _('Color mode') }}" data-bs-toggle="dropdown">
     <i class="theme-switch fa-solid fa-sun fa-lg fa-fw" data-mode="light" title="{{ _('Light') }}"></i>
     <i class="theme-switch fa-solid fa-moon fa-lg fa-fw" data-mode="dark"  title="{{ _('Dark') }}"></i>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -3,8 +3,8 @@
 <div class="theme-switch-container dropdown pst-js-only" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ _('Color mode') }}">
   <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" aria-label="{{ _('Color mode') }}" data-bs-toggle="dropdown">
     <i class="theme-switch fa-solid fa-sun fa-lg fa-fw" data-mode="light" title="{{ _('Light') }}"></i>
-    <i class="theme-switch fa-solid fa-moon fa-lg fa-fw" data-mode="dark"  title="{{ _('Dark') }}"></i>
-    <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto"  title="{{ _('System Settings') }}"></i>
+    <i class="theme-switch fa-solid fa-moon fa-lg fa-fw" data-mode="dark" title="{{ _('Dark') }}"></i>
+    <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto" title="{{ _('System Settings') }}"></i>
   </button>
   <ul class="dropdown-menu">
     <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1"></i>{{ _('System Settings') }}</button></li>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -2,13 +2,13 @@
 {# As the theme switcher will only work when JavaScript is enabled, we hide it with `pst-js-only`. #}
 <div class="theme-switch-container dropdown pst-js-only">
   <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" aria-label="{{ _('Color mode') }}" data-bs-toggle="dropdown">
-    <i class="theme-switch fa-solid fa-sun                fa-lg fa-fw" data-mode="light" title="{{ _('Light') }}"></i>
-    <i class="theme-switch fa-solid fa-moon               fa-lg fa-fw" data-mode="dark"  title="{{ _('Dark') }}"></i>
+    <i class="theme-switch fa-solid fa-sun fa-lg fa-fw" data-mode="light" title="{{ _('Light') }}"></i>
+    <i class="theme-switch fa-solid fa-moon fa-lg fa-fw" data-mode="dark"  title="{{ _('Dark') }}"></i>
     <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto"  title="{{ _('System Settings') }}"></i>
   </button>
   <ul class="dropdown-menu">
     <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1"></i>{{ _('System Settings') }}</button></li>
-    <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="light"><i class="fa-solid fa-sun                fa-lg fa-fw me-1"></i>{{ _('Light') }}</button></li>
-    <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="dark"><i class="fa-solid fa-moon               fa-lg fa-fw me-1"></i>{{ _('Dark') }}</button></li>
+    <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="light"><i class="fa-solid fa-sun fa-lg fa-fw me-1"></i>{{ _('Light') }}</button></li>
+    <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="dark"><i class="fa-solid fa-moon fa-lg fa-fw me-1"></i>{{ _('Dark') }}</button></li>
   </ul>
 </div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,7 +1,14 @@
 {# Displays an icon to switch between light mode, dark mode, and auto (use browser's setting). #}
 {# As the theme switcher will only work when JavaScript is enabled, we hide it with `pst-js-only`. #}
-<button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button pst-js-only" aria-label="{{ _('Color mode') }}" data-bs-title="{{ _('Color mode') }}"  data-bs-placement="bottom" data-bs-toggle="tooltip">
-  <i class="theme-switch fa-solid fa-sun                fa-lg" data-mode="light" title="{{ _('Light') }}"></i>
-  <i class="theme-switch fa-solid fa-moon               fa-lg" data-mode="dark"  title="{{ _('Dark') }}"></i>
-  <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg" data-mode="auto"  title="{{ _('System Settings') }}"></i>
-</button>
+<div class="dropdown pst-js-only">
+  <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" aria-label="{{ _('Color mode') }}" data-bs-toggle="dropdown">
+    <i class="theme-switch fa-solid fa-sun                fa-lg fa-fw" data-mode="light" title="{{ _('Light') }}"></i>
+    <i class="theme-switch fa-solid fa-moon               fa-lg fa-fw" data-mode="dark"  title="{{ _('Dark') }}"></i>
+    <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto"  title="{{ _('System Settings') }}"></i>
+  </button>
+  <ul class="dropdown-menu">
+    <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1"></i>{{ _('System Settings') }}</button></li>
+    <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="light"><i class="fa-solid fa-sun                fa-lg fa-fw me-1"></i>{{ _('Light') }}</button></li>
+    <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="dark"><i class="fa-solid fa-moon               fa-lg fa-fw me-1"></i>{{ _('Dark') }}</button></li>
+  </ul>
+</div>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -1,6 +1,6 @@
 {# Displays an icon to switch between light mode, dark mode, and auto (use browser's setting). #}
 {# As the theme switcher will only work when JavaScript is enabled, we hide it with `pst-js-only`. #}
-<div class="dropdown pst-js-only">
+<div class="theme-switch-container dropdown pst-js-only">
   <button class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" aria-label="{{ _('Color mode') }}" data-bs-toggle="dropdown">
     <i class="theme-switch fa-solid fa-sun                fa-lg fa-fw" data-mode="light" title="{{ _('Light') }}"></i>
     <i class="theme-switch fa-solid fa-moon               fa-lg fa-fw" data-mode="dark"  title="{{ _('Dark') }}"></i>

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -843,7 +843,9 @@ def test_version_switcher_error_states(
 def test_theme_switcher(sphinx_build_factory, file_regression) -> None:
     """Regression test for the theme switcher button."""
     sphinx_build = sphinx_build_factory("base").build()
-    switcher = sphinx_build.html_tree("index.html").find(class_="theme-switch-button")
+    switcher = sphinx_build.html_tree("index.html").find(
+        class_="theme-switch-container"
+    )
     file_regression.check(
         switcher.prettify(), basename="navbar_theme", extension=".html"
     )

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,4 +1,4 @@
-<div class="theme-switch-container dropdown pst-js-only">
+<div class="theme-switch-container dropdown pst-js-only" data-bs-placement="bottom" data-bs-toggle="tooltip" title="Color mode">
  <button aria-label="Color mode" class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" data-bs-toggle="dropdown">
   <i class="theme-switch fa-solid fa-sun fa-lg fa-fw" data-mode="light" title="Light">
   </i>

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -1,8 +1,33 @@
-<button aria-label="Color mode" class="btn btn-sm nav-link pst-navbar-icon theme-switch-button pst-js-only" data-bs-placement="bottom" data-bs-title="Color mode" data-bs-toggle="tooltip">
- <i class="theme-switch fa-solid fa-sun fa-lg" data-mode="light" title="Light">
- </i>
- <i class="theme-switch fa-solid fa-moon fa-lg" data-mode="dark" title="Dark">
- </i>
- <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg" data-mode="auto" title="System Settings">
- </i>
-</button>
+<div class="theme-switch-container dropdown pst-js-only">
+ <button aria-label="Color mode" class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" data-bs-toggle="dropdown">
+  <i class="theme-switch fa-solid fa-sun fa-lg fa-fw" data-mode="light" title="Light">
+  </i>
+  <i class="theme-switch fa-solid fa-moon fa-lg fa-fw" data-mode="dark" title="Dark">
+  </i>
+  <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto" title="System Settings">
+  </i>
+ </button>
+ <ul class="dropdown-menu">
+  <li>
+   <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto">
+    <i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1">
+    </i>
+    System Settings
+   </button>
+  </li>
+  <li>
+   <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="light">
+    <i class="fa-solid fa-sun fa-lg fa-fw me-1">
+    </i>
+    Light
+   </button>
+  </li>
+  <li>
+   <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="dark">
+    <i class="fa-solid fa-moon fa-lg fa-fw me-1">
+    </i>
+    Dark
+   </button>
+  </li>
+ </ul>
+</div>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -33,14 +33,39 @@
   </div>
   <div class="sidebar-header-items__end">
    <div class="navbar-item">
-    <button aria-label="Color mode" class="btn btn-sm nav-link pst-navbar-icon theme-switch-button pst-js-only" data-bs-placement="bottom" data-bs-title="Color mode" data-bs-toggle="tooltip">
-     <i class="theme-switch fa-solid fa-sun fa-lg" data-mode="light" title="Light">
-     </i>
-     <i class="theme-switch fa-solid fa-moon fa-lg" data-mode="dark" title="Dark">
-     </i>
-     <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg" data-mode="auto" title="System Settings">
-     </i>
-    </button>
+    <div class="theme-switch-container dropdown pst-js-only">
+     <button aria-label="Color mode" class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" data-bs-toggle="dropdown">
+      <i class="theme-switch fa-solid fa-sun fa-lg fa-fw" data-mode="light" title="Light">
+      </i>
+      <i class="theme-switch fa-solid fa-moon fa-lg fa-fw" data-mode="dark" title="Dark">
+      </i>
+      <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto" title="System Settings">
+      </i>
+     </button>
+     <ul class="dropdown-menu">
+      <li>
+       <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto">
+        <i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1">
+        </i>
+        System Settings
+       </button>
+      </li>
+      <li>
+       <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="light">
+        <i class="fa-solid fa-sun fa-lg fa-fw me-1">
+        </i>
+        Light
+       </button>
+      </li>
+      <li>
+       <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="dark">
+        <i class="fa-solid fa-moon fa-lg fa-fw me-1">
+        </i>
+        Dark
+       </button>
+      </li>
+     </ul>
+    </div>
    </div>
   </div>
  </div>

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -33,7 +33,7 @@
   </div>
   <div class="sidebar-header-items__end">
    <div class="navbar-item">
-    <div class="theme-switch-container dropdown pst-js-only">
+    <div class="theme-switch-container dropdown pst-js-only" data-bs-placement="bottom" data-bs-toggle="tooltip" title="Color mode">
      <button aria-label="Color mode" class="btn btn-sm nav-link pst-navbar-icon theme-switch-button dropdown-toggle" data-bs-toggle="dropdown">
       <i class="theme-switch fa-solid fa-sun fa-lg fa-fw" data-mode="light" title="Light">
       </i>


### PR DESCRIPTION
This pull request replaces the theme switch button with a dropdown menu.

Previously, the theme was changed by cycling through options with a single button.
With this change, users can directly select the desired color mode (auto, light, or dark) from a dropdown menu.

This makes it easier and more intuitive to change the theme.

## Related Issue
Closes #1941 

Feedback is very welcome, and I would be happy to update the implementation if needed.