### PR TITLE
feat(theme): add sticky_version_warning_banner option

### DIFF
--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -94,6 +94,24 @@ In addition to the general-purpose announcement banner, the theme includes a bui
     version compares greater than the preferred version (or if the version match contains the strings `"dev"`,
     `"rc"` or `"pre"`), the announcement will say they are viewing an unstable development version instead.
 
+Stick the warning banner to the top of the viewport
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default the version warning banner scrolls off-screen with the rest of the page,
+which can hide the warning when users land on a deep-link inside an old-version page.
+To keep the banner visible while users scroll, set:
+
+.. code-block:: python
+    :caption: conf.py
+
+    html_theme_options = {
+        ...
+        "sticky_version_warning_banner": True,
+    }
+
+This sticks the entire banner wrapper (version warning plus any announcement)
+to the top of the viewport. Default is ``False``.
+
 If you want similar functionality for *older* versions of your docs (i.e. those built before the ``show_version_warning_banner`` configuration option was available), you can manually add a banner by prepending the following HTML to all pages (be sure to replace ``URL_OF_STABLE_VERSION_OF_PROJECT`` with a valid URL, and adjust styling as desired):
 
 .. code-block:: html

--- a/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
@@ -13,6 +13,14 @@
   }
 }
 
+.pst-async-banner-revealer.pst-sticky-banners {
+  position: sticky;
+  top: 0;
+
+  // Above the fixed header (which uses z-index inside the bd-navbar).
+  z-index: 1030;
+}
+
 #bd-header-version-warning,
 .bd-header-announcement {
   min-height: 3rem;

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
@@ -1,5 +1,9 @@
 {#- The "revealer" allows async banners to be loaded, revealed, and animated together in a controlled way -#}
-<div class="pst-async-banner-revealer d-none">
+{%- set revealer_classes = "pst-async-banner-revealer d-none" -%}
+{%- if theme_sticky_version_warning_banner | tobool -%}
+  {%- set revealer_classes = revealer_classes + " pst-sticky-banners" -%}
+{%- endif -%}
+<div class="{{ revealer_classes }}">
 {#- Version warning banner is always loaded remotely/asynchronously #}
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="{{ _('Version warning') }}"></aside>
 {#- But the announcement banner might be loaded locally or remotely -#}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -55,6 +55,7 @@ footer_center =
 footer_end = theme-version
 secondary_sidebar_items = page-toc, edit-this-page, sourcelink
 show_version_warning_banner = False
+sticky_version_warning_banner = False
 announcement =
 
 # DEPRECATED (remove after 1.0 release)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -352,6 +352,29 @@ def test_remote_announcement_banner(sphinx_build_factory) -> None:
     assert "pst-async-banner-revealer" in banner.parent["class"]
 
 
+def test_sticky_version_warning_banner_on(sphinx_build_factory) -> None:
+    """When the option is True, the revealer carries the sticky class."""
+    confoverrides = {
+        "html_theme_options.sticky_version_warning_banner": True,
+    }
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
+    index_html = sphinx_build.html_tree("index.html")
+    results = index_html.find_all(class_="pst-async-banner-revealer")
+
+    assert len(results) == 1
+    assert "pst-sticky-banners" in results[0]["class"]
+
+
+def test_sticky_version_warning_banner_default_off(sphinx_build_factory) -> None:
+    """The sticky class is absent by default (no behavior change for existing users)."""
+    sphinx_build = sphinx_build_factory("base").build()
+    index_html = sphinx_build.html_tree("index.html")
+    results = index_html.find_all(class_="pst-async-banner-revealer")
+
+    assert len(results) == 1
+    assert "pst-sticky-banners" not in results[0]["class"]
+
+
 @pytest.mark.parametrize(
     "align,klass",
     [


### PR DESCRIPTION
## Summary

Adds a `sticky_version_warning_banner` theme option (default `False`). When `True`, the `pst-async-banner-revealer` wrapper carries a `pst-sticky-banners` class with `position: sticky; top: 0; z-index: 1030`, keeping the warning (plus any announcement banner in the same wrapper) visible while the user scrolls.

Closes #2328. @Carreau invited a PR in the issue thread.

## Why

The version-warning banner is positioned `relative`, so when a user lands on a section anchor of an old-version page (the example in the issue: `https://napari.org/0.6.0/api/napari.html#napari.save_layers`), the banner is already scrolled past and there's no indication the page is stale. Existing users get no behavior change because the option defaults to off.

## Files changed

- `src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf` (+1): new option, default `False`
- `src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html` (+5/-1): conditional `pst-sticky-banners` class on the revealer
- `src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss` (+8): `position: sticky` rule keyed off the new class
- `docs/user_guide/announcements.rst` (+18): sub-section under "Version warning banners" describing the option
- `tests/test_build.py` (+23): two tests covering on / default-off

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_build.py -k "sticky_version_warning or local_announcement or remote_announcement" -q`: 4 passed
- `pre-commit run --files <changed files>`: passed (stylelint auto-formatted the new SCSS block; included in the commit)

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
