### PR TITLE
fix: stabilize Read the Docs Ubuntu image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,9 +3,9 @@ version: 2
 formats:
   - htmlzip
 
-# build with latest available ubuntu version
+# Build with a supported Ubuntu LTS version for Playwright/Chromium.
 build:
-  os: ubuntu-lts-latest
+  os: ubuntu-24.04
   tools:
     python: "3.12"
   # need to install playwright deps via apt (lack of sudo means we can't use

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
   # `playwright install-deps`).  NB: Graphviz is a separate dep urelated to playwright
   apt_packages:
     - graphviz
-    - libasound2
+    - libasound2t64
     - libdbus-glib-1-2
   jobs:
     # build the gallery of themes before building the doc


### PR DESCRIPTION
## Summary
- Pin the Read the Docs build image to `ubuntu-24.04` instead of the moving `ubuntu-lts-latest` alias.
- Replace `libasound2` with the concrete Ubuntu package `libasound2t64` so Chromium audio dependencies remain installable.

## Testing
- [x] `python3 -u /tmp/verify_rtd_yaml.py`
- [x] `python3 -u /tmp/fetch_rtd_docs.py`
- [x] `git diff --check`

Closes #2428
