### PR TITLE
Fix empty search page when search_as_you_type and dirhtml is used

### DIFF
--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -263,8 +263,13 @@ def update_and_remove_templates(
         """
         app.add_js_file(None, body=js)
 
-    # Specify whether search-as-you-type should be used or not.
-    search_as_you_type = str(context["theme_search_as_you_type"]).lower()
+    # Specify whether search-as-you-type should be used or not. It is always
+    # off on the dedicated search page, where it would fight searchtools.js
+    # over the #search-results container.
+    if pagename == "search":
+        search_as_you_type = "false"
+    else:
+        search_as_you_type = str(context["theme_search_as_you_type"]).lower()
     app.add_js_file(
         None, body=f"DOCUMENTATION_OPTIONS.search_as_you_type = {search_as_you_type};"
     )

--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -329,12 +329,11 @@ var setupSearchButtons = () => {
  * to have that exact ID.
  */
 var setupSearchAsYouType = () => {
+  // False when the theme option is off, and also forced off by the Python
+  // html-page-context hook on the dedicated search page (search.html, or
+  // search/ under the dirhtml builder), where searchtools.js owns the
+  // #search-results container.
   if (!DOCUMENTATION_OPTIONS.search_as_you_type) {
-    return;
-  }
-
-  // Don't interfere with the default search UX on /search.html.
-  if (window.location.pathname.endsWith("/search.html")) {
     return;
   }
 


### PR DESCRIPTION
The setupSearchAsYouType guard checked for a pathname ending in
/search.html, which the dirhtml builder's search/ URL never matches, so
the inline search removed the search page's #search-results container
(searchtools.js's render target) and recreated it empty inside the
search dialog, leaving the page blank. The Escape-key handler reached
resetSearchAsYouTypeResults through a second path with the same effect,
even under the html builder.

Force the search_as_you_type flag off on the dedicated search page from
the html-page-context hook instead, mirroring the pagename == 'search'
guard in layout.html. That disables every inline-search entry point
there through the existing flag guards, for every builder, and the
pathname check becomes dead code.
