### PR TITLE
Fix primary sidebar collapse glitches on resize and expand

### DIFF
--- a/src/pydata_sphinx_theme/assets/styles/components/_sidebar-collapse.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_sidebar-collapse.scss
@@ -85,7 +85,7 @@
   @media (prefers-reduced-motion: no-preference) {
     $duration: 400ms;
 
-    transition: width $duration ease;
+    transition: --pst-sidebar-primary-width $duration ease;
 
     #pst-collapse-sidebar-button {
       .pst-icon {
@@ -139,7 +139,10 @@
   // so it seemed best to avoid possible confusion. (Later the class name was
   // prefixed with `pst-`.)
   &.pst-squeeze {
-    width: 4rem;
+    // Collapse by changing the animated property, see
+    // sections/_sidebar-primary.scss, rather than `width`.
+    --pst-sidebar-primary-width: 4rem;
+
     overflow: hidden;
 
     #pst-collapse-sidebar-button {

--- a/src/pydata_sphinx_theme/assets/styles/components/_sidebar-collapse.scss
+++ b/src/pydata_sphinx_theme/assets/styles/components/_sidebar-collapse.scss
@@ -105,7 +105,7 @@
           // When the sidebar is expanding, it's the opposite: we need to transition
           // the properties that make the elements visible immediately so the user
           // can watch the opacity transition from 0 to 1.
-          ":not(.pst-squeeze)": "0s"
+          ":not(.pst-squeeze)": 0s
         )
     {
       &#{$selector} {

--- a/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
+++ b/src/pydata_sphinx_theme/assets/styles/sections/_sidebar-primary.scss
@@ -5,6 +5,14 @@
 
 $sidebar-padding-right: 1rem;
 
+// The collapse button animates this property instead of `width`. A resize
+// across the breakpoint then changes nothing that is animated.
+@property --pst-sidebar-primary-width {
+  syntax: "<length-percentage>";
+  inherits: false;
+  initial-value: 25%;
+}
+
 .bd-sidebar-primary {
   display: flex;
   flex-direction: column;
@@ -14,6 +22,15 @@ $sidebar-padding-right: 1rem;
   top: var(--pst-header-height);
 
   @include make-col(3);
+
+  // Only while the sidebar is a column. Below the breakpoint the drawer width
+  // in sections/_sidebar-toggle.scss applies, so a resize across the
+  // breakpoint changes nothing that is animated.
+  @include media-breakpoint-up($breakpoint-sidebar-primary) {
+    --pst-sidebar-primary-width: 25%;
+
+    width: var(--pst-sidebar-primary-width);
+  }
 
   // Borders padding and whitespace
   padding: $sidebar-padding-right;

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -324,6 +324,70 @@ class TestCollapseSidebarButton:
 
         _check_test_site(self.site_name, site_path, check_collapse_expand)
 
+    @pytest.mark.parametrize("squeezed", [False, True], ids=["expanded", "squeezed"])
+    def test_sidebar_width_not_animated_across_breakpoint(
+        self, sphinx_build_factory: Callable, page: Page, url_base: str, squeezed: bool
+    ) -> None:
+        """Crossing the sidebar breakpoint must swap the width without animating."""
+        site_path = _build_test_site(
+            self.site_name, sphinx_build_factory=sphinx_build_factory
+        )
+        assert site_path is not None
+
+        def get_width(locator):
+            bbox = locator.bounding_box()
+            assert bbox is not None
+            return bbox["width"]
+
+        def settle_a_frame():
+            # Give the browser a frame to start whatever the new styles ask for
+            page.evaluate("""
+                () =>
+                    new Promise((done) =>
+                        requestAnimationFrame(() => requestAnimationFrame(done)),
+                    )
+            """)
+
+        def running_animations(locator):
+            return locator.evaluate(
+                "el => el.getAnimations().map((a) => a.transitionProperty)"
+            )
+
+        def check_width_after_breakpoint_flip():
+            page.set_viewport_size({"width": 1200, "height": 900})
+            page.goto(
+                urljoin(
+                    url_base, f"playwright_tests/{self.site_name}/section1/index.html"
+                )
+            )
+            page.wait_for_load_state("load")
+
+            sidebar = page.locator("#pst-primary-sidebar")
+            button = page.locator("#pst-collapse-sidebar-button")
+
+            if squeezed:
+                button.click()
+                # aria-expanded flips once the squeeze transition has finished
+                expect(button).to_have_attribute("aria-expanded", "false")
+
+            page.set_viewport_size({"width": 800, "height": 900})
+            settle_a_frame()
+            assert running_animations(sidebar) == []
+
+            page.set_viewport_size({"width": 1200, "height": 900})
+            settle_a_frame()
+            assert running_animations(sidebar) == []
+
+            flipped_width = get_width(sidebar)
+            if squeezed:
+                # 4rem at the browser's default 16px font size
+                assert flipped_width == pytest.approx(64, abs=1)
+
+            page.wait_for_timeout(600)
+            assert get_width(sidebar) == pytest.approx(flipped_width, abs=1)
+
+        _check_test_site(self.site_name, site_path, check_width_after_breakpoint_flip)
+
     def test_collapse_sidebar_button_not_in_mobile(
         self, sphinx_build_factory: Callable, page: Page, url_base: str
     ) -> None:


### PR DESCRIPTION
Two fixes to the left/primary sidebar's "Collapse Sidebar" button, split out of #2474, in order to simplify review.

Each clip shows `main` on the left and this branch on the right. Developed with AI tooling (Claude, Opus 5/Fable 5.1). I take responsibility for the changes and will stay around to followup with fixes if there is trouble.

## Resizing the window no longer animates the layout

https://github.com/user-attachments/assets/c8068bbd-d548-4272-a30e-1aecbf3c182f

What to look at: the moment the window widens. On the left (`main`) the sidebar comes in too wide and the article is squeezed into a narrow column for a moment before both settle. On the right (this PR) the layout settles at once.

<details>
<summary>Why it happens and how it is fixed</summary>

The collapse button animates the sidebar by transitioning `width`, but that declaration is not scoped to a viewport width, so it also animates the width change the breakpoint itself causes. For 400ms after widening the window past 960px the article is a quarter of its width and the page nearly twice as tall as it settles at, and the text moves under the reader.

The collapse button now animates a custom property instead of `width`, so a resize changes nothing that is animated. The property is `--pst-sidebar-primary-width`, registered with `@property` so it can be transitioned. The collapse animation itself is unchanged. A sidebar that was collapsed before the resize keeps its collapsed width on both sides of the breakpoint, so that case does not animate either (it never did on `main`, and the test keeps it that way).

Browser support: `@property` has been in Chrome since 85 (2020), Safari since 16.4 (2023) and Firefox since 128 (2024). In an older browser the sidebar still lays out correctly; only the collapse button's width animation is lost, the sidebar just changes width at once.

</details>

## Expanding the sidebar fades its content back in

https://github.com/user-attachments/assets/0ed0d32b-1bb6-4602-b144-74c084719396

What to look at: the second press, when the sidebar expands again. On the left the navigation and the "Collapse Sidebar" label pop in at once while the sidebar is still widening. On the right they fade in as the sidebar widens.

<details>
<summary>Why it happens and how it is fixed</summary>

The sidebar's content fades out when it collapses but snaps back when it expands. The delay for the expanding case is written as the string `"0s"`, which Sass emits quoted and the browser discards as an invalid transition declaration, so the content is shown at once instead of fading in.

</details>

## Tests

`test_sidebar_width_not_animated_across_breakpoint`: widening past the breakpoint must leave no transition running on the sidebar and must not change its width afterwards. It runs twice, with the sidebar expanded and collapsed. The expanded run fails on `main` and passes here; the collapsed run passes on both and guards the new custom property. Measured on Chromium only.

## How this was tested

Default theme configuration. Nothing here depends on a theme option: the collapse button is part of the primary sidebar the theme ships by default (`html_sidebars` not overridden), and the width bug also reproduces on the theme's own docs at pydata-sphinx-theme.readthedocs.io.

The clips come from a small Sphinx site made for this: a nested toctree so the sidebar has entries, one page with thirty sections, otherwise default options. The same site is built once with `main` and once with this branch and the two are recorded side by side in Chromium through Playwright, at 1400x900 with the window narrowed to 700px for the resize.

The Playwright test uses the `sidebars` test site already in the repo (`tests/sites/sidebars`), whose only configuration is turning the primary sidebar off on one page.

