### PR TITLE
Fix gettext builder

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -294,6 +294,10 @@ def _fix_canonical_url(
 
 def add_shorten_xform(app: Sphinx) -> None:
     """Add the link shortening transform."""
+    # Non-HTML builders (e.g. sphinx-build -b gettext, MessageCatalogBuilder)
+    # have no theme
+    if not hasattr(app.builder, "theme"):
+        return
     theme_options = utils.get_theme_options_dict(app)
     theme_conf_options = app.builder.theme.get_options()
     if (theme_conf_options | theme_options).get("shorten_urls"):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -23,6 +23,20 @@ def test_theme_loaded_as_extension(sphinx_build_factory) -> None:
     sphinx_build.build(no_warning=False)
 
 
+def test_gettext_builder(sphinx_build_factory) -> None:
+    """Non-HTML builders (gettext) have no builder.theme, #2402."""
+    sphinx_build = sphinx_build_factory(
+        "base",
+        buildername="gettext",
+        confoverrides={
+            "extensions": ["pydata_sphinx_theme"],
+            "html_theme_options": {"shorten_urls": True},
+        },
+    )
+    sphinx_build.build(no_warning=False)
+    assert (sphinx_build.outdir / "index.pot").exists()
+
+
 def test_build_html(sphinx_build_factory, file_regression) -> None:
     """Test building the base html template and config."""
     sphinx_build = sphinx_build_factory("base")


### PR DESCRIPTION
Building the message catalogs with the gettext builder (make gettext / sphinx-build -b gettext) fails when pydata_sphinx_theme is enabled. The theme's builder-inited handler add_shorten_xform unconditionally accesses app.builder.theme, but non-HTML builders such as the gettext MessageCatalogBuilder do not have a theme attribute, so the build aborts before extracting any strings.

https://github.com/pydata/pydata-sphinx-theme/issues/2402

Co-Authored-By: @basti982