### PR TITLE
Bump internal actions ; Bump pyupgrade options to 3.7+ -> 3.11+

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -125,7 +125,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
@@ -189,7 +189,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           # 3.14 is not supported by py-spy yet
           python-version: "3.13"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           pandoc: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -92,7 +92,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: "Setup CI environment 🛠"
         # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@047227ad41f26a993ea7b2182955d26aa837acea
+        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@562617b8cf2f4e86e159641a800415a71ee861af
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
   # calls our general CI workflows (tests, coverage, profile, etc.)
   tests:
     # Important: make sure to update the SHA after making any changes to the CI workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@047227ad41f26a993ea7b2182955d26aa837acea
+    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@562617b8cf2f4e86e159641a800415a71ee861af
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
     # needed for the coverage action
@@ -30,7 +30,7 @@ jobs:
       # calls our docs workflow (build docs, check broken links, lighthouse)
   docs:
     # Important: make sure to update the SHA after making any changes to the docs workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@047227ad41f26a993ea7b2182955d26aa837acea
+    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@562617b8cf2f4e86e159641a800415a71ee861af
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py311-plus]
 
   - repo: "https://github.com/Riverside-Healthcare/djLint"
     rev: v1.36.4

--- a/docs/_extension/component_directive.py
+++ b/docs/_extension/component_directive.py
@@ -8,7 +8,7 @@ GitHub file.
 import re
 
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from docutils import nodes
 from sphinx.application import Sphinx
@@ -33,7 +33,7 @@ class ComponentListDirective(SphinxDirective):
     optional_arguments = 0
     final_argument_whitespace = True
 
-    def run(self) -> List[nodes.Node]:
+    def run(self) -> list[nodes.Node]:
         """Create the list."""
         # get the list of all th jinja templates
         # not that to remain compatible with sphinx they are labeled as html files
@@ -84,7 +84,7 @@ class ComponentListDirective(SphinxDirective):
         return [nodes.bullet_list("", *items)]
 
 
-def setup(app: Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, Any]:
     """Add custom configuration to sphinx app.
 
     Args:

--- a/docs/_extension/gallery_directive.py
+++ b/docs/_extension/gallery_directive.py
@@ -10,7 +10,7 @@ but might be abstracted into a standalone package if it proves useful.
 """
 
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -67,7 +67,7 @@ class GalleryGridDirective(SphinxDirective):
         "class-card": directives.unchanged,
     }
 
-    def run(self) -> List[nodes.Node]:
+    def run(self) -> list[nodes.Node]:
         """Create the gallery grid."""
         if self.arguments:
             # If an argument is given, assume it's a path to a YAML file
@@ -128,7 +128,7 @@ class GalleryGridDirective(SphinxDirective):
         return [container.children[0]]
 
 
-def setup(app: Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, Any]:
     """Add custom configuration to sphinx app.
 
     Args:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,13 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
-intersphinx_mapping = {"sphinx": ("https://www.sphinx-doc.org/en/master", None)}
+intersphinx_mapping = {
+    "sphinx": ("https://www.sphinx-doc.org/en/master", None),
+    # Sphinx treats typing.* as reftype = 'obj' but pyupgrade moved
+    # from typing.* in favor of collections.abc (reftype = 'class'),
+    # whose references are not found without the following line:
+    "python": ("https://docs.python.org/3", None),
+}
 
 # -- Sitemap -----------------------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from sphinx.application import Sphinx
 from sphinx.locale import _
@@ -350,7 +350,7 @@ def setup_to_main(
     context["to_main"] = to_main
 
 
-def setup(app: Sphinx) -> Dict[str, Any]:
+def setup(app: Sphinx) -> dict[str, Any]:
     """Add custom configuration to sphinx app.
 
     Args:

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -4,7 +4,6 @@ import json
 
 from functools import partial
 from pathlib import Path
-from typing import Dict
 from urllib.parse import urlparse
 
 import requests
@@ -310,7 +309,7 @@ def add_shorten_xform(app: Sphinx) -> None:
         app.add_post_transform(short_link.ShortenLinkTransform)
 
 
-def setup(app: Sphinx) -> Dict[str, str]:
+def setup(app: Sphinx) -> dict[str, str]:
     """Setup the Sphinx application."""
     here = Path(__file__).parent.resolve()
     theme_path = here / "theme" / "pydata_sphinx_theme"

--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -1,10 +1,10 @@
 """Methods to build the toctree used in the html pages."""
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import cache
 from itertools import count
 from textwrap import dedent
-from typing import Iterator, List, Tuple, Union
 from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
@@ -114,7 +114,7 @@ def add_toctree_functions(
         return next(get_or_create_id_generator(base_id))
 
     @cache
-    def _generate_nav_info() -> List[LinkInfo]:
+    def _generate_nav_info() -> list[LinkInfo]:
         """Generate informations necessary to generate nav.
 
         Instead of messing with html later, having this as a util function
@@ -196,7 +196,7 @@ def add_toctree_functions(
     @cache
     def _generate_header_nav_before_dropdown(
         n_links_before_dropdown,
-    ) -> Tuple[str, List[str]]:
+    ) -> tuple[str, list[str]]:
         """Return html for navbar and dropdown.
 
         Given the number of links before the dropdown, return the html for the navbar,
@@ -310,7 +310,7 @@ def add_toctree_functions(
     @cache
     def generate_toctree_html(
         kind: str, startdepth: int = 1, show_nav_level: int = 1, **kwargs
-    ) -> Union[BeautifulSoup, str]:
+    ) -> BeautifulSoup | str:
         """Return the navigation link structure in HTML.
 
         This is similar to Sphinx's own default TocTree generation, but it is modified
@@ -460,7 +460,7 @@ def add_toctree_functions(
         else:
             return soup
 
-    def navbar_align_class() -> List[str]:
+    def navbar_align_class() -> list[str]:
         """Return the class that aligns the navbar based on config."""
         align = context.get("theme_navbar_align", "content")
         align_options = {

--- a/src/pydata_sphinx_theme/utils.py
+++ b/src/pydata_sphinx_theme/utils.py
@@ -4,14 +4,15 @@ import copy
 import os
 import re
 
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from collections.abc import Callable, Iterable
+from typing import Any
 
 from docutils.nodes import Node
 from sphinx.application import Sphinx
 from sphinx.util import logging, matching
 
 
-def get_theme_options_dict(app: Sphinx) -> Dict[str, Any]:
+def get_theme_options_dict(app: Sphinx) -> dict[str, Any]:
     """Return theme options for the application w/ a fallback if they don't exist.
 
     The "top-level" mapping (the one we should usually check first, and modify
@@ -38,7 +39,7 @@ def config_provided_by_user(app: Sphinx, key: str) -> bool:
 
 
 def traverse_or_findall(
-    node: Node, condition: Union[Callable, type], **kwargs
+    node: Node, condition: Callable | type, **kwargs
 ) -> Iterable[Node]:
     """Triage node.traverse (docutils <0.18.1) vs node.findall.
 
@@ -90,11 +91,11 @@ def set_secondary_sidebar_items(
 
 def _update_and_remove_templates(
     app: Sphinx,
-    context: Dict[str, Any],
-    templates: Union[List, str],
+    context: dict[str, Any],
+    templates: list | str,
     section: str,
-    templates_skip_empty_check: Optional[List[str]] = None,
-) -> List[str]:
+    templates_skip_empty_check: list[str] | None = None,
+) -> list[str]:
     """
     Update templates to include html suffix if needed; remove templates which render
     empty.
@@ -155,8 +156,8 @@ def _update_and_remove_templates(
 
 
 def _get_matching_sidebar_items(
-    pagename: str, sidebars: Dict[str, List[str]]
-) -> List[str]:
+    pagename: str, sidebars: dict[str, list[str]]
+) -> list[str]:
     """Get the matching sidebar templates to render for the given pagename.
 
     If a page matches more than one pattern, a warning is emitted, and the templates

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,18 +3,18 @@
 import re
 import time
 
+from collections.abc import Callable
 from http.client import HTTPConnection
 from os import environ
 from pathlib import Path
 from shutil import copytree
 from subprocess import PIPE, Popen
-from typing import Callable
+from typing import Self
 
 import pytest
 
 from bs4 import BeautifulSoup
 from sphinx.testing.util import SphinxTestApp
-from typing_extensions import Self
 
 
 pytest_plugins = "sphinx.testing.fixtures"

--- a/tests/intermittent_warning_list.txt
+++ b/tests/intermittent_warning_list.txt
@@ -2,8 +2,3 @@ WARNING: Cell printed to stderr:
 Matplotlib is building the font cache; this may take a moment.
 WARNING: failed to reach any of the inventories with the following issues:
 intersphinx inventory
-# THE FOLLOWING 4 LINES WILL GO AWAY WHEN OUR MIN SPHINX VERSION IS 7.3 OR HIGHER (because 7.3 introduces the versionremoved directive)
-We also support *italic*, **bold**, ``code``, `links <https://www.sphinx-doc.org/en/master/>`_, and more.
-Here's a version removed message.
-.. versionremoved:: v0.1.1
-ERROR: Unknown directive type "versionremoved".

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -6,8 +6,8 @@ to `tests/sites/` or use an existing one.
 
 import re
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 from urllib.parse import urljoin
 
 import pytest


### PR DESCRIPTION
8196a14b76a38ea8ac09b962ed8f97973e4b6c7e is follow-up of https://github.com/pydata/pydata-sphinx-theme/pull/2412 (see also https://github.com/pydata/pydata-sphinx-theme/issues/2383) 

bumping pyupgrade options in .pre-commit-config.yaml that I missed in the above PR, automatic code changes ensued