### PR TITLE
Fix theme dropdown menu going offscreen

### DIFF
--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/components/theme-switcher.html
@@ -6,7 +6,7 @@
     <i class="theme-switch fa-solid fa-moon fa-lg fa-fw" data-mode="dark" title="{{ _('Dark') }}"></i>
     <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto" title="{{ _('System Settings') }}"></i>
   </button>
-  <ul class="dropdown-menu">
+  <ul class="dropdown-menu dropdown-menu-end">
     <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto"><i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1"></i>{{ _('System Settings') }}</button></li>
     <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="light"><i class="fa-solid fa-sun fa-lg fa-fw me-1"></i>{{ _('Light') }}</button></li>
     <li><button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="dark"><i class="fa-solid fa-moon fa-lg fa-fw me-1"></i>{{ _('Dark') }}</button></li>

--- a/tests/test_build/navbar_theme.html
+++ b/tests/test_build/navbar_theme.html
@@ -7,7 +7,7 @@
   <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto" title="System Settings">
   </i>
  </button>
- <ul class="dropdown-menu">
+ <ul class="dropdown-menu dropdown-menu-end">
   <li>
    <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto">
     <i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1">

--- a/tests/test_build/sidebar_subpage.html
+++ b/tests/test_build/sidebar_subpage.html
@@ -42,7 +42,7 @@
       <i class="theme-switch fa-solid fa-circle-half-stroke fa-lg fa-fw" data-mode="auto" title="System Settings">
       </i>
      </button>
-     <ul class="dropdown-menu">
+     <ul class="dropdown-menu dropdown-menu-end">
       <li>
        <button class="dropdown-item d-flex align-items-center theme-change-button" data-mode="auto">
         <i class="fa-solid fa-circle-half-stroke fa-lg fa-fw me-1">


### PR DESCRIPTION
This pull request fixes the position of the theme dropdown menu.

Previously, when the theme dropdown was located on the far right side of the page, the dropdown menu went offscreen.
This change aligns the right edge of the dropdown menu with the dropdown button.

- Closes #2384