### PR TITLE
Add a configuration option for which templates to skip empty checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/examples/generated/
+docs/api/
 warnings.txt
 
 # PyBuilder

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -188,11 +188,22 @@ def update_config(app):
         theme_logo["link"] = theme_logo_link
     theme_options["logo"] = theme_logo
 
+    if "templates_skip_empty_check" not in theme_options and hasattr(
+        app.builder, "theme"
+    ):
+        default_tsec = app.builder.theme.get_options().get(
+            "templates_skip_empty_check"
+        ) or ["sidebar-nav-bs.html", "navbar-nav.html"]
+        theme_options["templates_skip_empty_check"] = default_tsec
+
 
 def update_and_remove_templates(
     app: Sphinx, pagename: str, templatename: str, context, doctree
 ) -> None:
     """Update template names and assets for page build."""
+    templates_skip_empty_check_config = utils.get_theme_options_dict(app).get(
+        "templates_skip_empty_check", []
+    )
     # Allow for more flexibility in template names
     template_sections = [
         "theme_navbar_start",
@@ -216,7 +227,7 @@ def update_and_remove_templates(
                 context=context,
                 templates=context.get(section, []),
                 section=section,
-                templates_skip_empty_check=["sidebar-nav-bs.html", "navbar-nav.html"],
+                templates_skip_empty_check=templates_skip_empty_check_config,
             )
 
     # Remove a duplicate entry of the theme CSS. This is because it is in both:

--- a/src/pydata_sphinx_theme/__init__.py
+++ b/src/pydata_sphinx_theme/__init__.py
@@ -188,22 +188,18 @@ def update_config(app):
         theme_logo["link"] = theme_logo_link
     theme_options["logo"] = theme_logo
 
-    if "templates_skip_empty_check" not in theme_options and hasattr(
-        app.builder, "theme"
-    ):
-        default_tsec = app.builder.theme.get_options().get(
-            "templates_skip_empty_check"
-        ) or ["sidebar-nav-bs.html", "navbar-nav.html"]
-        theme_options["templates_skip_empty_check"] = default_tsec
-
 
 def update_and_remove_templates(
     app: Sphinx, pagename: str, templatename: str, context, doctree
 ) -> None:
     """Update template names and assets for page build."""
-    templates_skip_empty_check_config = utils.get_theme_options_dict(app).get(
-        "templates_skip_empty_check", []
+    templates_skip_empty_check_config = context.get(
+        "theme_templates_skip_empty_check", []
     )
+    if isinstance(templates_skip_empty_check_config, str):
+        templates_skip_empty_check_config = [
+            t.strip() for t in templates_skip_empty_check_config.split(",")
+        ]
     # Allow for more flexibility in template names
     template_sections = [
         "theme_navbar_start",

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -57,6 +57,7 @@ secondary_sidebar_items = page-toc, edit-this-page, sourcelink
 show_version_warning_banner = False
 sticky_banners = False
 announcement =
+templates_skip_empty_check =
 
 # DEPRECATED (remove after 1.0 release)
 pygment_light_style =

--- a/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
+++ b/src/pydata_sphinx_theme/theme/pydata_sphinx_theme/theme.conf
@@ -57,7 +57,7 @@ secondary_sidebar_items = page-toc, edit-this-page, sourcelink
 show_version_warning_banner = False
 sticky_banners = False
 announcement =
-templates_skip_empty_check =
+templates_skip_empty_check = sidebar-nav-bs.html, navbar-nav.html
 
 # DEPRECATED (remove after 1.0 release)
 pygment_light_style =

--- a/tests/sites/base/_templates_empty_navbar/navbar-nav.html
+++ b/tests/sites/base/_templates_empty_navbar/navbar-nav.html
@@ -1,0 +1,6 @@
+{# Intentionally renders an empty string.
+
+Overrides the theme navbar-nav.html, which always renders static markup, so
+that the empty-template check would remove it unless it is listed in the
+templates_skip_empty_check theme option.
+#}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1179,6 +1179,58 @@ def test_empty_templates(sphinx_build_factory) -> None:
     assert not html.select(".navbar-icon-links")
 
 
+@pytest.mark.parametrize(
+    ("skip_empty_check", "navbar_center_rendered"),
+    [
+        # With no user config the default (from theme.conf) skips navbar-nav.html
+        pytest.param(None, True, id="default"),
+        # An explicitly empty list opts out of skipping navbar-nav.html
+        pytest.param([], False, id="empty-list"),
+        # navbar-nav.html is skipped if listed w/ its .html suffix
+        pytest.param(["navbar-nav.html"], True, id="list"),
+        # A suffix-less skip entry doesn't match; entries must include the
+        # suffix (or be a suffix of the full template name)
+        pytest.param(["navbar-nav"], False, id="list-no-suffix"),
+        # A list that doesn't contain navbar-nav.html does not skip it
+        pytest.param(["sidebar-nav-bs.html"], False, id="list-other-template"),
+        # Strings are parsed as comma-separated lists, like theme.conf options
+        pytest.param("navbar-nav.html", True, id="string"),
+        pytest.param("sidebar-nav-bs.html, navbar-nav.html", True, id="string-comma"),
+    ],
+)
+def test_templates_skip_empty_check(
+    skip_empty_check, navbar_center_rendered, sphinx_build_factory
+) -> None:
+    """Templates in templates_skip_empty_check are kept even if they render empty."""
+    confoverrides = {
+        # Override navbar-nav.html with a template that renders empty, so the
+        # empty check removes it (w/ its whole navbar section) unless it is skipped.
+        "templates_path": ["_templates_empty_navbar"],
+        # The default sidebars are turned off because opting sidebar-nav-bs.html
+        # out of the skip list makes the empty check render it w/o the guard in
+        # layout.html, which raises on pages w/o a toctree ancestor (e.g. the root)
+        "html_sidebars": {"**": []},
+        "html_theme_options": (
+            {"templates_skip_empty_check": skip_empty_check}
+            if skip_empty_check is not None
+            else {}
+        ),
+    }
+    sphinx_build = sphinx_build_factory("base", confoverrides=confoverrides).build()
+    html = sphinx_build.html_tree("page1.html")
+
+    navbar_center = html.select(".navbar-header-items__center")
+    if navbar_center_rendered:
+        # The empty template was kept, so the section and its (empty) item render
+        assert len(navbar_center) == 1
+        navbar_items = navbar_center[0].select(".navbar-item")
+        assert len(navbar_items) == 1
+        assert navbar_items[0].get_text(strip=True) == ""
+    else:
+        # The empty template was removed along w/ its parent section
+        assert not navbar_center
+
+
 def test_translations(sphinx_build_factory) -> None:
     """Test that basic translation functionality works.
 


### PR DESCRIPTION
Thanks to new the [sphinx-benchmark](https://github.com/Schefflera-Arboricola/sphinx-benchmark/) tool, I looked at how long it was taking to build sunpy's documentation with our sunpy-sphinx-theme child theme of pydata-sphinx-theme.


This is the relevant bit of the profile before I changed anything:

```
Build time:  317.0214979859993
========================================================================================================================================================
html-page-context  —  208.281944s own time (65.70% of build)  |  701 emissions  |  depth 0
========================================================================================================================================================
  Handler                                           Kind                Ext/Module                                   Calls       Total(s)        Avg(ms)
--------------------------------------------------------------------------------------------------------------------------------------------------------
  update_and_remove_templates                       theme               pydata_sphinx_theme                            701     206.208510        294.163
  set_secondary_sidebar_items                       theme               pydata_sphinx_theme                            701       1.519667          2.168
[...]
```

I looked into this and found it was because of the template render check for empty templates:

https://github.com/pydata/pydata-sphinx-theme/blob/46ac937b31ac7b54b9c4b83932dd246245395329/src/pydata_sphinx_theme/utils.py#L151-L153

I was confused by this till I looked into it more, it's because the main left side bar is different in sunpy-sphinx-theme and has a different name, so was being rendered twice for each page. In pydata-sphinx-theme itself the main nav is skipped from this check. This PR adds a config option which lets me configure the sunpy-sphinx-theme to skip the empty check on the main nav (https://github.com/sunpy/sunpy-sphinx-theme/pull/332).

This leads to a much happier profile, and a much faster build:

```
Build time:  190.35233786200115
========================================================================================================================================================
html-page-context  —  1.670405s own time (0.88% of build)  |  701 emissions  |  depth 0
========================================================================================================================================================
  Handler                                           Kind                Ext/Module                                   Calls       Total(s)        Avg(ms)
--------------------------------------------------------------------------------------------------------------------------------------------------------
  set_secondary_sidebar_items                       theme               pydata_sphinx_theme                            701       0.646747          0.923
  update_and_remove_templates                       theme               pydata_sphinx_theme                            701       0.533664          0.761
```

~I had some trouble figuring out exactly the right path through the config system, I'm not sure how best to unit test it either.~