### PR TITLE
Replace broken Unsplash image URLs with Picsum in light-dark guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -383,7 +383,6 @@ linkcheck_ignore = [
     "../examples/blog/index.html",
     # get a 403 on CI
     "https://canvas.workday.com/styles/tokens/type",
-    "https://unsplash.com/",
     r"https?://www.gnu.org/software/gettext/.*",
     r"https://www.npmjs.com/.*",
     r"https://sass-lang.com/.*",

--- a/docs/user_guide/light-dark.rst
+++ b/docs/user_guide/light-dark.rst
@@ -94,28 +94,28 @@ Change the theme and a new image should be displayed.
 
         .. code-block:: rst
 
-            .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+            .. image:: https://picsum.photos/id/237/200/200
                 :class: only-dark
 
-            .. image:: https://source.unsplash.com/200x200/daily?cute+dog
+            .. image:: https://picsum.photos/id/1025/200/200
                 :class: only-light
 
     .. tab-item:: markdown
 
         .. code-block:: md
 
-            ```{image} https://source.unsplash.com/200x200/daily?cute+cat
+            ```{image} https://picsum.photos/id/237/200/200
             :class: only-dark
             ```
 
-            ```{image} https://source.unsplash.com/200x200/daily?cute+dog
+            ```{image} https://picsum.photos/id/1025/200/200
             :class: only-light
             ```
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+cat
+.. image:: https://picsum.photos/id/237/200/200
     :class: only-dark
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+dog
+.. image:: https://picsum.photos/id/1025/200/200
     :class: only-light
 
 Images and content that work in both themes
@@ -139,19 +139,19 @@ Change to the dark theme and a grey background will be present.
 
         .. code-block:: rst
 
-            .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+            .. image:: https://picsum.photos/id/237/200/200
                 :class: p-2
 
     .. tab-item:: markdown
 
         .. code-block:: md
 
-            ```{image} https://source.unsplash.com/200x200/daily?cute+cat
+            ```{image} https://picsum.photos/id/237/200/200
             :class: p-2
             ```
 
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+cat
+.. image:: https://picsum.photos/id/237/200/200
     :class: p-2
 
 Here's the same image with this class added:
@@ -162,18 +162,18 @@ Here's the same image with this class added:
 
         .. code-block:: rst
 
-            .. image:: https://source.unsplash.com/200x200/daily?cute+cat
+            .. image:: https://picsum.photos/id/237/200/200
                 :class: dark-light
 
     .. tab-item:: markdown
 
         .. code-block:: md
 
-            ```{image} https://source.unsplash.com/200x200/daily?cute+cat
+            ```{image} https://picsum.photos/id/237/200/200
             :class: dark-light p-2
             ```
 
-.. image:: https://source.unsplash.com/200x200/daily?cute+cat
+.. image:: https://picsum.photos/id/237/200/200
     :class: dark-light p-2
 
 Define custom JavaScript to react to theme changes

--- a/docs/user_guide/light-dark.rst
+++ b/docs/user_guide/light-dark.rst
@@ -94,7 +94,7 @@ Change the theme and a new image should be displayed.
 
         .. code-block:: rst
 
-            .. image:: https://picsum.photos/id/237/200/200
+            .. image:: https://picsum.photos/id/9/200/200
                 :class: only-dark
 
             .. image:: https://picsum.photos/id/1025/200/200
@@ -104,7 +104,7 @@ Change the theme and a new image should be displayed.
 
         .. code-block:: md
 
-            ```{image} https://picsum.photos/id/237/200/200
+            ```{image} https://picsum.photos/id/9/200/200
             :class: only-dark
             ```
 
@@ -112,7 +112,7 @@ Change the theme and a new image should be displayed.
             :class: only-light
             ```
 
-.. image:: https://picsum.photos/id/237/200/200
+.. image:: https://picsum.photos/id/9/200/200
     :class: only-dark
 
 .. image:: https://picsum.photos/id/1025/200/200


### PR DESCRIPTION
## Summary

The light and dark themes documentation page uses `source.unsplash.com` URLs for example images, but this service no longer serves images, leaving all examples on the page broken.

This replaces the Unsplash URLs with `picsum.photos` URLs (consistent with the approach used in #2190 for other docs pages) and removes the now-unnecessary `unsplash.com` entry from `linkcheck_ignore` in `conf.py`.

Fixes #2208

## Changes

- `docs/user_guide/light-dark.rst`: Replace all `source.unsplash.com` image URLs with `picsum.photos` equivalents (id/237 for the dark-theme cat image, id/1025 for the light-theme dog image)
- `docs/conf.py`: Remove `"https://unsplash.com/"` from `linkcheck_ignore` since no Unsplash URLs remain in the docs

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)