### PR TITLE
Add helper release script to bump version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,9 @@ These steps should be taken in order to create a new release![^release-refs]
 
 - [ ] Bump `__version__` in [`__init__.py`](https://github.com/pydata/pydata-sphinx-theme/blob/main/src/pydata_sphinx_theme/__init__.py#L16)
 - [ ] Update our [version switcher `.json` file](https://github.com/pydata/pydata-sphinx-theme/blob/main/docs/_static/switcher.json) with the new version
+
+The two above steps can be done automatically with `python tools/bump_version.py 0.2.0`.
+
 - [ ] Make a release commit: `git commit -m 'bump: 0.1.9 → 0.2.0'`
 - [ ] Push the RLS commit `git push upstream main`
 - [ ] If a **release candidate** is needed, tick this box when we're now ready for a full release.

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,77 @@
+"""Tests for tools/bump_version.py."""
+
+import importlib.util
+
+from pathlib import Path
+
+
+spec = importlib.util.spec_from_file_location(
+    "bump_version", Path(__file__).parents[1] / "tools" / "bump_version.py"
+)
+bump_version = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bump_version)
+
+DEV = {"version": "dev", "url": f"{bump_version.DOCS_URL}/en/latest/"}
+
+
+def stable_entry(version):
+    """Build the switcher entry for the current stable `version`."""
+    return {
+        "name": f"{version} (stable)",
+        "version": f"v{version}",
+        "url": f"{bump_version.DOCS_URL}/en/stable/",
+        "preferred": True,
+    }
+
+
+def archived_entry(version):
+    """Build the switcher entry for a past, non-stable `version`."""
+    return {
+        "name": version,
+        "version": f"v{version}",
+        "url": f"{bump_version.DOCS_URL}/en/v{version}/",
+    }
+
+
+def test_bump_to_rc_inserts_a_new_entry():
+    """A release candidate bump inserts a new entry, keeping stable in place."""
+    entries = [DEV, stable_entry("0.18.0")]
+
+    entries = bump_version.compute_new_entries(entries, "0.18.0", "0.19.0rc0")
+
+    assert entries == [
+        DEV,
+        {
+            "name": "0.19.0rc0",
+            "version": "v0.19.0rc0",
+            "url": f"{bump_version.DOCS_URL}/en/v0.19.0rc0/",
+        },
+        stable_entry("0.18.0"),
+    ]
+
+
+def test_bump_rc_to_rc_updates_in_place():
+    """A new candidate for the same release updates the rc entry in place."""
+    entries = [DEV, archived_entry("0.19.0rc0"), stable_entry("0.18.0")]
+
+    entries = bump_version.compute_new_entries(entries, "0.19.0rc0", "0.19.0rc1")
+
+    assert entries == [DEV, archived_entry("0.19.0rc1"), stable_entry("0.18.0")]
+
+
+def test_bump_from_rc_to_final_promotes_and_demotes():
+    """A final release promotes its rc entry and demotes the old stable."""
+    entries = [DEV, archived_entry("0.19.0rc0"), stable_entry("0.18.0")]
+
+    entries = bump_version.compute_new_entries(entries, "0.19.0rc0", "0.19.0")
+
+    assert entries == [DEV, stable_entry("0.19.0"), archived_entry("0.18.0")]
+
+
+def test_bump_without_a_preceding_rc_demotes_current_stable():
+    """With no rc entry to promote, the current stable itself is demoted."""
+    entries = [DEV, stable_entry("0.18.0")]
+
+    entries = bump_version.compute_new_entries(entries, "0.18.0", "0.18.1")
+
+    assert entries == [DEV, stable_entry("0.18.1"), archived_entry("0.18.0")]

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,98 @@
+"""Bump the theme version and update the version switcher.
+
+Usage:
+    python tools/bump_version.py <new_version>
+
+Updates __init__.py.
+
+Updates switcher.json:
+- stable to stable: update preferred entry to new version, create entry for the previous
+- rc to stable: update preferred entry to new version, remove the rc.
+- stable to rc: don't touch the preferred entry, add the rc
+- rc to rc: don't touch the preferred entry, replace the old rc by the new rc.
+"""
+
+import json
+import re
+import sys
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+INIT_PY = ROOT / "src/pydata_sphinx_theme/__init__.py"
+SWITCHER_JSON = ROOT / "docs/_static/switcher.json"
+DOCS_URL = "https://pydata-sphinx-theme.readthedocs.io"
+
+
+def read_version():
+    """Read the current `__version__` from `__init__.py`."""
+    return re.search(r'__version__ = "(.*)"', INIT_PY.read_text()).group(1)
+
+
+def write_version(new_version):
+    """Overwrite `__version__` in `__init__.py` with `new_version`."""
+    pattern = r'__version__ = ".*"'
+    text = re.sub(pattern, f'__version__ = "{new_version}"', INIT_PY.read_text())
+    INIT_PY.write_text(text)
+
+
+def compute_new_entries(entries, old_version, new_version):
+    """Update the switcher `entries` in place for `old_version` -> `new_version`."""
+    current = next((e for e in entries if e["version"] == f"v{old_version}"), None)
+    was_rc = current is not None and not current.get("preferred")
+
+    if "rc" in new_version:
+        if was_rc:
+            # Another candidate for the same release: update it in place.
+            current["name"] = new_version
+            current["version"] = f"v{new_version}"
+            current["url"] = f"{DOCS_URL}/en/v{new_version}/"
+        else:
+            entries.insert(
+                1,
+                {
+                    "name": new_version,
+                    "version": f"v{new_version}",
+                    "url": f"{DOCS_URL}/en/v{new_version}/",
+                },
+            )
+        return entries
+
+    if was_rc:
+        stable = next(e for e in entries if e.get("preferred"))
+        stable["name"] = stable["version"].removeprefix("v")
+        stable["url"] = f"{DOCS_URL}/en/{stable['version']}/"
+        del stable["preferred"]
+    else:
+        # No release candidate preceded this release: demote it ourselves.
+        entries.insert(
+            entries.index(current) + 1,
+            {
+                "name": old_version,
+                "version": f"v{old_version}",
+                "url": f"{DOCS_URL}/en/v{old_version}/",
+            },
+        )
+
+    current["name"] = f"{new_version} (stable)"
+    current["version"] = f"v{new_version}"
+    current["url"] = f"{DOCS_URL}/en/stable/"
+    current["preferred"] = True
+    return entries
+
+
+def main(new_version):
+    """Bump `__init__.py` and the switcher to `new_version`."""
+    old_version = read_version()
+    write_version(new_version)
+
+    switcher = json.loads(SWITCHER_JSON.read_text())
+    entries = compute_new_entries(switcher, old_version, new_version)
+    SWITCHER_JSON.write_text(json.dumps(entries, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):
+        sys.exit(f"usage: {sys.argv[0]} <new_version>")
+    main(sys.argv[1])


### PR DESCRIPTION
Updating the switcher.json in particular is tedious and can be error-prone.

Change documented in RELEASE.md.

Assisted-By: Claude 4.8