### PR TITLE
bump: 0.18.0rc1 → 0.18.0rc2

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,7 @@ These steps should be taken in order to create a new release![^release-refs]
 - [ ] Confirm that the release completed
   - [The `publish` github action job](https://github.com/pydata/pydata-sphinx-theme/blob/main/.github/workflows/publish.yml#L31) has completed successfully in the [actions tab](https://github.com/pydata/pydata-sphinx-theme/actions).
   - [The PyPI version is updated](https://pypi.org/project/pydata-sphinx-theme/)
+- [ ] If it's a pre-release, activate it in RDT interface (Add version).
 - [ ] Hide the previous patch version build in the RDT interface if needed.
 - [ ] Open a new PR to bump the version to the next dev target (e.g. `0.2.1.dev0`) in [`__init__.py`](https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/__init__.py#L16)
 - [ ] Celebrate, you're done!

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -4,9 +4,9 @@
     "url": "https://pydata-sphinx-theme.readthedocs.io/en/latest/"
   },
   {
-    "name": "0.18.0rc1",
-    "version": "v0.18.0rc1",
-    "url": "https://pydata-sphinx-theme.readthedocs.io/en/v0.18.0rc1/"
+    "name": "0.18.0rc2",
+    "version": "v0.18.0rc2",
+    "url": "https://pydata-sphinx-theme.readthedocs.io/en/v0.18.0rc2/"
   },
   {
     "name": "0.17.1 (stable)",

--- a/docs/community/practices/release.md
+++ b/docs/community/practices/release.md
@@ -38,6 +38,12 @@ Follow these steps to make a release:
 - **Copy the [release checklist](https://github.com/pydata/pydata-sphinx-theme/blob/main/RELEASE.md) into a new issue**.
 - **Complete the checklist**. That's it!
 
+### Release candidates
+
+If you choose to add the release candidate to the switcher.json, it will not be deployed by default on Read the Docs and cause a 404.
+
+To deploy it, go to the [RTD panel](https://app.readthedocs.org/projects/pydata-sphinx-theme/), Add version, select the release candidate tag and set it to Hidden and Active.
+
 ## Choosing a version increment
 
 We use [semantic versioning](https://semver.org/) to decide whether it's a major, minor, or patch bump. Before we have released `1.0`, treat minor versions as breaking releases, and patch versions as feature / patch releases. **If this is a release candidate**, tag it like `0.1rc1`.

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -17,7 +17,7 @@ from sphinx.errors import ExtensionError
 from . import edit_this_page, logo, pygments, short_link, toctree, translator, utils
 
 
-__version__ = "0.18.0rc1"
+__version__ = "0.18.0rc2"
 
 
 def update_config(app):


### PR DESCRIPTION
#2376 

Includes these two fixes: https://github.com/pydata/pydata-sphinx-theme/pull/2385 https://github.com/pydata/pydata-sphinx-theme/pull/2387

I think we can release the "proper" 0.18.0 very soon after :)