### PR TITLE
Fix default behavior when shorten_urls is unset

### DIFF
--- a/docs/user_guide/theme-elements.md
+++ b/docs/user_guide/theme-elements.md
@@ -220,6 +220,14 @@ In **reStructuredText**, URLs are automatically converted to links, so this work
 In **MyST Markdown**, by default, you must define a standard Markdown link and duplicate the URL in the link text.
 You may skip the need to manually define the link text by [activating the MyST Linkify extension](https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#linkify).
 
+Link shortening is enabled by default. To disable it, set the following option in your `conf.py`:
+
+```python
+html_theme_options = {
+    "shorten_urls": False,
+}
+```
+
 For example:
 
 - **reStructuredText**

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -300,7 +300,7 @@ def setup(app: Sphinx) -> Dict[str, str]:
     app.add_html_theme("pydata_sphinx_theme", str(theme_path))
 
     theme_options = utils.get_theme_options_dict(app)
-    if theme_options.get("shorten_urls"):
+    if theme_options.get("shorten_urls", True):
         app.add_post_transform(short_link.ShortenLinkTransform)
 
     app.connect("builder-inited", translator.setup_translators)

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -292,17 +292,21 @@ def _fix_canonical_url(
     context["pageurl"] = app.config.html_baseurl + target
 
 
+def add_shorten_xform(app: Sphinx) -> None:
+    """Add the link shortening transform."""
+    theme_options = utils.get_theme_options_dict(app)
+    theme_conf_options = app.builder.theme.get_options()
+    if (theme_conf_options | theme_options).get("shorten_urls"):
+        app.add_post_transform(short_link.ShortenLinkTransform)
+
+
 def setup(app: Sphinx) -> Dict[str, str]:
     """Setup the Sphinx application."""
     here = Path(__file__).parent.resolve()
     theme_path = here / "theme" / "pydata_sphinx_theme"
-
     app.add_html_theme("pydata_sphinx_theme", str(theme_path))
 
-    theme_options = utils.get_theme_options_dict(app)
-    if theme_options.get("shorten_urls", True):
-        app.add_post_transform(short_link.ShortenLinkTransform)
-
+    app.connect("builder-inited", add_shorten_xform)
     app.connect("builder-inited", translator.setup_translators)
     app.connect("builder-inited", update_config)
     app.connect("html-page-context", _fix_canonical_url)


### PR DESCRIPTION
This pull request fixes the behavior of the `shorten_urls` option.

Previously, when `shorten_urls` was not set, it defaulted to `False`.
With this change, it now defaults to `True`.

- Fixes #2348