### PR TITLE
Fix docs build with sphinx 'extensions' config key

### DIFF
--- a/src/pydata_sphinx_theme/utils.py
+++ b/src/pydata_sphinx_theme/utils.py
@@ -20,7 +20,11 @@ def get_theme_options_dict(app: Sphinx) -> Dict[str, Any]:
     their ``conf.py``); sometimes that copy never occurs though which is why we
     check both.
     """
-    if hasattr(app.builder, "theme_options"):
+    if (
+        hasattr(app, "builder")
+        and app.builder is not None
+        and hasattr(app.builder, "theme_options")
+    ):
         return app.builder.theme_options
     elif hasattr(app.config, "html_theme_options"):
         return app.config.html_theme_options

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -15,6 +15,14 @@ COMMON_CONF_OVERRIDES = dict(
 )
 
 
+def test_theme_loaded_as_extension(sphinx_build_factory) -> None:
+    """Theme must not crash when loaded via extensions= instead of html_theme=."""
+    sphinx_build = sphinx_build_factory(
+        "base", confoverrides={"extensions": ["pydata_sphinx_theme"]}
+    )
+    sphinx_build.build(no_warning=False)
+
+
 def test_build_html(sphinx_build_factory, file_regression) -> None:
     """Test building the base html template and config."""
     sphinx_build = sphinx_build_factory("base")


### PR DESCRIPTION
Fixes #2349

Regression introduced by 469e908, which adds a call to `get_theme_options_dict`, which reads `self.builder`, but `self.builder` is not yet defined if the `extensions` sphinx config is used.

https://github.com/sphinx-doc/sphinx/blob/cc7c6f435ad37bb12264f8118c8461b230e6830c/sphinx/application.py#L299 
https://github.com/sphinx-doc/sphinx/blob/cc7c6f435ad37bb12264f8118c8461b230e6830c/sphinx/application.py#L334