### PR TITLE
Docs update PyTorch logo URL

### DIFF
--- a/docs/community/inspiration.md
+++ b/docs/community/inspiration.md
@@ -20,7 +20,7 @@ When making new decisions about design and UI/UX, we often consult these themes 
   image: ../_static/inspiration/docker-mark-blue.svg
 - title: "**PyTorch**"
   link: https://docs.pytorch.org/docs/stable/index.html
-  image: https://docs.pytorch.org/docs/stable/_static/img/logo-dark.svg
+  image: https://raw.githubusercontent.com/pytorch/pytorch/main/docs/source/_static/img/pytorch-logo-dark.svg
 - title: "**Docasaurus**"
   link: https://docusaurus.io/docs
   image: https://d33wubrfki0l68.cloudfront.net/c088b7acfcf11100903c44fe44f2f2d7e0f30531/47727/img/docusaurus.svg


### PR DESCRIPTION
This PR fixes the URL of the PyTorch logo used in the documentation.
https://pydata-sphinx-theme.readthedocs.io/en/stable/community/inspiration.html

Previously, the docs referenced the PyTorch stable documentation URL.
However, static files under `_static` are not redirected from `stable` to a versioned path, which causes the link checker to fail.

This change replaces the URL with the GitHub raw file URL instead.

- Closes #2332 