### PR TITLE
Add distinctive style for menuselection, based on guilabel

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_spans.scss
@@ -3,8 +3,12 @@
  */
 
 span.guilabel {
-  border: 1px solid var(--pst-color-info);
   font-size: 80%;
+}
+
+span.guilabel,
+span.menuselection {
+  border: 1px solid var(--pst-color-info);
   font-weight: 700;
   border-radius: 4px;
   padding: 2.4px 6px;


### PR DESCRIPTION
This PR adds a style for `menuselection`, based on `guilabel`.

Closes #2365.

Feedback appreciated.

## Before

<img width="734" height="335" alt="Screenshot 2026-04-29 at 4 14 14 PM" src="https://github.com/user-attachments/assets/9421bd2a-de88-43bb-82d5-b8e5ce335a98" />

## After

<img width="734" height="335" alt="Screenshot 2026-04-29 at 4 14 41 PM" src="https://github.com/user-attachments/assets/0ea2e321-0604-456d-aef3-fd2af8dab94f" />

ping @Yann-P.