### PR TITLE
Unpin internal actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,5 @@
 # This workflow runs our usual CI jobs: testing with pytest, profiling,
 # and coverage checks for PST
-# IMPORTANT: if you make changes to this workflow, you will need to open a follow-up
-# PR after merge to update the action SHA in the publish workflow
 
 name: continuous-integration
 
@@ -64,8 +62,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -125,7 +122,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 
@@ -189,7 +186,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           # 3.14 is not supported by py-spy yet
           python-version: "3.13"

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
           pandoc: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@
 # Python, and Sphinx versions.
 # It also checks for broken links in the documentation and runs Lighthouse audits
 # on the built site.
-# IMPORTANT: if you make changes to this workflow, you will need to open a follow-up
-# PR after merge to update the action SHA in the publish workflow
 
 name: docs-checks
 
@@ -60,8 +58,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true
@@ -91,8 +88,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment"
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           python-version: ${{ env.DEFAULT_PYTHON_VERSION }}
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -30,8 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: "Setup CI environment 🛠"
-        # Important: make sure to update the SHA after making any changes to the set-dev-env action
-        uses: pydata/pydata-sphinx-theme/.github/actions/set-dev-env@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+        uses: ./.github/actions/set-dev-env
         with:
           python-version: ${{ matrix.python-version }}
           pandoc: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,7 @@ permissions:
 jobs:
   # calls our general CI workflows (tests, coverage, profile, etc.)
   tests:
-    # Important: make sure to update the SHA after making any changes to the CI workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/CI.yml@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+    uses: ./.github/workflows/CI.yml
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
     # needed for the coverage action
@@ -29,8 +28,7 @@ jobs:
       actions: read
       # calls our docs workflow (build docs, check broken links, lighthouse)
   docs:
-    # Important: make sure to update the SHA after making any changes to the docs workflow
-    uses: pydata/pydata-sphinx-theme/.github/workflows/docs.yml@620d9ebd05ecde3df5d4a09b563c2d62c468634c
+    uses: ./.github/workflows/docs.yml
     # only run this workflow for pydata owned repositories (avoid forks)
     if: github.repository_owner == 'pydata'
 


### PR DESCRIPTION
Closes https://github.com/pydata/pydata-sphinx-theme/issues/2383.

This was introduced on purpose by
https://github.com/pydata/pydata-sphinx-theme/commit/4a1e7898d6c92dade5e489684277ab4ffd0eb053

It makes sense to pin external actions for security but it has been a recurring footgun when it comes to internal actions:

- every change in docs or CI has to be followed-up by a PR to re-pin the actions
- if this step is forgotten, and it has happened two times already, it only fails during the release.
- dependabot is inconsistent, opens 1 PR per pin and does not open all necessary PRs