### PR TITLE
Fix the stickiness of the version warning banner, and rename the config option to `sticky_banners`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,6 +201,8 @@ html_theme_options = {
     # "show_nav_level": 2,
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
     "show_version_warning_banner": True,
+    # Temporary for testing. TODO remove before merging
+    "sticky_version_warning_banner": True,
     "navbar_center": ["version-switcher", "navbar-nav"],
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -201,8 +201,6 @@ html_theme_options = {
     # "show_nav_level": 2,
     "announcement": "https://raw.githubusercontent.com/pydata/pydata-sphinx-theme/main/docs/_templates/custom-template.html",
     "show_version_warning_banner": True,
-    # Temporary for testing. TODO remove before merging
-    "sticky_version_warning_banner": True,
     "navbar_center": ["version-switcher", "navbar-nav"],
     # "navbar_start": ["navbar-logo"],
     # "navbar_end": ["theme-switcher", "navbar-icon-links"],

--- a/docs/user_guide/announcements.rst
+++ b/docs/user_guide/announcements.rst
@@ -94,23 +94,25 @@ In addition to the general-purpose announcement banner, the theme includes a bui
     version compares greater than the preferred version (or if the version match contains the strings `"dev"`,
     `"rc"` or `"pre"`), the announcement will say they are viewing an unstable development version instead.
 
-Stick the warning banner to the top of the viewport
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Stick banners to the top of the viewport
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default the version warning banner scrolls off-screen with the rest of the page,
 which can hide the warning when users land on a deep-link inside an old-version page.
-To keep the banner visible while users scroll, set:
+To keep the version warning banner and the announcement banner pinned to the top of
+the viewport while users scroll, set:
 
 .. code-block:: python
     :caption: conf.py
 
     html_theme_options = {
         ...
-        "sticky_version_warning_banner": True,
+        "sticky_banners": True,
     }
 
-This sticks the entire banner wrapper (version warning plus any announcement)
-to the top of the viewport. Default is ``False``.
+This pins both the version warning banner and the announcement banner (whether
+local or remote) above the navbar at the top of the viewport. Default is
+``False``.
 
 If you want similar functionality for *older* versions of your docs (i.e. those built before the ``show_version_warning_banner`` configuration option was available), you can manually add a banner by prepending the following HTML to all pages (be sure to replace ``URL_OF_STABLE_VERSION_OF_PROJECT`` with a valid URL, and adjust styling as desired):
 

--- a/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_announcement.scss
@@ -13,14 +13,6 @@
   }
 }
 
-.pst-async-banner-revealer.pst-sticky-banners {
-  position: sticky;
-  top: 0;
-
-  // Above the fixed header (which uses z-index inside the bd-navbar).
-  z-index: 1030;
-}
-
 #bd-header-version-warning,
 .bd-header-announcement {
   min-height: 3rem;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -5,8 +5,8 @@
 
 // Styling for the Icon links can be found in components/_icon-links.scss
 
-// A wrapper used when `sticky_version_warning_banner` is enabled. It pins the
-// announcement/version-warning banners and the navbar at the top of the viewport.
+// A wrapper used when `sticky_banners` is enabled. It pins the announcement /
+// version-warning banners and the navbar at the top of the viewport.
 .pst-sticky-header {
   position: sticky;
   top: 0;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_header.scss
@@ -5,6 +5,20 @@
 
 // Styling for the Icon links can be found in components/_icon-links.scss
 
+// A wrapper used when `sticky_version_warning_banner` is enabled. It pins the
+// announcement/version-warning banners and the navbar at the top of the viewport.
+.pst-sticky-header {
+  position: sticky;
+  top: 0;
+  z-index: $zindex-fixed;
+
+  // The .bd-header (top navbar) inside the wrapper must not be sticky on its
+  // own, as .pst-sticky-header above is already sticky.
+  .bd-header {
+    position: static;
+  }
+}
+
 // If we want the shadow to only point downward in the future, set
 // box-shadow to: 0 0.125rem 0.25rem -0.125rem rgba(0, 0, 0, 0.11);
 .bd-header {

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -81,6 +81,11 @@
   {%- endif %}
   {%- endblock search_dialog %}
 
+  {%- set pst_stick_banners = theme_sticky_version_warning_banner | tobool -%}
+  {%- if pst_stick_banners %}
+  <div class="pst-sticky-header">
+  {%- endif %}
+
   {% include "sections/announcement.html" %}
 
   {% block docs_navbar %}
@@ -88,6 +93,10 @@
       {%- include "sections/header.html" %}
     </header>
   {% endblock docs_navbar %}
+
+  {%- if pst_stick_banners %}
+  </div>
+  {%- endif %}
 
   <div class="bd-container">
     <div class="bd-container__inner bd-page-width">

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/layout.html
@@ -81,7 +81,7 @@
   {%- endif %}
   {%- endblock search_dialog %}
 
-  {%- set pst_stick_banners = theme_sticky_version_warning_banner | tobool -%}
+  {%- set pst_stick_banners = theme_sticky_banners | tobool -%}
   {%- if pst_stick_banners %}
   <div class="pst-sticky-header">
   {%- endif %}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/announcement.html
@@ -1,9 +1,5 @@
 {#- The "revealer" allows async banners to be loaded, revealed, and animated together in a controlled way -#}
-{%- set revealer_classes = "pst-async-banner-revealer d-none" -%}
-{%- if theme_sticky_version_warning_banner | tobool -%}
-  {%- set revealer_classes = revealer_classes + " pst-sticky-banners" -%}
-{%- endif -%}
-<div class="{{ revealer_classes }}">
+<div class="pst-async-banner-revealer d-none">
 {#- Version warning banner is always loaded remotely/asynchronously #}
   <aside id="bd-header-version-warning" class="d-none d-print-none" aria-label="{{ _('Version warning') }}"></aside>
 {#- But the announcement banner might be loaded locally or remotely -#}

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -55,7 +55,7 @@ footer_center =
 footer_end = theme-version
 secondary_sidebar_items = page-toc, edit-this-page, sourcelink
 show_version_warning_banner = False
-sticky_version_warning_banner = False
+sticky_banners = False
 announcement =
 
 # DEPRECATED (remove after 1.0 release)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -352,12 +352,12 @@ def test_remote_announcement_banner(sphinx_build_factory) -> None:
     assert "pst-async-banner-revealer" in banner.parent["class"]
 
 
-def test_sticky_version_warning_banner_on(sphinx_build_factory) -> None:
+def test_sticky_banners_on(sphinx_build_factory) -> None:
     """When the option is True, the banner and the navbar are wrapped in a
     sticky container.
     """
     confoverrides = {
-        "html_theme_options.sticky_version_warning_banner": True,
+        "html_theme_options.sticky_banners": True,
     }
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     index_html = sphinx_build.html_tree("index.html")
@@ -369,7 +369,7 @@ def test_sticky_version_warning_banner_on(sphinx_build_factory) -> None:
     assert wrapper.find(id="pst-header") is not None
 
 
-def test_sticky_version_warning_banner_default_off(sphinx_build_factory) -> None:
+def test_sticky_banners_default_off(sphinx_build_factory) -> None:
     """The sticky class is absent by default (no behavior change for existing users)."""
     sphinx_build = sphinx_build_factory("base").build()
     index_html = sphinx_build.html_tree("index.html")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -353,26 +353,29 @@ def test_remote_announcement_banner(sphinx_build_factory) -> None:
 
 
 def test_sticky_version_warning_banner_on(sphinx_build_factory) -> None:
-    """When the option is True, the revealer carries the sticky class."""
+    """When the option is True, the banner and the navbar are wrapped in a
+    sticky container.
+    """
     confoverrides = {
         "html_theme_options.sticky_version_warning_banner": True,
     }
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     index_html = sphinx_build.html_tree("index.html")
-    results = index_html.find_all(class_="pst-async-banner-revealer")
+    wrappers = index_html.find_all(class_="pst-sticky-header")
 
-    assert len(results) == 1
-    assert "pst-sticky-banners" in results[0]["class"]
+    assert len(wrappers) == 1
+    wrapper = wrappers[0]
+    assert wrapper.find(class_="pst-async-banner-revealer") is not None
+    assert wrapper.find(id="pst-header") is not None
 
 
 def test_sticky_version_warning_banner_default_off(sphinx_build_factory) -> None:
     """The sticky class is absent by default (no behavior change for existing users)."""
     sphinx_build = sphinx_build_factory("base").build()
     index_html = sphinx_build.html_tree("index.html")
-    results = index_html.find_all(class_="pst-async-banner-revealer")
 
-    assert len(results) == 1
-    assert "pst-sticky-banners" not in results[0]["class"]
+    assert not index_html.find_all(class_="pst-sticky-header")
+    assert len(index_html.find_all(class_="pst-async-banner-revealer")) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR renames the `sticky_version_warning_banner` theme configuration option to `sticky_banners` and fixes issues reported in #2328 after the initial fix landed in #2372.

The fix is that the stickiness moves one level up. I've added `.pst-sticky-header` which wraps both the `.pst-async-banner-revealer` banner and the `.bd-header` navbar. The rule also overrides `.bd-header { position: sticky }` for the navbar inside the wrapper to neutralise its effect.

**[EDIT: Resolved!]** ~There is no behaviour change besides the fix, but I do have some additional thoughts below: https://github.com/pydata/pydata-sphinx-theme/pull/2385#issuecomment-4450982544~

Closes #2328

### Some screenshots

<details><summary>Click to expand</summary>
<p>

| Scenario | Screenshot |
|--------|--------|
| Default view on the home page | <img width="5088" height="2978" alt="Default view on the home page" src="https://github.com/user-attachments/assets/f00bfdef-d2c2-47bc-990d-546574e63e33" /> |
| Scrolled down on the home page, the version warning banner still remains sticky | <img width="5088" height="2978" alt="image" src="https://github.com/user-attachments/assets/c6d07c6d-a8b6-41f8-92a3-732b7d8de6e5" /> |
| Navigated to a new page that's not the home page | <img width="5088" height="2978" alt="image" src="https://github.com/user-attachments/assets/e54b0c86-573d-40ac-b25e-bab093cd1bdc" /> |
| Navigated to a new page that's not the home page, and scrolled down from the top | <img width="5088" height="2978" alt="image" src="https://github.com/user-attachments/assets/130a4919-4acc-410d-ab0f-c80f31d45b15" /> |
| Navigated to a new page that's not the home page, with the announcement banner checked off, default view | <img width="5088" height="2978" alt="image" src="https://github.com/user-attachments/assets/6767943d-c988-4841-a06f-0002bcc2c8be" /> | 
| Navigated to a new page that's not the home page, with the announcement banner checked off, and scrolled down from the top | <img width="5088" height="2978" alt="image" src="https://github.com/user-attachments/assets/58041152-c583-47f3-855c-b77bc5d37849" /> | 

</p>
</details> 

