### PR TITLE
fix: don't share sidebars between pages with non-flat output URIs

### DIFF
--- a/src/pydata_sphinx_theme/toctree.py
+++ b/src/pydata_sphinx_theme/toctree.py
@@ -381,7 +381,11 @@ def add_toctree_functions(
         # large sites, so where possible we serve it from a cache instead
         # (see _sidebar_cache_key for when and _patch_cached_sidebar for how)
         cache_key = _sidebar_cache_key(
-            kind, ancestorname, pagename, show_nav_level, kwargs
+            kind,
+            ancestorname,
+            app.builder.get_target_uri(pagename),
+            show_nav_level,
+            kwargs,
         )
         if cache_key is not None:
             cached_html = _patch_cached_sidebar(
@@ -529,7 +533,7 @@ def add_toctree_functions(
 def _sidebar_cache_key(
     kind: str,
     ancestorname: str | None,
-    pagename: str,
+    page_uri: str,
     show_nav_level: int,
     kwargs: dict,
 ) -> tuple | None:
@@ -540,15 +544,23 @@ def _sidebar_cache_key(
     `collapse=True`), the resolved toctree has the same structure for every page
     under the same ancestor -- only the "current" markers (`current`/`active`
     classes and open `<details>`) and the relative link targets differ. So the
-    finished soup can be shared by all pages in the same directory (same
-    relative link targets) below the same ancestor, provided the "current"
-    markers are moved to each page's own toctree entry (_patch_cached_sidebar).
+    finished soup can be shared by all pages written to the same output
+    directory (same relative link targets) below the same ancestor, provided the
+    "current" markers are moved to each page's own toctree entry
+    (_patch_cached_sidebar).
+
+    `page_uri` is this page's output URI (`builder.get_target_uri()`), not its
+    docname: builders whose page URIs are directories rather than files (e.g.
+    "dirhtml") give every page its own output directory, so no two pages can
+    share a sidebar and nothing is cached for them.
     """
     if kind != "sidebar" or ancestorname is None or kwargs.get("collapse", True):
         return None
+    if not page_uri or page_uri.endswith("/"):
+        return None
     return (
         ancestorname,
-        posixpath.dirname(pagename),
+        posixpath.dirname(page_uri),
         show_nav_level,
         tuple(sorted(kwargs.items())),
     )

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 import sphinx.errors
 
+from bs4 import BeautifulSoup
+
 from pydata_sphinx_theme.utils import escape_ansi
 
 
@@ -569,16 +571,19 @@ def test_sidebars_show_nav_level0(sphinx_build_factory) -> None:
         assert "open" in ii.attrs
 
 
+@pytest.mark.parametrize("buildername", ["html", "dirhtml"])
 @pytest.mark.parametrize("show_nav_level", [0, 1, 2])
 def test_sidebar_toctree_cache(
-    sphinx_build_factory, make_app, monkeypatch, show_nav_level
+    sphinx_build_factory, make_app, monkeypatch, show_nav_level, buildername
 ):
     """Sidebars patched from the cache must be identical to freshly built ones.
 
     With collapse_navigation=False (the default), the sidebar of the second,
     third, ... page written in a given directory is produced by moving the
     "current" markers within a cached soup of a sibling page's sidebar instead
-    of being resolved from scratch (see generate_toctree_html).
+    of being resolved from scratch (see generate_toctree_html). "dirhtml" is
+    covered too: it gives every page its own output directory, so no two pages
+    can share a sidebar and the cache has to stay out of the way.
     """
     from pydata_sphinx_theme import toctree
 
@@ -593,16 +598,39 @@ def test_sidebar_toctree_cache(
 
     monkeypatch.setattr(toctree, "_move_current_markers", spy)
     confoverrides = {"html_theme_options.show_nav_level": show_nav_level}
-    build = sphinx_build_factory("sidebars", confoverrides=confoverrides).build()
-    assert any(hits), "no sidebar was served from the cache"
+    build = sphinx_build_factory(
+        "sidebars", confoverrides=confoverrides, buildername=buildername
+    ).build()
+    if buildername == "html":
+        assert any(hits), "no sidebar was served from the cache"
+    else:
+        assert not hits, "sidebars must not be shared when page URIs are not flat"
     with_cache = {
         path: path.read_text("utf8") for path in sorted(build.outdir.rglob("*.html"))
     }
+    # every sidebar link must point at a page that actually exists
+    for path, html in with_cache.items():
+        nav = BeautifulSoup(html, "html.parser").select_one("nav.bd-docs-nav")
+        if nav is None:
+            continue
+        for anchor in nav.select("a.reference.internal"):
+            href = anchor["href"]
+            if href == "#":
+                continue
+            target = (path.parent / href).resolve()
+            if target.is_dir():
+                target = target / "index.html"
+            assert target.exists(), f"{path}: dangling sidebar link {href!r}"
 
     # build again from scratch with every cache lookup missing (so each page's
     # sidebar is built the slow way) and check that all pages come out identical
     monkeypatch.setattr(toctree, "_move_current_markers", lambda *a, **kw: False)
-    app = make_app(srcdir=build.src, confoverrides=confoverrides, freshenv=True)
+    app = make_app(
+        srcdir=build.src,
+        confoverrides=confoverrides,
+        buildername=buildername,
+        freshenv=True,
+    )
     app.build()
     for path, cached_html in with_cache.items():
         assert path.read_text("utf8") == cached_html, path


### PR DESCRIPTION
The sidebar cache I added in #2449 broke things for the `dirhtml` builder. This fixes it by keying on `builder.get_target_uri()` instead. This also adds a test for "dirhtml" that checks that every sidebar link resolves to a page that exists.

Bug found and fixed using Claude Fable 5. I also confirmed the test fails on `main` without the fix.