### PR TITLE
Fix incorrect tox env name in prerelease docs build step

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -42,8 +42,8 @@ jobs:
 
       - name: "Build PST docs and check for warnings 📖"
         run: |
-          # example substitution: tox run -e docs-py312-docs
-          python -Im tox run -e docs-py$(echo ${{ matrix.python-version }} | tr -d .)-docs -- --keep-going
+          # example substitution: tox run -e py312-docs
+          python -Im tox run -e py$(echo ${{ matrix.python-version }} | tr -d .)-docs -- --keep-going
 
       - name: "Run tests ✅ (no coverage)"
         run: |


### PR DESCRIPTION
Closes #2418

## Summary

The "Build PST docs and check for warnings 📖" step in `prerelease.yml` invoked `tox run -e docs-pyXXX-docs`, but no tox environment with that name is defined in `tox.ini`. tox silently composed an empty environment from the factor pattern and exited successfully without running `sphinx-build`, so the scheduled prerelease docs check has been passing while doing nothing.

This PR drops the stray `docs-` prefix so the step calls the real `pyXXX-docs` environment defined at `tox.ini:111` (`[testenv:py3{11,14}{,-sphinx82}-docs]`). The accompanying example comment was updated to match.

## Verification

I temporarily bypassed the `repository_owner == 'pydata'` guard on my fork and manually triggered the workflow against both the broken and fixed code.

**Before fix (`docs-py311-docs` — malformed):** the step finishes in ~22s. tox sets up a venv from the `py311` factor and installs base packages, then exits with `OK` — `sphinx-build` is never invoked and no docs are rendered.

https://github.com/yyccPhil/pydata-sphinx-theme/actions/runs/27667788899

**After fix (`py311-docs` — real env):** the step actually runs `sphinx-build -b html docs/ docs/_build/html -nTv -w warnings.txt`, launches Sphinx 9.0.4, and renders the project's documentation (AutoAPI reading files, etc.). Total step time is in the minutes range, as expected for a real docs build.

https://github.com/yyccPhil/pydata-sphinx-theme/actions/runs/27667654927