### PR TITLE
Drop Sphinx <= 8.1, Python <= 3.10

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // container instruction for codespace users
 {
   "name": "Python 3",
-  "image": "mcr.microsoft.com/devcontainers/python:1-3.10-bullseye",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bullseye",
   "features": {
     "ghcr.io/devcontainers-contrib/features/tox:2": {},
     "ghcr.io/devcontainers-contrib/features/nox:2": {},

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,27 +44,18 @@ jobs:
         # ubuntu-24.04==latest
         # windows-2022==latest
         os: ["ubuntu-latest", "ubuntu-22.04", "macos-14", "windows-latest"]
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
         sphinx-version: [""]
         include:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             sphinx-version: "8.2"
             # newest Python version with the newest Sphinx version
           - os: ubuntu-latest
             python-version: "3.14"
             # Sphinx HEAD
             sphinx-version: "dev"
-        exclude:
-          # Python 3.10 is not supported on arm64 darwin - https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-          - os: macos-14
-            python-version: "3.10"
-          # do not need all the tests so will limit to the latest versions of Python
-          - os: ubuntu-24.04
-            python-version: "3.10"
-          - os: ubuntu-24.04
-            python-version: "3.10"
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository 🛎"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
             python-version: "3.10"
-            sphinx-version: "8.0"
+            sphinx-version: "8.2"
             # newest Python version with the newest Sphinx version
           - os: ubuntu-latest
             python-version: "3.14"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
             python-version: "3.10"
-            sphinx-version: "8.0"
+            sphinx-version: "8.2"
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository 🛎"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
         include:
           # oldest Python version with the oldest Sphinx version
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             sphinx-version: "8.2"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.11", "3.14"]
 
     steps:
       - name: "Checkout repository 🛎"
@@ -53,20 +53,20 @@ jobs:
 
       - name: "Build and inspect package 📦"
         uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # 2.18.0
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         id: baipp
         with:
           # pydantic-core (via PyO3) does not yet support Python 3.14
           python-version: "3.13"
 
       - run: echo Packages can be found at "${BAIPP_DIST}"
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
 
       # Run tests on the built package (which will be later uploaded to PyPI)
       - name: "Install PST from wheel and test"
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         env:
           BAIPP_DIST: ${{ steps.baipp.outputs.dist }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "Setup Python 🐍"
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # 6.2.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - run: python -Im pip install tox-uv
 

--- a/docs/community/topics/manual-dev.md
+++ b/docs/community/topics/manual-dev.md
@@ -17,7 +17,7 @@ To do so, use a tool like [conda](https://docs.conda.io/en/latest/), [mamba](htt
 
 Before you start, ensure that you have the following installed:
 
-- Python >= 3.10
+- Python >= 3.11
 - [Pandoc](https://pandoc.org/): we use `nbsphinx` to support notebook (`.ipynb`) files in the documentation, which requires [installing Pandoc](https://pandoc.org/installing.html) at a system level (or within a Conda environment).
 
 ## Clone the repository locally

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -11,13 +11,6 @@ myst:
 You can configure the behavior, look, and feel of the theme in many ways.
 The remaining pages in the user guide cover various ways of doing so.
 
-```{danger}
-This theme is still under active development, and we make no promises
-about the stability of any specific HTML structure, CSS variables, etc.
-Make these customizations at your own risk, and pin versions if you're
-worried about breaking changes!
-```
-
 There are a number of options for configuring your site's look and feel.
 All configuration options are passed with the `html_theme_options` variable in your `conf.py` file.
 This is a dictionary with `key: val` pairs that you can configure in various ways.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dynamic = ["version"]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "sphinx>=8.0,<10",
+  "sphinx>=8.2,<10",
   "beautifulsoup4",
   "docutils!=0.17.0",
   "Babel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ name = "pydata-sphinx-theme"
 description = "Bootstrap-based Sphinx theme from the PyData community"
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
   "sphinx>=8.2,<10",
   "beautifulsoup4",
@@ -37,7 +37,6 @@ maintainers = [
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands =
 # run tests without coverage
 # tox run -e compile-assets,i18n-compile,py310-tests-no-cov
 # by default we will retain playwright traces on failure
-[testenv:py3{10,11,12,13,14}{,-sphinx82,-sphinxdev,}-tests{,-no-cov}]
+[testenv:py3{11,12,13,14}{,-sphinx82,-sphinxdev,}-tests{,-no-cov}]
 description = "Run tests Python and Sphinx versions. If a Sphinx version is specified, it will use that version vs the default in pyproject.toml"
 # need to ensure the package is installed in editable mode
 package = editable
@@ -66,7 +66,7 @@ extras =
 pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 deps =
     coverage[toml]
-    py310-sphinx82-tests: sphinx~=8.2.0
+    py311-sphinx82-tests: sphinx~=8.2.0
     py314-sphinxdev: sphinx[test] @ git+https://github.com/sphinx-doc/sphinx.git@master
 depends =
     compile-assets,
@@ -76,8 +76,8 @@ allowlist_externals=
     bash
 commands =
     bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
-    py3{10,11,12,13,14}{,-sphinx82,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
-    py3{10,11,12,13,14}{,-sphinx82,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{11,12,13,14}{,-sphinx82,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{11,12,13,14}{,-sphinx82,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
 
 # run accessibility tests with Playwright and axe-core
 # compiling the assets is needed before running the tests
@@ -108,15 +108,15 @@ commands =
 # since we are building the documentation we install the packaged dev version of PST
 # tox run -e py310-docs
 # tox run -e py310-sphinx82-docs
-[testenv:py3{10,14}{,-sphinx82}-docs]
+[testenv:py3{11,14}{,-sphinx82}-docs]
 description = build the documentation and place in docs/_build/html
 # suppress Py3.11's new "can't debug frozen modules" warning
 set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 # keep this in sync across all docs environments
 extras = {[testenv:docs-no-checks]extras}
 deps =
-    py310-sphinx82-docs: sphinx~=8.2.0
-    py310-sphinx82-docs: astroid>=3.0,!=4.0.3
+    py311-sphinx82-docs: sphinx~=8.2.0
+    py311-sphinx82-docs: astroid>=3.0,!=4.0.3
 depends =
     compile-assets,
     i18n-compile

--- a/tox.ini
+++ b/tox.ini
@@ -53,11 +53,11 @@ commands =
 # the tests without `compile-assets,i18n-compile`, for example:
 # tox run -e py310-tests
 # run tests with a specific Sphinx version
-# tox run -e compile-assets,i18n-compile,py310-sphinx80-tests
+# tox run -e compile-assets,i18n-compile,py310-sphinx82-tests
 # run tests without coverage
 # tox run -e compile-assets,i18n-compile,py310-tests-no-cov
 # by default we will retain playwright traces on failure
-[testenv:py3{10,11,12,13,14}{,-sphinx80,-sphinxdev,}-tests{,-no-cov}]
+[testenv:py3{10,11,12,13,14}{,-sphinx82,-sphinxdev,}-tests{,-no-cov}]
 description = "Run tests Python and Sphinx versions. If a Sphinx version is specified, it will use that version vs the default in pyproject.toml"
 # need to ensure the package is installed in editable mode
 package = editable
@@ -66,7 +66,7 @@ extras =
 pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions
 deps =
     coverage[toml]
-    py310-sphinx80-tests: sphinx~=8.0.0
+    py310-sphinx82-tests: sphinx~=8.2.0
     py314-sphinxdev: sphinx[test] @ git+https://github.com/sphinx-doc/sphinx.git@master
 depends =
     compile-assets,
@@ -76,8 +76,8 @@ allowlist_externals=
     bash
 commands =
     bash -c 'if [[ "{env:GITHUB_ACTIONS:}" == "true" ]]; then playwright install --with-deps; else playwright install; fi'
-    py3{10,11,12,13,14}{,-sphinx80,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
-    py3{10,11,12,13,14}{,-sphinx80,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{10,11,12,13,14}{,-sphinx82,-sphinxdev,}-tests: coverage run -m pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
+    py3{10,11,12,13,14}{,-sphinx82,-sphinxdev,}-tests-no-cov: pytest -m "not a11y" {posargs:--tracing=retain-on-failure}
 
 # run accessibility tests with Playwright and axe-core
 # compiling the assets is needed before running the tests
@@ -107,16 +107,16 @@ commands =
 # build PST documentation with the default or a specific Sphinx version
 # since we are building the documentation we install the packaged dev version of PST
 # tox run -e py310-docs
-# tox run -e py310-sphinx80-docs
-[testenv:py3{10,14}{,-sphinx80}-docs]
+# tox run -e py310-sphinx82-docs
+[testenv:py3{10,14}{,-sphinx82}-docs]
 description = build the documentation and place in docs/_build/html
 # suppress Py3.11's new "can't debug frozen modules" warning
 set_env = PYDEVD_DISABLE_FILE_VALIDATION=1
 # keep this in sync across all docs environments
 extras = {[testenv:docs-no-checks]extras}
 deps =
-    py310-sphinx80-docs: sphinx~=8.0.0
-    py310-sphinx80-docs: astroid>=3.0,!=4.0.3
+    py310-sphinx82-docs: sphinx~=8.2.0
+    py310-sphinx82-docs: astroid>=3.0,!=4.0.3
 depends =
     compile-assets,
     i18n-compile


### PR DESCRIPTION
Sphinx 8.0 and 8.1 are from 2024, https://www.sphinx-doc.org/en/master/changes/index.html

Keeping 8.2 for now conservatively even though it is more than 1 year old

EDIT: dropping Sphinx 8.1 means dropping Python 3.10, because [Sphinx 8.2 dropped 3.10](https://www.sphinx-doc.org/en/master/changes/8.2.html#dependencies)... should we wait for Python 3.10 to reach end of life later this year to merge this?

WARNING: follow-up needed after merging: bumping all internal pins, https://github.com/pydata/pydata-sphinx-theme/issues/2383 - or Github actions will fail during next release.