### PR TITLE
Update to FontAwesome v7

### DIFF
--- a/docs/community/topics/assets.md
+++ b/docs/community/topics/assets.md
@@ -37,7 +37,7 @@ This is configured in the `webpack.config.js` file, and imported in the respecti
 
 ## FontAwesome icons
 
-Three "styles" of the [FontAwesome 6 Free](https://fontawesome.com/icons?m=free)
+Three "styles" of the [FontAwesome 7 Free](https://fontawesome.com/icons?m=free)
 icon font are used for {ref}`icon links <icon-links>` and admonitions and is
 the only `vendored` font.
 

--- a/docs/community/topics/assets.md
+++ b/docs/community/topics/assets.md
@@ -38,7 +38,7 @@ This is configured in the `webpack.config.js` file, and imported in the respecti
 ## FontAwesome icons
 
 Three "styles" of the [FontAwesome 7 Free](https://fontawesome.com/icons?m=free)
-icon font are used for {ref}`icon links <icon-links>` and admonitions and is
+icon font are used for {ref}`icon links <icon-links>` and admonitions, and it is
 the only `vendored` font.
 
 - It is managed as a dependency in `package.json`

--- a/docs/user_guide/extending.rst
+++ b/docs/user_guide/extending.rst
@@ -169,7 +169,7 @@ And add the following to your ``custom.css`` file:
 Using a custom icon
 -------------------
 
-Customizing the icon uses a similar process to customizing the color: create a new CSS class in your `custom.css <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files>`__ file. The theme supports `fontawesome v6 icons <https://fontawesome.com/v6/search?o=r&m=free&f=brands>`__ ("free" and "brands" sets). To use an icon, copy its unicode value into your custom class as shown in the CSS tab below:
+Customizing the icon uses a similar process to customizing the color: create a new CSS class in your `custom.css <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files>`__ file. The theme supports `fontawesome v7 icons <https://fontawesome.com/v7.2/search?o=r&m=free&f=brands>`__ ("free" and "brands" sets). To use an icon, copy its unicode value into your custom class as shown in the CSS tab below:
 
 .. begin-example-icon
 .. admonition:: Check out my custom icon

--- a/docs/user_guide/fonts.rst
+++ b/docs/user_guide/fonts.rst
@@ -1,7 +1,7 @@
 Fonts and FontAwesome
 =====================
 
-The theme includes the `FontAwesome 6 Free <https://fontawesome.com/icons?m=free>`__
+The theme includes the `FontAwesome 7 Free <https://fontawesome.com/icons?m=free>`__
 icon font (the ``.fa-solid, .fa-regular, .fa-brands`` styles, which are used for
 :ref:`icon links <icon-links>` and admonitions).
 This is the only *vendored* font, and otherwise, the theme by default relies on

--- a/docs/user_guide/header-links.rst
+++ b/docs/user_guide/header-links.rst
@@ -89,7 +89,7 @@ and brand-specific icons (e.g. "GitHub").
 You can use FontAwesome icons by specifying ``"type": "fontawesome"``, and
 specifying a FontAwesome class in the ``icon`` value.
 The value of ``icon`` can be any full
-`FontAwesome 6 Free <https://fontawesome.com/search?o=r&m=free>`__ icon.
+`FontAwesome 7 Free <https://fontawesome.com/v7.2/search?o=r&m=free>`__ icon.
 In addition to the main icon class, e.g. ``fa-cat``, the "style" class must
 also be provided e.g. `fa-brands` for *branding*, or `fa-solid` for *solid*.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "pydata_sphinx_theme",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.5.1",
+        "@fortawesome/fontawesome-free": "^7.2.0",
         "@popperjs/core": "^2.11.6",
         "bootstrap": "^5.2.2",
         "compare-versions": "^5.0.3",
@@ -194,10 +194,10 @@
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
-      "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==",
-      "hasInstallScript": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
+      "integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.5.1",
+    "@fortawesome/fontawesome-free": "^7.2.0",
     "@popperjs/core": "^2.11.6",
     "bootstrap": "^5.2.2",
     "compare-versions": "^5.0.3",

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -14,6 +14,14 @@
     .fa-lg {
       aspect-ratio: 1 / 1;
     }
+
+    // FA v7 has redesigned fa-moon with a ~14% larger crescent glyph, where the
+    // path grew from 16x18.66px to 18.36x21.33px within the same SVG canvas).
+    // We can scale it back to the old value, to match the visual weight of the
+    // other theme icons.
+    &.fa-moon {
+      transform: scaleX(0.871459695) scaleY(0.8748241913);
+    }
   }
 }
 

--- a/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_switcher-theme.scss
@@ -16,7 +16,7 @@
     }
 
     // FA v7 has redesigned fa-moon with a ~14% larger crescent glyph, where the
-    // path grew from 16x18.66px to 18.36x21.33px within the same SVG canvas).
+    // path grew from 16x18.66px to 18.36x21.33px within the same SVG canvas.
     // We can scale it back to the old value, to match the visual weight of the
     // other theme icons.
     &.fa-moon {

--- a/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_fonts.scss
@@ -47,4 +47,3 @@ html {
 }
 
 $line-height-body: 1.65;
-$fa-font-path: "vendor/fontawesome/webfonts/";

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -13,7 +13,12 @@
           {% set attributeString = attributeString | join(" ") -%}
           <a {{ attributeString }}>
             {%- if type == "fontawesome" -%}
+            {%- set icon_parts = icon.split() -%}
+            {%- if icon_parts[0] == "fa-custom" -%}
+            <i class="{{ icon_parts[0] }} fa-lg" data-prefix="{{ icon_parts[0] }}" data-icon="{{ icon_parts[1][3:] }}" aria-hidden="true"></i>
+            {%- else -%}
             <i class="{{ icon }} fa-lg" aria-hidden="true"></i>
+            {%- endif -%}
             <span class="visually-hidden">{{ name }}</span>
             {%- elif type == "local" -%}
             <img src="{{ pathto(icon, 1) }}" class="icon-link-image" alt="{{ name }}"/>

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -14,7 +14,7 @@
           <a {{ attributeString }}>
             {%- if type == "fontawesome" -%}
             <i class="{{ icon }} fa-lg" aria-hidden="true"></i>
-            <span class="sr-only">{{ name }}</span>
+            <span class="visually-hidden">{{ name }}</span>
             {%- elif type == "local" -%}
             <img src="{{ pathto(icon, 1) }}" class="icon-link-image" alt="{{ name }}"/>
             {%- elif type == "url" -%}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/icon-links.html
@@ -15,6 +15,13 @@
             {%- if type == "fontawesome" -%}
             {%- set icon_parts = icon.split() -%}
             {%- if icon_parts[0] == "fa-custom" -%}
+            {#-
+              FA v7 no longer resolves custom icon prefixes from CSS class names alone.
+              We can keep the fa-custom class for DOM discovery and add these
+              data-prefix/data-icon attributes to ensure the custom icon is rendered, and
+              that the prefix is resolved correctly. See the discussion at
+              https://github.com/pydata/pydata-sphinx-theme/pull/2370#discussion_r3178092050
+            -#}
             <i class="{{ icon_parts[0] }} fa-lg" data-prefix="{{ icon_parts[0] }}" data-icon="{{ icon_parts[1][3:] }}" aria-hidden="true"></i>
             {%- else -%}
             <i class="{{ icon }} fa-lg" aria-hidden="true"></i>

--- a/tests/test_build/navbar_icon_links.html
+++ b/tests/test_build/navbar_icon_links.html
@@ -3,7 +3,7 @@
   <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site1.org" rel="noopener" target="_blank" title="FONTAWESOME">
    <i aria-hidden="true" class="FACLASS fa-lg">
    </i>
-   <span class="sr-only">
+   <span class="visually-hidden">
     FONTAWESOME
    </span>
   </a>
@@ -12,7 +12,7 @@
   <a class="nav-link pst-navbar-icon" data-bs-placement="bottom" data-bs-toggle="tooltip" href="https://site2.org" rel="noopener" target="_blank" title="FONTAWESOME DEFAULT">
    <i aria-hidden="true" class="FADEFAULTCLASS fa-lg">
    </i>
-   <span class="sr-only">
+   <span class="visually-hidden">
     FONTAWESOME DEFAULT
    </span>
   </a>
@@ -38,7 +38,7 @@
   <a class="overridden classes" data-bs-placement="bottom" data-bs-toggle="tooltip" foo="bar" href="https://override.com" rel="noopener" target="_blank" title="FONTAWESOME">
    <i aria-hidden="true" class="FACLASS fa-lg">
    </i>
-   <span class="sr-only">
+   <span class="visually-hidden">
     FONTAWESOME
    </span>
   </a>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -155,7 +155,7 @@ var config = {
     },
     {
       // Font vendoring and management - will separate FA and export the font files
-      test: /\.(woff|woff2|eot|ttf|otf)$/i,
+      test: /\.woff2$/i,
       type: 'asset/resource',
       generator: {
         filename: 'vendor/fontawesome/webfonts/[name][ext]'


### PR DESCRIPTION
Closes #2317. This PR makes the following changes:
- Bumps the JavaScript dependency to v7.2.0
- Replaces the use of the `sr-only` classes with [Bootstrap v5's `visually-hidden`](https://getbootstrap.com/docs/5.3/helpers/visually-hidden/) ([docs](https://getbootstrap.com/docs/5.3/getting-started/accessibility/#visually-hidden-content))
- Legacy font formats have been removed, so I removed a Webpack config regex that used to look for them. It now only looks for `.woff2` font files.
- Removes a dead code path for `fa-font-path` since the variable has been renamed (see my explanation in https://github.com/pydata/pydata-sphinx-theme/pull/2370#discussion_r3177826975).
- Uses `data-prefix` and `data-icon` HTML attributes for `fa-custom` icons (see my explanation in https://github.com/pydata/pydata-sphinx-theme/pull/2370#discussion_r3178092050).
- The moon icon in the theme switcher has a larger glyph now. It went from 16×18.66px to 18.36×21.33px, so I brought it back to the previous size. I would welcome suggestions to improve this.

Other visual changes I could notice:
- [The House icon](https://fontawesome.com/icons/house?f=classic&s=solid) in the breadcrumbs changed slightly. Honestly, I like the new one!
