### PR TITLE
Update internal github actions tags

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -134,7 +134,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
@@ -190,7 +190,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           # 3.14 is not supported by py-spy yet
           python-version: "3.13"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           pandoc: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -92,7 +92,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@a4986faa4b8241e041634d39ca6ed0e30c175240
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@178df7a9d69695be4e49fa56822d76b048977387
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
       # calls our docs workflow (build docs, check broken links, lighthouse)
   docs:
     # Important: make sure to update the SHA after making any changes to the docs workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@a4986faa4b8241e041634d39ca6ed0e30c175240
+    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@178df7a9d69695be4e49fa56822d76b048977387
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
 


### PR DESCRIPTION
Sphinx 7 was [dropped](https://github.com/pydata/pydata-sphinx-theme/pull/2366), but actions references older shas => release failed because the outdated CI is trying to build for sphinx 7.

https://github.com/pydata/pydata-sphinx-theme/actions/runs/25695535093/job/75442657882