### PR TITLE
fix a console error when pstAnnouncementUrl is undefined

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -966,7 +966,7 @@ async function setupAnnouncementBanner() {
     }
   }
 
-  const { pstAnnouncementUrl } = banner ? banner.dataset : null;
+  const { pstAnnouncementUrl } = banner ? banner.dataset : {};
 
   if (!pstAnnouncementUrl) {
     return;


### PR DESCRIPTION
Thanks for maintaining this!

This fixes a console issue when banner data is not available.