### PR TITLE
Docs update Font Awesome links

### DIFF
--- a/docs/user_guide/extending.rst
+++ b/docs/user_guide/extending.rst
@@ -169,7 +169,7 @@ And add the following to your ``custom.css`` file:
 Using a custom icon
 -------------------
 
-Customizing the icon uses a similar process to customizing the color: create a new CSS class in your `custom.css <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files>`__ file. The theme supports `fontawesome v7 icons <https://fontawesome.com/v7.2/search?o=r&m=free&f=brands>`__ ("free" and "brands" sets). To use an icon, copy its unicode value into your custom class as shown in the CSS tab below:
+Customizing the icon uses a similar process to customizing the color: create a new CSS class in your `custom.css <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files>`__ file. The theme supports `fontawesome v7 icons <https://fontawesome.com/v7/search?ip=brands&ic=free-collection>`__ ("free" and "brands" sets). To use an icon, copy its unicode value into your custom class as shown in the CSS tab below:
 
 .. begin-example-icon
 .. admonition:: Check out my custom icon

--- a/docs/user_guide/header-links.rst
+++ b/docs/user_guide/header-links.rst
@@ -89,7 +89,7 @@ and brand-specific icons (e.g. "GitHub").
 You can use FontAwesome icons by specifying ``"type": "fontawesome"``, and
 specifying a FontAwesome class in the ``icon`` value.
 The value of ``icon`` can be any full
-`FontAwesome 7 Free <https://fontawesome.com/v7.2/search?o=r&m=free>`__ icon.
+`FontAwesome 7 Free <https://fontawesome.com/v7/search?ic=free-collection>`__ icon.
 In addition to the main icon class, e.g. ``fa-cat``, the "style" class must
 also be provided e.g. `fa-brands` for *branding*, or `fa-solid` for *solid*.
 


### PR DESCRIPTION
This pull request updates fontawesome links in the documentation.

when running `tox run -e docs-linkcheck`,  redirect warnings were detected.

```
/home/runner/work/pydata-sphinx-theme/pydata-sphinx-theme/docs/user_guide/extending.rst:172: WARNING: redirect  https://fontawesome.com/v7.2/search?o=r&m=free&f=brands - with Found to https://fontawesome.com/v7/search?o=r&m=free&f=brands
/home/runner/work/pydata-sphinx-theme/pydata-sphinx-theme/docs/user_guide/header-links.rst:89: WARNING: redirect  https://fontawesome.com/v7.2/search?o=r&m=free - with Found to https://fontawesome.com/v7/search?o=r&m=free
``` 

This PR updates the documentation to use the current Font Awesome v7 URLs and query parameters to avoid redirects.