### PR TITLE
Fix vertical scrollbar in math container

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/content/_math.scss
+++ b/src/pydata_sphinx_theme/assets/styles/content/_math.scss
@@ -39,7 +39,7 @@ div.math {
   mjx-container {
     flex-grow: 1;
     padding-bottom: 0.2rem;
-    overflow: auto;
+    overflow: auto hidden;
 
     // Set height to 0 so that it does not cause scrollbars to appear
     // ref: https://github.com/mathjax/MathJax/issues/2521


### PR DESCRIPTION
This pull request fixes an unnecessary vertical scrollbar in MathJax equations.

Closes #2312