### PR TITLE
Update internal CI action pin for tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
   # calls our general CI workflows (tests, coverage, profile, etc.)
   tests:
     # Important: make sure to update the SHA after making any changes to the CI workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@cd00a86a87aba3903543c00c5ce5f009c436e0b1
+    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@178df7a9d69695be4e49fa56822d76b048977387
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
     # needed for the coverage action

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -4,9 +4,9 @@
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/latest/"
   },
   {
-    "name": "0.18.0rc0",
-    "version": "v0.18.0rc0",
-    "url": "https://pydata-sphinx-theme.readthedocs.io/en/v0.18.0rc0/"
+    "name": "0.18.0rc1",
+    "version": "v0.18.0rc1",
+    "url": "https://pydata-sphinx-theme.readthedocs.io/en/v0.18.0rc1/"
   },
   {
     "name": "0.17.1 (stable)",

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -17,7 +17,7 @@ from sphinx.errors import ExtensionError
 from . import edit_this_page, logo, pygments, short_link, toctree, translator, utils
 
 
-__version__ = "0.18.0rc0"
+__version__ = "0.18.0rc1"
 
 
 def update_config(app):


### PR DESCRIPTION
Forgotten line in initial PR #2381. Unblocks #2376.

No more outdated pins left: `grep -rn "pydata/pydata-sphinx-theme/.github" /Users/yann/oss/pydata-sphinx-theme/.github/ | grep "@" | grep -v "178df7a9"` => empty