### PR TITLE
fix: configure defaults for Google Analytics before loading script

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -124,21 +124,27 @@ def update_config(app):
         # Google Analytics
         gid = analytics.get("google_analytics_id")
         if gid:
-            gid_js_path = f"https://www.googletagmanager.com/gtag/js?id={gid}"
-            gid_script = f"""
+            gid_defaults = """
                 window.dataLayer = window.dataLayer || [];
-                function gtag(){{ dataLayer.push(arguments); }}
-                gtag('consent', 'default', {{
+                function gtag(){ dataLayer.push(arguments); }
+                gtag('consent', 'default', {
                     'ad_storage': 'denied',
                     'ad_user_data': 'denied',
                     'ad_personalization': 'denied',
                     'analytics_storage': 'denied'
-                }});
+                });
+            """
+            gid_js_path = f"https://www.googletagmanager.com/gtag/js?id={gid}"
+            gid_script = f"""
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){{dataLayer.push(arguments);}}
                 gtag('js', new Date());
                 gtag('config', '{gid}');
             """
 
             # Link the JS files
+            # Ref: https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#implementation_example
+            app.add_js_file(None, body=gid_defaults)
             app.add_js_file(gid_js_path, loading_method="async")
             app.add_js_file(None, body=gid_script)
 

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -144,9 +144,9 @@ def update_config(app):
 
             # Link the JS files
             # Ref: https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#implementation_example
-            app.add_js_file(None, body=gid_defaults)
+            app.add_js_file("", body=gid_defaults)
             app.add_js_file(gid_js_path, loading_method="async")
-            app.add_js_file(None, body=gid_script)
+            app.add_js_file("", body=gid_script)
 
     # Update ABlog configuration default if present
     fa_provided = utils.config_provided_by_user(app, "fontawesome_included")

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -25,7 +25,7 @@
 
 /* Assign base colors for the PyData theme */
 $color-palette: (
-  // Primary color
+  /* Primary color*/
   "teal": (
       "50": #f4fbfc,
       "100": #e9f6f8,
@@ -38,7 +38,7 @@ $color-palette: (
       "800": #042c33,
       "900": #021b1f,
     ),
-  // Secondary color
+  /* Secondary color*/
   "violet": (
       "50": #f4eefb,
       "100": #e0c7ff,
@@ -51,7 +51,7 @@ $color-palette: (
       "800": #341a61,
       "900": #1e0e39,
     ),
-  // Neutrals
+  /* Neutrals*/
   "gray": (
       "50": #f9f9fa,
       "100": #f3f4f5,
@@ -64,7 +64,7 @@ $color-palette: (
       "800": #222832,
       "900": #14181e,
     ),
-  // Accent color
+  /* Accent color*/
   "pink": (
       "50": #fcf8fd,
       "100": #fcf0fa,
@@ -78,8 +78,8 @@ $color-palette: (
       "900": #2b0b27,
     ),
   "foundation": (
-    "white": #ffffff,
-    // gray-900
+    "white": #fff,
+    /* gray-900*/
     "black": #14181e,
   )
 );
@@ -156,7 +156,7 @@ $pst-semantic-colors: (
     "dark": #5fb488,
     "bg-dark": #002f17,
   ),
-  // This is based on the warning color
+  /* This is based on the warning color*/
   "attention": (
       "light": var(--pst-color-warning),
       "bg-light": var(--pst-color-warning-bg),
@@ -178,20 +178,20 @@ $pst-semantic-colors: (
     "dark": #{map-deep-get($color-palette, "gray", "400")},
   ),
   "shadow": (
-    "light": rgba(0, 0, 0, 0.1),
-    "dark": rgba(0, 0, 0, 0.2),
+    "light": rgb(0 0 0 / 10%),
+    "dark": rgb(0 0 0 / 20%),
   ),
   "border": (
     "light": #{map-deep-get($color-palette, "gray", "300")},
     "dark": #{map-deep-get($color-palette, "gray", "600")},
   ),
   "border-muted": (
-    "light": rgba(23, 23, 26, 0.2),
+    "light": rgb(23 23 26 / 20%),
     "dark": #{map-deep-get($color-palette, "gray", "700")},
   ),
   "blockquote-notch": (
-    // These colors have a contrast ratio > 3.0 against both the background and
-    // surface colors that the notch is sandwiched between
+    /* These colors have a contrast ratio > 3.0 against both the background and*/
+    /* surface colors that the notch is sandwiched between*/
     "light": #{map-deep-get($color-palette, "gray", "500")},
     "dark": #{map-deep-get($color-palette, "gray", "400")},
   ),
@@ -200,11 +200,11 @@ $pst-semantic-colors: (
     "dark": #{map-deep-get($color-palette, "pink", "300")},
   ),
   "link-higher-contrast": (
-    // teal-600 provides higher contrast than teal-500 (our regular light mode
-    // link color) for off-white or non-white backgrounds
+    /* teal-600 provides higher contrast than teal-500 (our regular light mode*/
+    /* link color) for off-white or non-white backgrounds*/
     "light": #{map-deep-get($color-palette, "teal", "600")},
-    // teal-400 is actually the same color already used for links in dark mode,
-    // but it actually works for most of our other dark mode backgrounds
+    /* teal-400 is actually the same color already used for links in dark mode,*/
+    /* but it actually works for most of our other dark mode backgrounds*/
     "dark": #{map-deep-get($color-palette, "teal", "400")},
   ),
   "target": (
@@ -223,15 +223,15 @@ $pst-semantic-colors: (
     "light": #{map-deep-get($color-palette, "gray", "200")},
     "dark": #364150,
   ),
-  // DEPTH COLORS - you can see the elevation colours and shades
-  // in the Figma file https://www.figma.com/file/rUrrHGhUBBIAAjQ82x6pz9/PyData-Design-system---proposal-for-implementation-(2)?node-id=1492%3A922&t=sQeQZehkOzposYEg-1
-  // background: color of the canvas / the furthest back layer
+  /* DEPTH COLORS - you can see the elevation colours and shades*/
+  /* in the Figma file https://www.figma.com/file/rUrrHGhUBBIAAjQ82x6pz9/PyData-Design-system---proposal-for-implementation-(2)?node-id=1492%3A922&t=sQeQZehkOzposYEg-1*/
+  /* background: color of the canvas / the furthest back layer*/
   "background": (
       "light": #{map-deep-get($color-palette, "foundation", "white")},
       "dark": #{map-deep-get($color-palette, "foundation", "black")},
     ),
-  // on-background: provides slight contrast against background
-  // (by use of shadows in light theme)
+  /* on-background: provides slight contrast against background*/
+  /* (by use of shadows in light theme)*/
   "on-background": (
       "light": #{map-deep-get($color-palette, "foundation", "white")},
       "dark": #{map-deep-get($color-palette, "gray", "800")},
@@ -240,7 +240,7 @@ $pst-semantic-colors: (
     "light": #{map-deep-get($color-palette, "gray", "100")},
     "dark": #{map-deep-get($color-palette, "gray", "700")},
   ),
-  // on_surface: object on top of surface object (without shadows)
+  /* on_surface: object on top of surface object (without shadows)*/
   "on-surface": (
       "light": #{map-deep-get($color-palette, "gray", "800")},
       "dark": $foundation-light-gray,

--- a/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_color.scss
@@ -25,7 +25,7 @@
 
 /* Assign base colors for the PyData theme */
 $color-palette: (
-  /* Primary color*/
+  // Primary color
   "teal": (
       "50": #f4fbfc,
       "100": #e9f6f8,
@@ -38,7 +38,7 @@ $color-palette: (
       "800": #042c33,
       "900": #021b1f,
     ),
-  /* Secondary color*/
+  // Secondary color
   "violet": (
       "50": #f4eefb,
       "100": #e0c7ff,
@@ -51,7 +51,7 @@ $color-palette: (
       "800": #341a61,
       "900": #1e0e39,
     ),
-  /* Neutrals*/
+  // Neutrals
   "gray": (
       "50": #f9f9fa,
       "100": #f3f4f5,
@@ -64,7 +64,7 @@ $color-palette: (
       "800": #222832,
       "900": #14181e,
     ),
-  /* Accent color*/
+  // Accent color
   "pink": (
       "50": #fcf8fd,
       "100": #fcf0fa,
@@ -78,8 +78,8 @@ $color-palette: (
       "900": #2b0b27,
     ),
   "foundation": (
-    "white": #fff,
-    /* gray-900*/
+    "white": #ffffff,
+    // gray-900
     "black": #14181e,
   )
 );
@@ -156,7 +156,7 @@ $pst-semantic-colors: (
     "dark": #5fb488,
     "bg-dark": #002f17,
   ),
-  /* This is based on the warning color*/
+  // This is based on the warning color
   "attention": (
       "light": var(--pst-color-warning),
       "bg-light": var(--pst-color-warning-bg),
@@ -178,20 +178,20 @@ $pst-semantic-colors: (
     "dark": #{map-deep-get($color-palette, "gray", "400")},
   ),
   "shadow": (
-    "light": rgb(0 0 0 / 10%),
-    "dark": rgb(0 0 0 / 20%),
+    "light": rgba(0, 0, 0, 0.1),
+    "dark": rgba(0, 0, 0, 0.2),
   ),
   "border": (
     "light": #{map-deep-get($color-palette, "gray", "300")},
     "dark": #{map-deep-get($color-palette, "gray", "600")},
   ),
   "border-muted": (
-    "light": rgb(23 23 26 / 20%),
+    "light": rgba(23, 23, 26, 0.2),
     "dark": #{map-deep-get($color-palette, "gray", "700")},
   ),
   "blockquote-notch": (
-    /* These colors have a contrast ratio > 3.0 against both the background and*/
-    /* surface colors that the notch is sandwiched between*/
+    // These colors have a contrast ratio > 3.0 against both the background and
+    // surface colors that the notch is sandwiched between
     "light": #{map-deep-get($color-palette, "gray", "500")},
     "dark": #{map-deep-get($color-palette, "gray", "400")},
   ),
@@ -200,11 +200,11 @@ $pst-semantic-colors: (
     "dark": #{map-deep-get($color-palette, "pink", "300")},
   ),
   "link-higher-contrast": (
-    /* teal-600 provides higher contrast than teal-500 (our regular light mode*/
-    /* link color) for off-white or non-white backgrounds*/
+    // teal-600 provides higher contrast than teal-500 (our regular light mode
+    // link color) for off-white or non-white backgrounds
     "light": #{map-deep-get($color-palette, "teal", "600")},
-    /* teal-400 is actually the same color already used for links in dark mode,*/
-    /* but it actually works for most of our other dark mode backgrounds*/
+    // teal-400 is actually the same color already used for links in dark mode,
+    // but it actually works for most of our other dark mode backgrounds
     "dark": #{map-deep-get($color-palette, "teal", "400")},
   ),
   "target": (
@@ -223,15 +223,15 @@ $pst-semantic-colors: (
     "light": #{map-deep-get($color-palette, "gray", "200")},
     "dark": #364150,
   ),
-  /* DEPTH COLORS - you can see the elevation colours and shades*/
-  /* in the Figma file https://www.figma.com/file/rUrrHGhUBBIAAjQ82x6pz9/PyData-Design-system---proposal-for-implementation-(2)?node-id=1492%3A922&t=sQeQZehkOzposYEg-1*/
-  /* background: color of the canvas / the furthest back layer*/
+  // DEPTH COLORS - you can see the elevation colours and shades
+  // in the Figma file https://www.figma.com/file/rUrrHGhUBBIAAjQ82x6pz9/PyData-Design-system---proposal-for-implementation-(2)?node-id=1492%3A922&t=sQeQZehkOzposYEg-1
+  // background: color of the canvas / the furthest back layer
   "background": (
       "light": #{map-deep-get($color-palette, "foundation", "white")},
       "dark": #{map-deep-get($color-palette, "foundation", "black")},
     ),
-  /* on-background: provides slight contrast against background*/
-  /* (by use of shadows in light theme)*/
+  // on-background: provides slight contrast against background
+  // (by use of shadows in light theme)
   "on-background": (
       "light": #{map-deep-get($color-palette, "foundation", "white")},
       "dark": #{map-deep-get($color-palette, "gray", "800")},
@@ -240,7 +240,7 @@ $pst-semantic-colors: (
     "light": #{map-deep-get($color-palette, "gray", "100")},
     "dark": #{map-deep-get($color-palette, "gray", "700")},
   ),
-  /* on_surface: object on top of surface object (without shadows)*/
+  // on_surface: object on top of surface object (without shadows)
   "on-surface": (
       "light": #{map-deep-get($color-palette, "gray", "800")},
       "dark": $foundation-light-gray,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -780,7 +780,7 @@ def test_analytics(sphinx_build_factory, provider, tags) -> None:
     first_gtag_found = False
     second_gtag_found = False
     for script in index_html.select("script"):
-        if script.string and tags[0] in script.string and tags[1] in script.string:
+        if script.string and tags[0] in script.string:
             # If the tag is found, make sure the consent mode is also there
             if tags[0] == "gtag" and not first_gtag_found:
                 assert "gtag('consent', 'default', {" in script.string
@@ -790,6 +790,7 @@ def test_analytics(sphinx_build_factory, provider, tags) -> None:
                 assert "'analytics_storage': 'denied'" in script.string
                 first_gtag_found = True
             elif script.string and tags[0] == "gtag" and first_gtag_found:
+                assert tags[1] in script.string
                 second_gtag_found = True
     assert first_gtag_found is True
     assert second_gtag_found is True

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -770,19 +770,29 @@ def test_analytics(sphinx_build_factory, provider, tags) -> None:
     sphinx_build.build()
     index_html = sphinx_build.html_tree("index.html")
 
-    # Search all the scripts and make sure one of them has the Google tag in there
-    tags_found = False
+    # Search all the scripts and make sure the Google tag in there.
+    # To match
+    # https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#implementation_example
+    # there are three script tags:
+    #   1. Set consent (first gtag).
+    #   2. Load the library.
+    #   3. Initialize the library (second gtag).
+    first_gtag_found = False
+    second_gtag_found = False
     for script in index_html.select("script"):
         if script.string and tags[0] in script.string and tags[1] in script.string:
             # If the tag is found, make sure the consent mode is also there
-            if tags[0] == "gtag":
+            if tags[0] == "gtag" and not first_gtag_found:
                 assert "gtag('consent', 'default', {" in script.string
                 assert "'ad_storage': 'denied'," in script.string
                 assert "'ad_user_data': 'denied'," in script.string
                 assert "'ad_personalization': 'denied'," in script.string
                 assert "'analytics_storage': 'denied'" in script.string
-            tags_found = True
-    assert tags_found is True
+                first_gtag_found = True
+            elif script.string and tags[0] == "gtag" and first_gtag_found:
+                second_gtag_found = True
+    assert first_gtag_found is True
+    assert second_gtag_found is True
 
 
 def test_plausible(sphinx_build_factory) -> None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -777,23 +777,53 @@ def test_analytics(sphinx_build_factory, provider, tags) -> None:
     #   1. Set consent (first gtag).
     #   2. Load the library.
     #   3. Initialize the library (second gtag).
-    first_gtag_found = False
-    second_gtag_found = False
-    for script in index_html.select("script"):
-        if script.string and tags[0] in script.string:
-            # If the tag is found, make sure the consent mode is also there
-            if tags[0] == "gtag" and not first_gtag_found:
-                assert "gtag('consent', 'default', {" in script.string
-                assert "'ad_storage': 'denied'," in script.string
-                assert "'ad_user_data': 'denied'," in script.string
-                assert "'ad_personalization': 'denied'," in script.string
-                assert "'analytics_storage': 'denied'" in script.string
-                first_gtag_found = True
-            elif script.string and tags[0] == "gtag" and first_gtag_found:
-                assert tags[1] in script.string
-                second_gtag_found = True
-    assert first_gtag_found is True
-    assert second_gtag_found is True
+
+    inline_scripts = [s.string for s in index_html.select("script") if s.string]
+
+    # 1. Set consent (first gtag)
+    consent_scripts = [s for s in inline_scripts if f"{tags[0]}('consent'" in s]
+    assert len(consent_scripts) == 1, (
+        "Expected exactly 1 consent script, "
+        f"but found {len(consent_scripts)}: {consent_scripts}"
+    )
+    consent_script = consent_scripts[0]
+    assert "window.dataLayer = window.dataLayer || [];" in consent_script
+    assert (
+        f"function {tags[0]}(){{ dataLayer.push(arguments); }}" in consent_script
+        or f"function {tags[0]}(){{dataLayer.push(arguments);}}" in consent_script
+    )
+    assert f"{tags[0]}('consent', 'default', {{" in consent_script
+    assert "'ad_storage': 'denied'," in consent_script
+    assert "'ad_user_data': 'denied'," in consent_script
+    assert "'ad_personalization': 'denied'," in consent_script
+    assert "'analytics_storage': 'denied'" in consent_script
+
+    # 2. Load the library (external script)
+    external_scripts = [s for s in index_html.select("script") if s.attrs.get("src")]
+    expected_src = f"https://www.googletagmanager.com/gtag/js?id={tags[1]}"
+    matching_external = [
+        s for s in external_scripts if s.attrs.get("src") == expected_src
+    ]
+    assert len(matching_external) == 1, (
+        f"Expected exactly 1 external script loading {expected_src}, "
+        f"but found {len(matching_external)}"
+    )
+    assert matching_external[0].attrs.get("async") == "async"
+
+    # 3. Initialize the library (second gtag)
+    init_scripts = [
+        s for s in inline_scripts if f"{tags[0]}('config', '{tags[1]}')" in s
+    ]
+    assert len(init_scripts) == 1, (
+        f"Expected exactly 1 init script, found {len(init_scripts)}: {init_scripts}"
+    )
+    init_script = init_scripts[0]
+    assert "window.dataLayer = window.dataLayer || [];" in init_script
+    assert (
+        f"function {tags[0]}(){{ dataLayer.push(arguments); }}" in init_script
+        or f"function {tags[0]}(){{dataLayer.push(arguments);}}" in init_script
+    )
+    assert f"{tags[0]}('js', new Date());" in init_script
 
 
 def test_plausible(sphinx_build_factory) -> None:


### PR DESCRIPTION
Refactor Google Analytics script handling for consent mode.

Match the example at https://developers.google.com/tag-platform/security/guides/consent?consentmode=advanced#implementation_example According to that,

> The order of the code here is vital. If your consent code is called out of order, consent defaults won't work.

Follow-up to https://github.com/pydata/pydata-sphinx-theme/pull/2289/changes