### PR TITLE
CSS: Prevent back-to-top button from being cropped on mobile

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/base/_base.scss
+++ b/src/pydata_sphinx_theme/assets/styles/base/_base.scss
@@ -178,6 +178,7 @@ pre {
   top: 90vh;
   left: 50vw;
   transform: translate(-50%);
+  overflow: visible;
   color: var(--pst-color-secondary-text);
   background-color: var(--pst-color-secondary);
   border: none;


### PR DESCRIPTION
Add overflow: visible to the #pst-back-to-top button to prevent it from being cropped on mobile browsers with button navigation.

Closes #2411