### PR TITLE
Tox run a11y-tests correctly defaults to chromium ; add doc to run a single test.

### DIFF
--- a/docs/community/setup.md
+++ b/docs/community/setup.md
@@ -237,6 +237,16 @@ $ tox run -m tests
 $ tox run -e tests-no-cov
 ```
 
+To run a single test in any pytest-based test environment, pass a pytest `-k`
+expression after `--`:
+
+```console
+$ tox run -e py314-tests-no-cov -- -k=test_theme_loaded_as_extension
+```
+
+The `-k` expression matches test names by substring. The same syntax works with
+other test environments, such as `a11y-tests`.
+
 To run the accessibility checks:
 
 ```console
@@ -246,15 +256,6 @@ $ tox run -m a11y
 # to run the tests without pre-compiling the assets and without re-building the docs (for example if you recently compiled the assets or built the docs)
 $ tox run -e a11y-tests
 ```
-
-To run a single accessibility test, pass a pytest `-k` expression after `--`:
-
-```console
-$ tox run -e a11y-tests -- -k=test_search_as_you_type
-```
-
-The `-k` expression matches test names by substring. The `a11y-tests` environment
-expects the assets and documentation to have already been built, as described above.
 
 ## GitHub Codespaces
 

--- a/docs/community/setup.md
+++ b/docs/community/setup.md
@@ -247,6 +247,15 @@ $ tox run -m a11y
 $ tox run -e a11y-tests
 ```
 
+To run a single accessibility test, pass a pytest `-k` expression after `--`:
+
+```console
+$ tox run -e a11y-tests -- -k=test_search_as_you_type
+```
+
+The `-k` expression matches test names by substring. The `a11y-tests` environment
+expects the assets and documentation to have already been built, as described above.
+
 ## GitHub Codespaces
 
 If you have good internet connectivity and want a temporary set-up, it is often faster to work on the PyData Sphinx Theme

--- a/docs/community/setup.md
+++ b/docs/community/setup.md
@@ -241,7 +241,7 @@ To run a single test in any pytest-based test environment, pass a pytest `-k`
 expression after `--`:
 
 ```console
-$ tox run -e py314-tests-no-cov -- -k=test_theme_loaded_as_extension
+$ tox run -e py314-tests-no-cov -- -k test_theme_loaded_as_extension
 ```
 
 The `-k` expression matches test names by substring. The same syntax works with

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ commands =
 # by default we will retain playwright traces on failure and run the tests on chromium
 # to run the tests on firefox you can call:
 # tox run -e compile,py314-docs,a11y-tests-firefox
-[testenv:a11y-tests{-chromium,-firefox}]
+[testenv:a11y-tests{,-chromium,-firefox}]
 description = "run accessibility tests with Playwright and axe-core"
 base_python = py314 # keep in sync with tests.yml
 pass_env = GITHUB_ACTIONS # so we can check if this is run on GitHub Actions


### PR DESCRIPTION
## Summary

- make the bare `a11y-tests` tox environment default to Chromium
- document pytest `-k` forwarding generically for pytest-based tox environments
- keep the accessibility commands consistent with the executable tox environment

Closes #2092.

## Validation

- `uvx --with tox-uv tox c -e a11y-tests` resolves to the Chromium accessibility pytest command
- targeted pre-commit whitespace and end-of-file checks pass
- `git diff --check`