### PR TITLE
fix: make the sidebar drawers behave, and stop resizes animating them

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -793,6 +793,30 @@ async function fetchAndUseVersions() {
 /*******************************************************************************
  * Sidebar modals (for mobile / narrow screens)
  */
+
+// The stylesheet publishes its sidebar breakpoints (variables/_layout.scss).
+// Without them the query never matches and a drawer just stays put on a
+// resize, which is the right degradation: no stylesheet, no drawer geometry.
+const inFlowAbove = (breakpointProperty) =>
+  window.matchMedia(
+    `(min-width: ${getComputedStyle(document.documentElement)
+      .getPropertyValue(breakpointProperty)
+      .trim()})`,
+  );
+
+// Focusing an element normally scrolls it into view, and the header is sticky,
+// so focusing anything in it would jump the page to the top.
+const FOCUS_WITHOUT_SCROLLING = { preventScroll: true };
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
 function setupMobileSidebarKeyboardHandlers() {
   // These are the left and right sidebars for wider screens. We cut and paste
   // the content from these widescreen sidebars into the mobile dialogs, when
@@ -821,40 +845,104 @@ function setupMobileSidebarKeyboardHandlers() {
     });
   };
 
-  // Hook up the ways to open and close the dialog
-  [
-    [primaryToggle, primaryDialog, primarySidebar],
-    [secondaryToggle, secondaryDialog, secondarySidebar],
-  ].forEach(([toggleButton, dialog, sidebar]) => {
-    if (!toggleButton || !dialog || !sidebar) {
+  // A drawer is one sidebar, the dialog its content moves into while it is
+  // open, the button that opens it, and the media query that matches while
+  // that sidebar belongs in the page flow rather than in a drawer.
+  const drawers = [
+    {
+      toggleButton: primaryToggle,
+      dialog: primaryDialog,
+      sidebar: primarySidebar,
+      inFlow: inFlowAbove("--pst-breakpoint-sidebar-primary"),
+    },
+    {
+      toggleButton: secondaryToggle,
+      dialog: secondaryDialog,
+      sidebar: secondarySidebar,
+      inFlow: inFlowAbove("--pst-breakpoint-sidebar-secondary"),
+    },
+  ].filter(
+    ({ toggleButton, dialog, sidebar }) => toggleButton && dialog && sidebar,
+  );
+
+  // getClientRects is non-empty even under `visibility: hidden`, where
+  // focus() would silently do nothing, so check the computed style too.
+  const isVisible = (element) =>
+    Boolean(element) &&
+    element.isConnected &&
+    element.getClientRects().length > 0 &&
+    getComputedStyle(element).visibility === "visible";
+
+  const anotherDrawerIsOpen = () => drawers.some(({ dialog }) => dialog.open);
+
+  // Where focus goes when a drawer closes: back to the button that opened it,
+  // or, when that button is gone because the sidebar returned to the page
+  // flow, to somewhere in the sidebar itself.
+  const focusToggleButton = ({ toggleButton }) => {
+    if (!isVisible(toggleButton)) {
+      return false;
+    }
+
+    toggleButton.focus(FOCUS_WITHOUT_SCROLLING);
+    return true;
+  };
+
+  const focusInsideSidebar = ({ sidebar }) => {
+    const target = Array.from(
+      sidebar.querySelectorAll(FOCUSABLE_SELECTOR),
+    ).find(isVisible);
+
+    if (target) {
+      target.focus(FOCUS_WITHOUT_SCROLLING);
       return;
     }
 
-    // Clicking the button can only open the sidebar, not close it.
-    // Clicking the button is also the *only* way to open the sidebar.
-    toggleButton.addEventListener("click", (event) => {
-      event.preventDefault();
-      event.stopPropagation();
+    if (isVisible(sidebar)) {
+      sidebar.tabIndex = -1;
+      sidebar.focus(FOCUS_WITHOUT_SCROLLING);
+      return;
+    }
 
-      // Save focus so we can restore it when the dialog closes
-      const previouslyFocused = document.activeElement;
+    // The page has no sidebar at this width, so the article is the nearest
+    // thing the reader can see.
+    const article = document.getElementById("main-content");
+
+    if (article) {
+      article.tabIndex = -1;
+      article.focus(FOCUS_WITHOUT_SCROLLING);
+    }
+  };
+
+  // Hook up the ways to open and close the dialog
+  drawers.forEach((drawer) => {
+    const { toggleButton, dialog, sidebar, inFlow } = drawer;
+
+    const openDrawer = () => {
+      // Two open modals would each make the other unreachable.
+      drawers.forEach((other) => {
+        if (other !== drawer && other.dialog.open) {
+          other.dialog.close();
+        }
+      });
 
       // When we open the dialog, we cut and paste the nodes and classes from
       // the widescreen sidebar into the dialog
       cutAndPasteNodesAndClasses(sidebar, dialog);
 
       dialog.showModal();
+      toggleButton.setAttribute("aria-expanded", "true");
+    };
 
-      // Restore focus when dialog closes
-      dialog.addEventListener(
-        "close",
-        () => {
-          if (previouslyFocused && previouslyFocused.focus) {
-            previouslyFocused.focus();
-          }
-        },
-        { once: true },
-      );
+    // Clicking the button is the *only* way to open the sidebar.
+    toggleButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (dialog.open) {
+        dialog.close();
+      } else {
+        openDrawer();
+      }
     });
 
     // Listen for clicks on the backdrop in order to close the dialog
@@ -871,10 +959,43 @@ function setupMobileSidebarKeyboardHandlers() {
       }
     });
 
-    // When the dialog is closed, move the nodes (and classes) back to their
-    // original place
-    dialog.addEventListener("close", () => {
+    // The sidebar is back in the page flow, so its drawer has nothing left to
+    // show. Nobody pressed anything, so this close is not animated: cancel
+    // the exit transitions (the ::backdrop's included) as soon as they start.
+    inFlow.addEventListener("change", (event) => {
+      if (event.matches && dialog.open) {
+        dialog.close();
+        dialog.getAnimations({ subtree: true }).forEach((a) => a.cancel());
+      }
+    });
+
+    let latestClose = 0;
+
+    dialog.addEventListener("close", async () => {
+      const thisClose = ++latestClose;
+
+      toggleButton.setAttribute("aria-expanded", "false");
+
+      // Restore focus when dialog closes
+      const focusHandled = anotherDrawerIsOpen() || focusToggleButton(drawer);
+
+      // When the dialog is closed, move the nodes (and classes) back to their
+      // original place, once the drawer has finished leaving. The subtree
+      // option is what includes the ::backdrop's fade.
+      await Promise.allSettled(
+        dialog.getAnimations({ subtree: true }).map((a) => a.finished),
+      );
+
+      // Another open or close overtook this one, which now owns the content.
+      if (dialog.open || thisClose !== latestClose) {
+        return;
+      }
+
       cutAndPasteNodesAndClasses(dialog, sidebar);
+
+      if (!focusHandled) {
+        focusInsideSidebar(drawer);
+      }
     });
   });
 }
@@ -1307,6 +1428,20 @@ function setupCollapseSidebarButton() {
     expandTooltip.hide();
   };
 
+  // The sidebar transition can end two ways: `transitionend`, or
+  // `transitioncancel` when crossing the sidebar breakpoint removes the
+  // transition mid-flight. The button must come back to life either way.
+  const afterSidebarTransition = (after) => {
+    const settle = () => {
+      sidebar.removeEventListener("transitionend", settle);
+      sidebar.removeEventListener("transitioncancel", settle);
+      after();
+    };
+
+    sidebar.addEventListener("transitionend", settle);
+    sidebar.addEventListener("transitioncancel", settle);
+  };
+
   function squeezeSidebar(prefersReducedMotion, done) {
     // Before squeezing the sidebar, freeze the widths of its subsections.
     // Otherwise, the subsections will also narrow and cause the text in the
@@ -1330,10 +1465,7 @@ function setupCollapseSidebarButton() {
       sidebar.classList.add("pst-squeeze");
       afterSqueeze();
     } else {
-      sidebar.addEventListener("transitionend", function onTransitionEnd() {
-        afterSqueeze();
-        sidebar.removeEventListener("transitionend", onTransitionEnd);
-      });
+      afterSidebarTransition(afterSqueeze);
       sidebar.classList.add("pst-squeeze");
     }
   }
@@ -1358,10 +1490,7 @@ function setupCollapseSidebarButton() {
       sidebar.classList.remove("pst-squeeze");
       afterExpand();
     } else {
-      sidebar.addEventListener("transitionend", function onTransitionEnd() {
-        afterExpand();
-        sidebar.removeEventListener("transitionend", onTransitionEnd);
-      });
+      afterSidebarTransition(afterExpand);
       sidebar.classList.remove("pst-squeeze");
     }
   }

--- a/src/pydata_sphinx_theme/assets/styles/components/_sidebar-collapse.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_sidebar-collapse.scss
@@ -81,99 +81,108 @@
     }
   }
 
-  // Define transitions (if the environment permits animation)
-  @media (prefers-reduced-motion: no-preference) {
-    $duration: 400ms;
-
-    transition: width $duration ease;
-
-    #pst-collapse-sidebar-button {
-      .pst-icon {
-        transition:
-          transform $duration ease,
-          padding $duration ease;
-      }
-    }
-
-    @each $selector,
-      $delay
-        in (
-          // When the sidebar is collapsing, we need to delay the transition of
-          // properties that make the elements invisible so the user can see the
-          // opacity transition from 1 to 0 first.
-          ".pst-squeeze": $duration,
-          // When the sidebar is expanding, it's the opposite: we need to transition
-          // the properties that make the elements visible immediately so the user
-          // can watch the opacity transition from 0 to 1.
-          ":not(.pst-squeeze)": "0s"
-        )
-    {
-      &#{$selector} {
-        .pst-collapse-sidebar-label {
-          transition:
-            opacity $duration linear,
-            visibility 0s linear $delay,
-            width 0s linear $delay,
-            height 0s linear $delay;
-        }
-
-        .sidebar-primary-item:not(.pst-sidebar-collapse) {
-          transition:
-            opacity $duration linear,
-            visibility 0s linear $delay;
-        }
-
-        // There is no need to transition any other properties on the expand
-        // label (width, height, opacity) because it is always visually hidden
-        // (i.e., width 0, height 0, etc), but toggles its availability to
-        // screen readers as the sidebar collapses or expands via the
-        // `visibility` property.
-        .pst-expand-sidebar-label {
-          transition: visibility 0s linear $delay;
-        }
-      }
-    }
+  // Unscoped: the squeezed width must hold on both sides of the breakpoint,
+  // or crossing it while squeezed would change the transitioned property
+  // (sections/_sidebar-primary.scss) and animate the width.
+  &.pst-squeeze {
+    --pst-sidebar-primary-width: 4rem;
   }
 
-  // Why "squeeze" and not "collapse"? Bootstrap uses the class name `collapse`
-  // so it seemed best to avoid possible confusion. (Later the class name was
-  // prefixed with `pst-`.)
-  &.pst-squeeze {
-    width: 4rem;
-    overflow: hidden;
+  // The collapsed state only applies while the sidebar is a column, not a drawer.
+  @include media-breakpoint-up($breakpoint-sidebar-primary) {
+    // Define transitions (if the environment permits animation)
+    @media (prefers-reduced-motion: no-preference) {
+      $duration: 400ms;
 
-    #pst-collapse-sidebar-button {
-      .pst-icon {
-        transform: translateX(0.25em) rotate(180deg);
+      transition: --pst-sidebar-primary-width $duration ease;
+
+      #pst-collapse-sidebar-button {
+        .pst-icon {
+          transition:
+            transform $duration ease,
+            padding $duration ease;
+        }
       }
 
-      .pst-collapse-sidebar-label {
+      @each $selector,
+        $delay
+          in (
+            // When the sidebar is collapsing, we need to delay the transition of
+            // properties that make the elements invisible so the user can see the
+            // opacity transition from 1 to 0 first.
+            ".pst-squeeze": $duration,
+            // When the sidebar is expanding, it's the opposite: we need to transition
+            // the properties that make the elements visible immediately so the user
+            // can watch the opacity transition from 0 to 1.
+            ":not(.pst-squeeze)": 0s
+          )
+      {
+        &#{$selector} {
+          .pst-collapse-sidebar-label {
+            transition:
+              opacity $duration linear,
+              visibility 0s linear $delay,
+              width 0s linear $delay,
+              height 0s linear $delay;
+          }
+
+          .sidebar-primary-item:not(.pst-sidebar-collapse) {
+            transition:
+              opacity $duration linear,
+              visibility 0s linear $delay;
+          }
+
+          // There is no need to transition any other properties on the expand
+          // label (width, height, opacity) because it is always visually hidden
+          // (i.e., width 0, height 0, etc), but toggles its availability to
+          // screen readers as the sidebar collapses or expands via the
+          // `visibility` property.
+          .pst-expand-sidebar-label {
+            transition: visibility 0s linear $delay;
+          }
+        }
+      }
+    }
+
+    // Why "squeeze" and not "collapse"? Bootstrap uses the class name `collapse`
+    // so it seemed best to avoid possible confusion. (Later the class name was
+    // prefixed with `pst-`.)
+    &.pst-squeeze {
+      overflow: hidden;
+
+      #pst-collapse-sidebar-button {
+        .pst-icon {
+          transform: translateX(0.25em) rotate(180deg);
+        }
+
+        .pst-collapse-sidebar-label {
+          opacity: 0;
+          visibility: hidden;
+          width: 0;
+          height: 0;
+        }
+
+        .pst-expand-sidebar-label {
+          visibility: visible;
+        }
+      }
+
+      .sidebar-primary-item:not(.pst-sidebar-collapse) {
         opacity: 0;
         visibility: hidden;
-        width: 0;
-        height: 0;
       }
+    }
 
+    &:not(.pst-squeeze) {
+      // When the sidebar is expanded, hide the "Expand Sidebar" label.
       .pst-expand-sidebar-label {
-        visibility: visible;
+        visibility: hidden;
       }
-    }
 
-    .sidebar-primary-item:not(.pst-sidebar-collapse) {
-      opacity: 0;
-      visibility: hidden;
+      // This block is shorter than its counterpart above because there's no need,
+      // for example, to explicitly set `visibility: visible` or `opacity: 1` on
+      // the collapse label and sidebar subsections because those are the default
+      // values.
     }
-  }
-
-  &:not(.pst-squeeze) {
-    // When the sidebar is expanded, hide the "Expand Sidebar" label.
-    .pst-expand-sidebar-label {
-      visibility: hidden;
-    }
-
-    // This block is shorter than its counterpart above because there's no need,
-    // for example, to explicitly set `visibility: visible` or `opacity: 1` on
-    // the collapse label and sidebar subsections because those are the default
-    // values.
   }
 }

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -5,6 +5,13 @@
 
 $sidebar-padding-right: 1rem;
 
+// The collapse button transitions this, not `width`, so the width change at the breakpoint is not animated.
+@property --pst-sidebar-primary-width {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 25%;
+}
+
 .bd-sidebar-primary {
   display: flex;
   flex-direction: column;
@@ -14,6 +21,15 @@ $sidebar-padding-right: 1rem;
   top: var(--pst-header-height);
 
   @include make-col(3);
+
+  // Only the column regime uses the property; below the breakpoint the drawer
+  // width in sections/_sidebar-toggle.scss applies instead, so crossing the
+  // breakpoint changes no transitioned value and animates nothing.
+  @include media-breakpoint-up($breakpoint-sidebar-primary) {
+    --pst-sidebar-primary-width: 25%;
+
+    width: var(--pst-sidebar-primary-width);
+  }
 
   // Borders padding and whitespace
   padding: $sidebar-padding-right;

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-toggle.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-toggle.scss
@@ -15,7 +15,7 @@
  * And the wide-screen behavior of the sections is defined in their own section
  * .scss files.
  */
-@mixin sliding-drawer($side: "left") {
+@mixin drawer-shape($side: "left") {
   position: fixed;
   top: 0;
   z-index: $zindex-modal;
@@ -24,44 +24,110 @@
   width: 75%;
   flex-grow: 0.75;
   max-width: 350px;
-  transition:
-    visibility $animation-time ease-out,
-    margin $animation-time ease-out;
-  visibility: hidden;
   border: 0;
+  background-color: var(--pst-color-background);
 
   @if $side == "right" {
-    margin-right: -75%;
     right: 0;
   } @else {
-    margin-left: -75%;
     left: 0;
   }
 }
 
-.bd-sidebar::backdrop {
-  background-color: black;
-  opacity: 0.5;
-}
-
 .bd-sidebar-primary {
   @include media-breakpoint-down($breakpoint-sidebar-primary) {
-    @include sliding-drawer("left");
-  }
+    @include drawer-shape("left");
 
-  &[open] {
-    margin-left: 0;
-    visibility: visible;
+    margin-left: -75%;
+    visibility: hidden;
   }
 }
 
 .bd-sidebar-secondary {
   @include media-breakpoint-down($breakpoint-sidebar-secondary) {
-    @include sliding-drawer("right");
+    @include drawer-shape("right");
+
+    margin-right: -75%;
+    visibility: hidden;
   }
+}
+
+#pst-primary-sidebar-modal {
+  @include drawer-shape("left");
+
+  // The browser's dialog styles pin both `left` and `right`, so the free margin holds the drawer to its edge.
+  margin-inline: 0 auto;
+  translate: -100%;
+
+  // A border, not padding: the sidebars set their own padding.
+  border-left: env(safe-area-inset-left, 0) solid transparent;
+}
+
+#pst-secondary-sidebar-modal {
+  @include drawer-shape("right");
+
+  margin-inline: auto 0;
+  translate: 100%;
+  border-right: env(safe-area-inset-right, 0) solid transparent;
+}
+
+#pst-primary-sidebar-modal,
+#pst-secondary-sidebar-modal {
+  visibility: visible;
+  overscroll-behavior: contain;
+  border-top: env(safe-area-inset-top, 0) solid transparent;
+  border-bottom: env(safe-area-inset-bottom, 0) solid transparent;
 
   &[open] {
-    margin-right: 0;
-    visibility: visible;
+    translate: 0;
   }
+
+  &::backdrop {
+    background-color: rgb(0 0 0 / 50%);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  #pst-primary-sidebar-modal,
+  #pst-secondary-sidebar-modal {
+    transition:
+      translate $animation-time ease-out,
+      display $animation-time allow-discrete,
+      overlay $animation-time allow-discrete;
+
+    &::backdrop {
+      opacity: 0;
+      transition:
+        opacity $animation-time ease-out,
+        display $animation-time allow-discrete,
+        overlay $animation-time allow-discrete;
+    }
+
+    &[open]::backdrop {
+      opacity: 1;
+    }
+  }
+
+  @starting-style {
+    #pst-primary-sidebar-modal[open] {
+      translate: -100%;
+    }
+
+    #pst-secondary-sidebar-modal[open] {
+      translate: 100%;
+    }
+
+    #pst-primary-sidebar-modal[open]::backdrop,
+    #pst-secondary-sidebar-modal[open]::backdrop {
+      opacity: 0;
+    }
+  }
+}
+
+// Scoped to the drawers: other dialogs (search, ones in page content) never
+// locked the page scroll and must not start to.
+// Without the stable gutter the page shifts sideways when the scrollbar goes.
+html:has(#pst-primary-sidebar-modal[open], #pst-secondary-sidebar-modal[open]) {
+  overflow: hidden;
+  scrollbar-gutter: stable;
 }

--- a/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
+++ b/src/pydata_sphinx_theme/assets/styles/variables/_layout.scss
@@ -1,14 +1,4 @@
-html {
-  /*****************************************************************************
-  * Overall Layout Variables
-  */
-
-  // Header height will impact the top offset for many sections
-  // Article header is 66% of Header
-  --pst-header-height: 4rem;
-  --pst-header-article-height: calc(var(--pst-header-height) * 2 / 3);
-  --pst-sidebar-secondary: 17rem;
-}
+@use "sass:map";
 
 /*******************************************************************************
 * Breakpoints that trigger UI changes
@@ -21,6 +11,29 @@ html {
 $breakpoint-sidebar-primary: lg; // When we collapse the primary sidebar
 $breakpoint-sidebar-secondary: xl; // When we collapse the secondary sidebar
 $breakpoint-page-width: 88rem; // taken from sphinx-basic-ng, which we are ultimately going to inherit
+
+html {
+  /*****************************************************************************
+  * Overall Layout Variables
+  */
+
+  // Header height will impact the top offset for many sections
+  // Article header is 66% of Header
+  --pst-header-height: 4rem;
+  --pst-header-article-height: calc(var(--pst-header-height) * 2 / 3);
+  --pst-sidebar-secondary: 17rem;
+
+  // Published for the drawer script, whose matchMedia queries need the same
+  // widths the stylesheet's own media queries use.
+  --pst-breakpoint-sidebar-primary: #{map.get(
+      $grid-breakpoints,
+      $breakpoint-sidebar-primary
+    )};
+  --pst-breakpoint-sidebar-secondary: #{map.get(
+      $grid-breakpoints,
+      $breakpoint-sidebar-secondary
+    )};
+}
 
 /*******************************************************************************
 * Define the animation behaviour

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/sections/header.html
@@ -1,6 +1,6 @@
 {% if theme_navbar_start or theme_navbar_center or theme_navbar_end or theme_navbar_persistent %}
 <div class="bd-header__inner bd-page-width">
-  <button class="pst-navbar-icon sidebar-toggle primary-toggle" aria-label="{{ _('Site navigation') }}">
+  <button class="pst-navbar-icon sidebar-toggle primary-toggle" aria-label="{{ _('Site navigation') }}" aria-expanded="false" aria-controls="pst-primary-sidebar-modal">
     <span class="fa-solid fa-bars"></span>
   </button>
   {% set navbar_start, navbar_class, navbar_align = navbar_align_class() %}
@@ -40,7 +40,7 @@
   {% endfor %}
 
   {% if not remove_sidebar_secondary and secondary_sidebar_items %}
-    <button class="pst-navbar-icon sidebar-toggle secondary-toggle" aria-label="{{ _('On this page') }}">
+    <button class="pst-navbar-icon sidebar-toggle secondary-toggle" aria-label="{{ _('On this page') }}" aria-expanded="false" aria-controls="pst-secondary-sidebar-modal">
       <span class="fa-solid fa-outdent"></span>
     </button>
   {% endif %}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1429,3 +1429,21 @@ def test_sidebar_secondary_templates_all_empty(sphinx_build_factory) -> None:
     # Hence the secondary sidebar has all its templates empty and should be removed
     sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
     assert not sphinx_build.html_tree("page1.html").select("div.bd-sidebar-secondary")
+
+
+def test_sidebar_breakpoints_match_stylesheet() -> None:
+    """The stylesheet publishes the breakpoints under the names the JS reads."""
+    assets = Path(__file__).parents[1] / "src" / "pydata_sphinx_theme" / "assets"
+    layout_scss = (assets / "styles" / "variables" / "_layout.scss").read_text()
+    theme_js = (assets / "scripts" / "pydata-sphinx-theme.js").read_text()
+
+    for sidebar in ("primary", "secondary"):
+        prop = f"--pst-breakpoint-sidebar-{sidebar}"
+
+        published = re.search(
+            rf"{prop}:\s*#\{{map\.get\(\s*\$grid-breakpoints,\s*"
+            rf"\$breakpoint-sidebar-{sidebar}\s*\)\}}",
+            layout_scss,
+        )
+        assert published is not None, f"{prop} is not published by _layout.scss"
+        assert f'inFlowAbove("{prop}")' in theme_js

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -324,6 +324,70 @@ class TestCollapseSidebarButton:
 
         _check_test_site(self.site_name, site_path, check_collapse_expand)
 
+    @pytest.mark.parametrize("squeezed", [False, True], ids=["expanded", "squeezed"])
+    def test_sidebar_width_not_animated_across_breakpoint(
+        self, sphinx_build_factory: Callable, page: Page, url_base: str, squeezed: bool
+    ) -> None:
+        """Crossing the sidebar breakpoint must swap the width without animating."""
+        site_path = _build_test_site(
+            self.site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def get_width(locator):
+            bbox = locator.bounding_box()
+            assert bbox is not None
+            return bbox["width"]
+
+        def settle_a_frame():
+            # Give the browser a frame to start whatever the new styles ask for
+            page.evaluate("""
+                () =>
+                    new Promise((done) =>
+                        requestAnimationFrame(() => requestAnimationFrame(done)),
+                    )
+            """)
+
+        def running_animations(locator):
+            return locator.evaluate(
+                "el => el.getAnimations().map((a) => a.transitionProperty)"
+            )
+
+        def check_width_after_breakpoint_flip():
+            page.set_viewport_size({"width": 1200, "height": 900})
+            page.goto(
+                urljoin(
+                    url_base, f"playwright_tests/{self.site_name}/section1/index.html"
+                )
+            )
+            page.wait_for_load_state("load")
+
+            sidebar = page.locator("#pst-primary-sidebar")
+            button = page.locator("#pst-collapse-sidebar-button")
+
+            if squeezed:
+                button.click()
+                # aria-expanded flips once the squeeze transition has finished
+                expect(button).to_have_attribute("aria-expanded", "false")
+
+            page.set_viewport_size({"width": 800, "height": 900})
+            settle_a_frame()
+            assert running_animations(sidebar) == []
+
+            page.set_viewport_size({"width": 1200, "height": 900})
+            settle_a_frame()
+            assert running_animations(sidebar) == []
+
+            flipped_width = get_width(sidebar)
+            if squeezed:
+                # 4rem at the browser's default 16px font size
+                assert flipped_width == pytest.approx(64, abs=1)
+
+            page.wait_for_timeout(600)
+            assert get_width(sidebar) == pytest.approx(flipped_width, abs=1)
+
+        _check_test_site(self.site_name, site_path, check_width_after_breakpoint_flip)
+
     def test_collapse_sidebar_button_not_in_mobile(
         self, sphinx_build_factory: Callable, page: Page, url_base: str
     ) -> None:
@@ -392,3 +456,305 @@ class TestCollapseSidebarButton:
             expect(button).not_to_be_attached()
 
         _check_test_site(self.site_name, site_path, check_no_collapse_sidebar_button)
+
+
+# ----------------- Test functions: mobile sidebar drawers -----------------------------
+# Below both breakpoints both sidebars are drawers; between them, only the secondary.
+NARROW_VIEWPORT = {"width": 800, "height": 900}
+MEDIUM_VIEWPORT = {"width": 1100, "height": 900}
+WIDE_VIEWPORT = {"width": 1300, "height": 900}
+
+
+class TestSidebarDrawers:
+    """Group the tests for the narrow-screen sidebar drawers."""
+
+    site_name = "sidebars"
+    page_path = "section1/index.html"
+
+    def _open(self, page: Page, url_base: str, viewport: dict) -> None:
+        """Load the test page at `viewport`, with both sidebars present."""
+        page.set_viewport_size(viewport)
+        page.goto(
+            urljoin(url_base, f"playwright_tests/{self.site_name}/{self.page_path}")
+        )
+        page.wait_for_load_state("load")
+
+    def _focused_is_visible(self, page: Page) -> bool:
+        """Whether focus is on something the reader can see and use."""
+        return page.evaluate("""
+            () => {
+                const el = document.activeElement;
+                return Boolean(
+                    el && el !== document.body && el.getClientRects().length > 0,
+                );
+            }
+        """)
+
+    @pytest.mark.parametrize(
+        ("sidebar_id", "toggle_name", "crossed_viewport"),
+        [
+            ("pst-primary-sidebar", "Site navigation", MEDIUM_VIEWPORT),
+            ("pst-secondary-sidebar", "On this page", WIDE_VIEWPORT),
+        ],
+    )
+    def test_drawer_closes_when_its_breakpoint_is_crossed(
+        self,
+        sphinx_build_factory: Callable,
+        page: Page,
+        url_base: str,
+        sidebar_id: str,
+        toggle_name: str,
+        crossed_viewport: dict,
+    ) -> None:
+        """Widening past a sidebar's breakpoint must close its open drawer."""
+        site_path = _build_test_site(
+            self.site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def check_drawer_closed_after_flip():
+            self._open(page, url_base, NARROW_VIEWPORT)
+
+            sidebar = page.locator(f"#{sidebar_id}")
+            dialog = page.locator(f"#{sidebar_id}-modal")
+
+            page.get_by_role("button", name=toggle_name).click()
+            expect(dialog).to_be_visible()
+            assert sidebar.locator("> *").count() == 0
+
+            page.set_viewport_size(crossed_viewport)
+
+            # This close is not animated: the drawer must already be parked
+            page.wait_for_function(
+                f"""() => !document.getElementById("{sidebar_id}-modal").open"""
+            )
+
+            # Filtered to what a reader can see: Chromium reports a display
+            # transition as the dialog leaves the top layer, drawing nothing
+            visible_animations = dialog.evaluate(
+                """el => el.getAnimations({ subtree: true })
+                    .map((a) => a.transitionProperty)
+                    .filter((name) => ["translate", "opacity"].includes(name))"""
+            )
+            assert visible_animations == []
+
+            parked = "-100%" if sidebar_id == "pst-primary-sidebar" else "100%"
+            assert dialog.evaluate("el => getComputedStyle(el).translate") == parked
+
+            # The drawer has left the top layer, so no backdrop remains
+            assert dialog.evaluate("el => el.matches(':modal')") is False
+
+            # Wait on the sidebar filling up: the nodes move back on `close`
+            expect(sidebar.locator("> *").first).to_be_attached()
+
+            assert self._focused_is_visible(page)
+
+            expect(sidebar).to_be_visible()
+            assert sidebar.locator("> *").count() > 0
+
+            assert page.locator("dialog[open]").count() == 0
+
+            header_link = page.locator(".bd-header a[href]").first
+            header_link.focus()
+            expect(header_link).to_be_focused()
+
+        _check_test_site(self.site_name, site_path, check_drawer_closed_after_flip)
+
+    def test_only_one_drawer_open_at_a_time(
+        self, sphinx_build_factory: Callable, page: Page, url_base: str
+    ) -> None:
+        """Opening one drawer must close the other."""
+        site_path = _build_test_site(
+            self.site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def check_second_drawer_replaces_first():
+            self._open(page, url_base, NARROW_VIEWPORT)
+
+            primary_sidebar = page.locator("#pst-primary-sidebar")
+            primary_dialog = page.locator("#pst-primary-sidebar-modal")
+            secondary_dialog = page.locator("#pst-secondary-sidebar-modal")
+            secondary_toggle = page.get_by_role("button", name="On this page")
+
+            page.get_by_role("button", name="Site navigation").click()
+            expect(primary_dialog).to_be_visible()
+
+            # The open modal makes this toggle inert; deliver the click as AT does
+            secondary_toggle.dispatch_event("click")
+
+            expect(secondary_dialog).to_be_visible()
+            expect(primary_dialog).not_to_be_visible()
+            assert page.locator("dialog[open]").count() == 1
+
+            expect(primary_sidebar.locator("> *").first).to_be_attached()
+            assert secondary_dialog.locator("> *").count() > 0
+
+            assert page.evaluate("""
+                () =>
+                    document
+                        .getElementById("pst-secondary-sidebar-modal")
+                        .contains(document.activeElement)
+            """)
+
+            page.keyboard.press("Escape")
+            expect(secondary_dialog).not_to_be_visible()
+            expect(secondary_toggle).to_be_focused()
+
+        _check_test_site(self.site_name, site_path, check_second_drawer_replaces_first)
+
+    def test_drawer_toggles_report_their_state(
+        self, sphinx_build_factory: Callable, page: Page, url_base: str
+    ) -> None:
+        """Each toggle must name the drawer it controls and say whether it is open."""
+        site_path = _build_test_site(
+            self.site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def check_toggle_state():
+            self._open(page, url_base, NARROW_VIEWPORT)
+
+            for toggle_name, sidebar_id in [
+                ("Site navigation", "pst-primary-sidebar"),
+                ("On this page", "pst-secondary-sidebar"),
+            ]:
+                toggle = page.get_by_role("button", name=toggle_name)
+                expect(toggle).to_have_attribute("aria-controls", f"{sidebar_id}-modal")
+                expect(toggle).to_have_attribute("aria-expanded", "false")
+
+                toggle.click()
+                expect(toggle).to_have_attribute("aria-expanded", "true")
+
+                page.keyboard.press("Escape")
+                expect(toggle).to_have_attribute("aria-expanded", "false")
+
+            # By class: above the breakpoint the button is hidden and has no role
+            primary_toggle = page.locator("button.primary-toggle")
+            primary_toggle.click()
+            expect(primary_toggle).to_have_attribute("aria-expanded", "true")
+            page.set_viewport_size(MEDIUM_VIEWPORT)
+            expect(primary_toggle).to_have_attribute("aria-expanded", "false")
+
+        _check_test_site(self.site_name, site_path, check_toggle_state)
+
+    def test_toggle_closes_the_drawer_it_opened(
+        self, sphinx_build_factory: Callable, page: Page, url_base: str
+    ) -> None:
+        """Pressing a toggle a second time must close the drawer it opened."""
+        site_path = _build_test_site(
+            self.site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def check_toggle_closes():
+            self._open(page, url_base, NARROW_VIEWPORT)
+
+            dialog = page.locator("#pst-primary-sidebar-modal")
+            sidebar = page.locator("#pst-primary-sidebar")
+            toggle = page.get_by_role("button", name="Site navigation")
+
+            toggle.click()
+            expect(dialog).to_be_visible()
+
+            # The open modal makes this toggle inert; deliver the click as AT does
+            toggle.dispatch_event("click")
+
+            expect(dialog).not_to_be_visible()
+            expect(sidebar.locator("> *").first).to_be_attached()
+            expect(toggle).to_be_focused()
+
+            # Nothing keeps the drawer in the top layer after it has left
+            assert dialog.evaluate("el => el.matches(':modal')") is False
+
+        _check_test_site(self.site_name, site_path, check_toggle_closes)
+
+    def test_drawer_does_not_move_the_page_behind_it(
+        self, sphinx_build_factory: Callable, page: Page, url_base: str
+    ) -> None:
+        """A drawer must leave the reader where they were on the page behind it."""
+        # This site's fixture page is long enough to scroll
+        site_name = "version_switcher"
+        site_path = _build_test_site(
+            site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def press(selector: str) -> None:
+            """Press the button where it sits, without scrolling it into view."""
+            box = page.locator(selector).bounding_box()
+            assert box is not None
+            page.mouse.click(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
+
+        def scroll_position() -> int:
+            return page.evaluate("() => Math.round(window.scrollY)")
+
+        def check_page_does_not_move():
+            page.set_viewport_size(NARROW_VIEWPORT)
+            page.goto(
+                urljoin(url_base, f"playwright_tests/{site_name}/fixture_blocks.html")
+            )
+            page.wait_for_load_state("load")
+
+            dialog = page.locator("#pst-primary-sidebar-modal")
+            sidebar = page.locator("#pst-primary-sidebar")
+            toggle = page.locator("button.primary-toggle")
+
+            page.evaluate("() => window.scrollTo(0, 400)")
+            reading_position = scroll_position()
+            assert reading_position > 0
+
+            # Do this round first, while nothing on the page has been focused
+            toggle.dispatch_event("click")
+            expect(dialog).to_be_visible()
+            assert scroll_position() == reading_position
+
+            page.keyboard.press("Escape")
+            expect(sidebar.locator("> *").first).to_be_attached()
+            expect(toggle).to_be_focused()
+            assert scroll_position() == reading_position
+
+            press("button.primary-toggle")
+            expect(dialog).to_be_visible()
+            assert scroll_position() == reading_position
+
+            page.keyboard.press("Escape")
+            expect(sidebar.locator("> *").first).to_be_attached()
+            assert scroll_position() == reading_position
+
+        _check_test_site(site_name, site_path, check_page_does_not_move)
+
+    def test_breakpoint_close_focuses_the_article_when_there_is_no_sidebar(
+        self, sphinx_build_factory: Callable, page: Page, url_base: str
+    ) -> None:
+        """A page with no primary sidebar still has somewhere to put focus."""
+        site_path = _build_test_site(
+            self.site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def check_focus_lands_on_the_article():
+            page.set_viewport_size(NARROW_VIEWPORT)
+            page.goto(
+                urljoin(
+                    url_base,
+                    f"playwright_tests/{self.site_name}/section2/no-sidebar.html",
+                )
+            )
+            page.wait_for_load_state("load")
+
+            sidebar = page.locator("#pst-primary-sidebar")
+            dialog = page.locator("#pst-primary-sidebar-modal")
+            article = page.locator("#main-content")
+
+            expect(sidebar).to_have_class(re.compile(r"\bhide-on-wide\b"))
+
+            page.get_by_role("button", name="Site navigation").click()
+            expect(dialog).to_be_visible()
+
+            page.set_viewport_size(MEDIUM_VIEWPORT)
+
+            expect(sidebar).not_to_be_visible()
+            expect(article).to_be_focused()
+
+        _check_test_site(self.site_name, site_path, check_focus_lands_on_the_article)


### PR DESCRIPTION
Sidebar animations were triggered by window resizes which overloaded the visual interaction of the resize operation, and sidebar animations weren't triggering nicely on dedicated user clicks to open/close sidebars. This PR means to fix them all.

Every video clip below shows `main` branch behavior on the left, and PR branch behavior on the right. PR developed by me with AI tooling (Claude / Opus 5). I take responsibility for the changes I propose and intend to stay around and ensure they land OK if accepted.

## Terminology

| Term | Note |
|-|-|
| **Primary sidebar** | the left one, the section navigation. |
| **Secondary sidebar** | the right one, "On this page". |
| **In-flow column** | How a sidebar looks on a wide screen, sitting beside the text and taking room from it (rather than being drawn on top). Primary at 960px and up, secondary at 1200px and up. |
| **Collapse aka. Squeeze** | When the reader pressed "Collapse sidebar", which shrinks the primary sidebar to a 4rem strip of icons. Primary sidebar only, and only while it is an in-flow column. |
| **Drawer** | how it looks on a narrow screen, sliding _over_ the page (compared to in-flow) from the edge when you press the hamburger or the contents button. |
| **The flip or breakpoint** | The moment a resize crosses the width where a sidebar changes between an in-flow column and a drawer. 960px for the left, 1200px for the right.
| **Hidden** | The page asked for no sidebar at all, so there is nothing to show at any width. |

One implementation detail worth knowing, because several fixes turn on it: a drawer is not the sidebar moved on screen. The script moves the sidebar's children, and its classes, into a `<dialog>` and opens that; on close it moves
them back. So while a drawer is open, the sidebar element is empty and the dialog is what the reader sees.

Two more words used below:

- **Open** and **closed** describe a drawer, not a sidebar: a drawer is open while it is over the page.
- **The breakpoint** is the width where a sidebar changes between column and drawer, 960px for the primary and 1200px for the secondary. Crossing it by resizing the window is where most of these bugs live.

## Fixes

**Widening to reveal the primary sidebar**

https://github.com/user-attachments/assets/2de8d80c-f579-4699-b773-f00d7a962c78

The primary sidebar's width is transitioned so the collapse button can animate it, but the declaration is not scoped to a viewport width, so it also animates the width change the breakpoint itself causes. For 400ms the article is a quarter
of its width, the page is nearly twice as tall as it settles at, and the text moves under the reader.

Fixed by holding the in-flow width in a registered custom property and transitioning that, so `width` itself is never a transitioned property. The collapse animation is unchanged.

**A collapsed sidebar, on a narrow window (hidden/shown state expected, not collapsed)**

https://github.com/user-attachments/assets/ddc4b3ad-650d-46e6-8445-e84ee9b3529b

Collapse the sidebar on a wide width view, then resize and open the same page on a narrow width view, and the drawer is a 35px sliver of sliced words with no navigation in it: the collapsed state is not scoped to the widths where it means anything.

Fixed by scoping it.

**Opening and closing a drawer**

https://github.com/user-attachments/assets/ec94c30e-44dd-4d59-83ec-0e0763636fed

The drawer's slide is declared on the sidebar, but the script moves the sidebar's contents into a modal dialog and shows that instead, so nothing animates. The same declaration does animate a resize, which is the one time it should not: narrowing past the second breakpoint slides the table of contents off the edge.

Fixed by moving the animation to the dialog, with `@starting-style` and `allow-discrete`. The right-hand drawer also gets the theme's backdrop instead of the browser's default, the page behind a drawer no longer scrolls, and the drawer keeps its contents until it has finished leaving.

**A drawer left open while the window widens**

https://github.com/user-attachments/assets/d6c8b036-49e1-46fd-9d3b-01d53b7bb383

Nothing watches the viewport, so the drawer stays open and modal: the page behind is inert, the sidebar column is empty, and focus is on `body`. Escape still works, but nothing on screen says so.

Fixed by closing the drawer when its sidebar returns to the page flow. That close does not animate, since the reader pressed nothing.

**The collapse button's labels**

https://github.com/user-attachments/assets/d5e9f7b2-caf5-4801-b1dd-fe2aceab61ee

They fade out and snap back. A delay is written as the string `"0s"`, so the browser discards the declaration.

**Also fixed, without a clip:**

- both drawers could be open at once
- a toggle could not close the drawer it opened
- the toggles carried no `aria-expanded`
- closing a drawer could send the page to the top, because focusing a control in a sticky header scrolls to it

## Tests

Eight test functions, all failing on `main`. The breakpoint-width test runs both expanded and collapsed and asserts no property animates on the sidebar at a crossing; the breakpoint-close test asserts the visible outcome, the drawer parked off screen with no backdrop left and nothing a reader can see animating; and the build test checks the stylesheet publishes the breakpoints under the names the script reads.

| Test | What it asserts |
|---|---|
| `test_sidebar_width_not_animated_across_breakpoint` | Widening past the sidebar breakpoint must not animate the sidebar width. |
| `test_drawer_closes_when_its_breakpoint_is_crossed` | Widening past a sidebar's breakpoint must close its open drawer. |
| `test_only_one_drawer_open_at_a_time` | Opening one drawer must close the other. |
| `test_drawer_toggles_report_their_state` | Each toggle must name the drawer it controls and say whether it is open. |
| `test_toggle_closes_the_drawer_it_opened` | Pressing a toggle a second time must close the drawer it opened. |
| `test_drawer_does_not_move_the_page_behind_it` | A drawer must leave the reader where they were on the page behind it. |
| `test_breakpoint_close_focuses_the_article_when_there_is_no_sidebar` | A page with no primary sidebar still has somewhere to put focus. |
| `test_sidebar_breakpoints_match_stylesheet` | The stylesheet must publish the breakpoints under the names the JS reads. |

The first seven are Playwright, in `TestCollapseSidebarButton` and a new `TestSidebarDrawers`; the last is a build test. The script holds no copy of the breakpoint widths: the stylesheet publishes them as `--pst-breakpoint-sidebar-*` custom properties and the script reads those, so a downstream theme that overrides `$grid-breakpoints` keeps CSS and JS consistent by construction. Without the stylesheet the media query never matches and the drawer simply stays put on a resize.

## Misc notes

A breakpoint-crossing close is snapped by cancelling the dialog's animations (`getAnimations({ subtree: true })`, so the backdrop's too) right after `close()`; ordinary closes await the same subtree set, so the backdrop fade is genuinely awaited before content moves back. Chromium reports one `display` transition as the dialog then leaves the top layer; it has no visible effect.

`@property` is Chrome 85, Safari 16.4, Firefox 128. Without it the layout is still correct and only the width animation is lost; the collapse button's bookkeeping still completes, because its `transitionend` handler does not filter on property name and the button icon carries its own transition.

Measured on Chromium only.