### PR TITLE
Fix navbar rendering for special pages in toctree

### DIFF
--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -157,11 +157,22 @@ def add_toctree_functions(
                 # sanitize page title for use in the html output if needed
                 if title is None:
                     title = ""
-                    for node in app.env.titles[page].children:
-                        if isinstance(node, nodes.math):
-                            title += add_inline_math(node)
-                        else:
-                            title += node.astext()
+                    if page in app.env.titles:
+                        for node in app.env.titles[page].children:
+                            if isinstance(node, nodes.math):
+                                title += add_inline_math(node)
+                            else:
+                                title += node.astext()
+                    elif page == "genindex":
+                        title = _("Index")
+                    elif page == "modindex":
+                        title = _("Python Module Index")
+                    elif page == "search":
+                        title = _("Search")
+                    else:
+                        raise RuntimeError(
+                            f"Could not find title for toctree entry: {page!r}"
+                        )
 
                 # set up the status of the link and the path
                 # if the path is relative then we use the context for the path
@@ -169,7 +180,13 @@ def add_toctree_functions(
                 # If it's an absolute one then we use the external class and
                 # the complete url.
                 is_absolute = bool(urlparse(page).netloc)
-                link_href = page if is_absolute else context["pathto"](page)
+                link_href = (
+                    page
+                    if is_absolute
+                    else context["pathto"](
+                        "py-modindex" if page == "modindex" else page
+                    )
+                )
 
                 links_data.append(
                     LinkInfo(
@@ -615,6 +632,8 @@ def get_nonroot_toctree(
         kwargs["maxdepth"] = 0
     kwargs["maxdepth"] = int(kwargs["maxdepth"])
     # starting from ancestor page, recursively parse `toctree::` elements
+    if ancestorname not in toctree.env.tocs:
+        return None
     ancestor_doctree = toctree.env.tocs[ancestorname].deepcopy()
     toctrees = []
 

--- a/tests/sites/test_toc_special_docnames/conf.py
+++ b/tests/sites/test_toc_special_docnames/conf.py
@@ -1,0 +1,18 @@
+"""Test conf file."""
+
+# -- Project information -----------------------------------------------------
+
+project = "Test"
+copyright = "Test"
+author = "Test"
+
+# -- General configuration ---------------------------------------------------
+
+# root_doc = "index-* overridden in test"
+
+# -- Options for HTML output -------------------------------------------------
+
+html_theme = "pydata_sphinx_theme"
+
+# see https://github.com/sphinx-doc/sphinx/issues/13462
+linkcheck_allowed_redirects = {}

--- a/tests/sites/test_toc_special_docnames/index-custom.rst
+++ b/tests/sites/test_toc_special_docnames/index-custom.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+Test
+====
+
+.. toctree::
+    Custom & Page <page1>
+    Custom & Index <genindex>
+    Custom & Module Index <modindex>
+    Custom & Search <search>

--- a/tests/sites/test_toc_special_docnames/index-default.rst
+++ b/tests/sites/test_toc_special_docnames/index-default.rst
@@ -1,0 +1,10 @@
+:orphan:
+
+Test
+====
+
+.. toctree::
+    page1
+    genindex
+    modindex
+    search

--- a/tests/sites/test_toc_special_docnames/page1.rst
+++ b/tests/sites/test_toc_special_docnames/page1.rst
@@ -1,0 +1,4 @@
+.. module:: test
+
+The ``test`` module
+===================

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -583,6 +583,26 @@ def test_included_toc(sphinx_build_factory) -> None:
     assert included_page_html is not None
 
 
+@pytest.mark.parametrize("root", ["default", "custom"])
+def test_toc_special_docnames(sphinx_build_factory, file_regression, root) -> None:
+    """
+    Test that Sphinx project with TOC (.. toctree::) referencing genindex, modindex or
+    search virtual docnames can be successfully built.
+    """
+    # Regression test for #2446.
+    root_doc = f"index-{root}"
+    sphinx_build = sphinx_build_factory(
+        "test_toc_special_docnames", confoverrides={"root_doc": root_doc}
+    ).build()
+    index_html = sphinx_build.html_tree(f"{root_doc}.html")
+    navbar = index_html.select("ul.bd-navbar-elements")[0]
+    file_regression.check(
+        navbar.prettify(),
+        basename=f"test_toc_special_docnames_{root}",
+        extension=".html",
+    )
+
+
 def test_footer(sphinx_build_factory) -> None:
     """Test for expected footer contents."""
     overrides = {

--- a/tests/test_build/test_toc_special_docnames_custom.html
+++ b/tests/test_build/test_toc_special_docnames_custom.html
@@ -1,0 +1,22 @@
+<ul class="bd-navbar-elements navbar-nav">
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="page1.html">
+   Custom &amp; Page
+  </a>
+ </li>
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="genindex.html">
+   Custom &amp; Index
+  </a>
+ </li>
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="py-modindex.html">
+   Custom &amp; Module Index
+  </a>
+ </li>
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="search.html">
+   Custom &amp; Search
+  </a>
+ </li>
+</ul>

--- a/tests/test_build/test_toc_special_docnames_default.html
+++ b/tests/test_build/test_toc_special_docnames_default.html
@@ -1,0 +1,22 @@
+<ul class="bd-navbar-elements navbar-nav">
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="page1.html">
+   The test module
+  </a>
+ </li>
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="genindex.html">
+   Index
+  </a>
+ </li>
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="py-modindex.html">
+   Python Module Index
+  </a>
+ </li>
+ <li class="nav-item">
+  <a class="nav-link nav-internal" href="search.html">
+   Search
+  </a>
+ </li>
+</ul>


### PR DESCRIPTION
Support Sphinx virtual docnames "genindex", "modindex" and "search" in `generate_header_nav_html()`. Fixes #2446.

AI disclosure: PyCharm AI Assistant (chat mode, GPT-5.5 Medium) assisted with identifying the problem and refining the solution and the test case.